### PR TITLE
Fixed the @odata.type value in the comment for a sample response, to us…

### DIFF
--- a/api-reference/beta/api/user_getmailtips.md
+++ b/api-reference/beta/api/user_getmailtips.md
@@ -60,7 +60,7 @@ Here is an example of the response. Note: The response object shown here may be 
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.mailtips"
+  "@odata.type": "microsoft.graph.mailTips"
 } -->
 ```http
 HTTP/1.1 200 OK


### PR DESCRIPTION
…e the correct casing for microsoft.graph.mailTips and avoid AppVeyor error.