### PR TITLE
Mention prohibition on anonymous links for folders

### DIFF
--- a/api-reference/v1.0/api/item_createlink.md
+++ b/api-reference/v1.0/api/item_createlink.md
@@ -54,7 +54,7 @@ link available will be created.
 
 | Type value     | Description                                                                                                                   |
 |:---------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `anonymous`    | Creates a link to the item accessible to anyone. Anonymous links may be disabled by the tenant administrator.                 |
+| `anonymous`    | Creates a link to the item accessible to anyone. Anonymous links can only be created for files, and this ability may be disabled by the tenant administrator.                 |
 | `organization` | Creates a link to the item accessible within an organization. Organization link scope is not available for OneDrive Personal. |
 
 ### Response


### PR DESCRIPTION
Just got off the phone with MS Support while trying to debug errors I was receiving and was informed that MS recently disabled anonymous link creation for folders because too many users were mistakenly over-sharing content (creating inadvertent security leaks).

Makes sense to include that here.
