### PR TITLE
Remove Remarks section since parentReference property is returned

### DIFF
--- a/api-reference/v1.0/api/item_search.md
+++ b/api-reference/v1.0/api/item_search.md
@@ -94,12 +94,6 @@ Content-type: application/json
 }
 ```
 
-## Remarks
-
-**Note:** In OneDrive for Business and SharePoint, search does not return the following properties:
-
-* `parentReference`
-
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->


### PR DESCRIPTION
Not sure if this is considered a Minor correction or not...

The API for OneDrive for Business and SharePoint does return the
parentReference property.  Tested with OneDrive Bus and Groups, both
backed by SharePoint I believe. Don't know any other way to test
Sharepoint via Graph.

https://graph.microsoft.com/v1.0/me/drive/root/search(q='.xlsx')
https://graph.microsoft.com/v1.0/groups/groupid/drive/root/search(q='.xlsx')

Removed the entire Remarks section since seems to be consistent with
rest of docs that don't have remarks. Also, assuming the "In this
article" link to Remarks will be removed by some auto-gen process.
