### PR TITLE
Rephrased create attachment as add attachment, as the actual object t…

### DIFF
--- a/api-reference/beta/api/attachment_delete.md
+++ b/api-reference/beta/api/attachment_delete.md
@@ -68,7 +68,7 @@ If successful, this method returns `204, No Content` response code. It does not 
 
 ## Example
 ##### Request
-Here is an example of the request.
+Here is an example of the request to delete an attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "delete_attachment"

--- a/api-reference/beta/api/attachment_get.md
+++ b/api-reference/beta/api/attachment_get.md
@@ -1,6 +1,17 @@
 # Get attachment
 
-Retrieve the properties and relationships of attachment object.
+Read the properties and relationships of an attachment, attached to an [event](../resources/event.md), 
+[message](../resources/message.md), or [post](../resources/post.md). 
+
+An attachment can be one of the following types:
+
+* A file ([fileAttachment](,,/resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](,,/resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](,,/resources/referenceAttachment.md) resource)
+
+All these types of attachment resources are derived from the [attachment](../resources/attachment.md)
+resource. 
+
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
 
@@ -65,10 +76,11 @@ This method supports the [OData Query Parameters](http://graph.microsoft.io/docs
 Do not supply a request body for this method.
 ## Response
 If successful, this method returns a `200 OK` response code and [attachment](../resources/attachment.md) object in the response body.
+
 ## Example (file attachment)
 
 ##### Request
-Here is an example of the request.
+Here is an example of the request to get a file attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "get_file_attachment"
@@ -90,6 +102,7 @@ Content-type: application/json
 Content-length: 199
 
 {
+  "@odata.type": "#microsoft.graph.fileAttachment",
   "contentType": "contentType-value",
   "contentLocation": "contentLocation-value",
   "contentBytes": "contentBytes-value",
@@ -105,7 +118,7 @@ Content-length: 199
 ## Example (item attachment)
 
 ##### Request
-Here is an example of the request.
+Here is an example of the request to get an item attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "get_item_attachment"
@@ -125,6 +138,7 @@ HTTP/1.1 200 OK
 Content-type: application/json
 
 {
+  "@odata.type": "#microsoft.graph.itemAttachment",
   "lastModifiedDateTime": "2016-10-19T10:37:00Z",
   "name": "name-value",
   "contentType": "contentType-value",
@@ -138,10 +152,10 @@ Content-type: application/json
 ## Example (reference attachment)
 
 ##### Request
-Here is an example of the request.
+Here is an example of the request to get a reference attachment on an event.
 <!-- {
   "blockType": "request",
-  "name": "get_item_attachment"
+  "name": "get_reference_attachment"
 }-->
 ```http
 GET https://graph.microsoft.com/beta/me/events/AAMkAGE1M88AADUv0uAAAG=/attachments/AAMkAGE1Mg72tgf7hJp0PICVGCc0g=
@@ -151,7 +165,7 @@ GET https://graph.microsoft.com/beta/me/events/AAMkAGE1M88AADUv0uAAAG=/attachmen
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.itemAttachment"
+  "@odata.type": "microsoft.graph.referenceAttachment"
 } -->
 ```http
 HTTP/1.1 200 OK

--- a/api-reference/beta/api/attachment_get.md
+++ b/api-reference/beta/api/attachment_get.md
@@ -5,9 +5,9 @@ Read the properties and relationships of an attachment, attached to an [event](.
 
 An attachment can be one of the following types:
 
-* A file ([fileAttachment](,,/resources/fileattachment.md) resource)
-* An item (contact, event or message, represented by an [itemAttachment](,,/resources/itemattachment.md) resource)
-* A link to a file ([referenceAttachment](,,/resources/referenceAttachment.md) resource)
+* A file ([fileAttachment](../resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](../resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](../resources/referenceAttachment.md) resource)
 
 All these types of attachment resources are derived from the [attachment](../resources/attachment.md)
 resource. 

--- a/api-reference/beta/api/event_post_attachments.md
+++ b/api-reference/beta/api/event_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to an event. Since there
 is currently a limit of 4MB on the total size of each REST request, this limits the size of the attachment

--- a/api-reference/beta/api/eventmessage_post_attachments.md
+++ b/api-reference/beta/api/eventmessage_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to create a new Attachment.
 ## Prerequisites

--- a/api-reference/beta/api/message_post_attachments.md
+++ b/api-reference/beta/api/message_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to a message. 
 

--- a/api-reference/beta/api/post_post_attachments.md
+++ b/api-reference/beta/api/post_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to a post. Since there
 is currently a limit of 4MB on the total size of each REST request, this limits the size of the attachment

--- a/api-reference/beta/resources/attachment.md
+++ b/api-reference/beta/resources/attachment.md
@@ -1,26 +1,36 @@
 # attachment resource type
 
-A file, item (contact, event or message), or link to a file, which is attached to an [event](../resources/event.md),
-[message](../resources/message.md), or [post](../resources/post.md). The  
-corresponding [fileAttachment](../resources/fileattachment.md), [itemAttachment](../resources/itemattachment.md), and
-[referenceAttachment](../resources/referenceattachment.md) resources are all derived from the **attachment**
-resource.
+You can add related content to an [event](../resources/event.md),
+[message](../resources/message.md), or [post](../resources/post.md) in the form of an attachment.
+
+**attachment** is the base resource for the following derived types of attachments:
+
+* A file ([fileAttachment](../resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](../resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](../resources/referenceAttachment.md) resource)
 
 ## Methods
 
+The following methods apply to any of the derived types of attachments (**fileAttachment**,
+**itemAttachment**, or **referenceAttachment**).
+
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get attachment](../api/attachment_get.md) | [attachment](attachment.md) |Read properties and relationships of attachment object.|
+|[Get attachment](../api/attachment_get.md) | [attachment](attachment.md) |Read the properties and relationships of an attachment, attached to an event, message, or post.|
 |[Add attachment to an event](../api/event_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to an event.|
 |[Add attachment to a message](../api/message_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to a message.|
 |[Add attachment to a post](../api/post_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to a post.|
 |[List attachments of an event](../api/event_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for an event. |
 |[List attachments of a message](../api/message_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for a message. |
 |[List attachments of a post](../api/post_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for a post. |
-|[Delete](../api/attachment_delete.md) | None |Delete attachment object. |
+|[Delete](../api/attachment_delete.md) | None |Delete an attachment on an event, message, or post. |
 
 
 ## Properties
+
+The following are the base properties of any attachment resource. Refer to the specific type of attachment ([fileAttachment](../resources/fileattachment.md),
+[itemAttachment](../resources/itemattachment.md), or [referenceAttachment](../resources/referenceAttachment.md)) for additional properties.
+
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |contentType|String|The MIME type.|

--- a/api-reference/beta/resources/fileattachment.md
+++ b/api-reference/beta/resources/fileattachment.md
@@ -4,6 +4,7 @@ A file (such as a text file or Word document) attached to an event, message or p
 property contains the base64-encoded contents of the file.  
 
 When creating a file attachment, include the following in the request body:
+
 * `"@odata.type": "#microsoft.graph.fileAttachment"`
 * The required properties **name** and **contentBytes**.
 
@@ -13,7 +14,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get fileAttachment](../api/fileattachment_get.md) | [fileAttachment](fileattachment.md) |Read properties and relationships of fileAttachment object.|
+|[Get](../api/attachment_get.md) | [fileAttachment](fileattachment.md) |Read properties and relationships of fileAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete fileAttachment object. |
 
 

--- a/api-reference/beta/resources/itemattachment.md
+++ b/api-reference/beta/resources/itemattachment.md
@@ -8,7 +8,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get itemAttachment](../api/itemattachment_get.md) | [itemAttachment](itemattachment.md) |Read properties and relationships of itemAttachment object.|
+|[Get](../api/attachment_get.md) | [itemAttachment](itemattachment.md) |Read properties and relationships of itemAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete itemAttachment object. |
 
 ## Properties

--- a/api-reference/beta/resources/referenceattachment.md
+++ b/api-reference/beta/resources/referenceattachment.md
@@ -8,7 +8,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get referenceAttachment](../api/referenceattachment_get.md) | [referenceAttachment](referenceattachment.md) |Read properties and relationships of referenceAttachment object.|
+|[Get](../api/attachment_get.md) | [referenceAttachment](referenceattachment.md) |Read properties and relationships of referenceAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete referenceAttachment object. |
 
 

--- a/api-reference/v1.0/api/attachment_delete.md
+++ b/api-reference/v1.0/api/attachment_delete.md
@@ -68,7 +68,7 @@ If successful, this method returns `204, No Content` response code. It does not 
 
 ## Example
 ##### Request
-Here is an example of the request.
+Here is an example of the request to delete an attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "delete_attachment"

--- a/api-reference/v1.0/api/attachment_get.md
+++ b/api-reference/v1.0/api/attachment_get.md
@@ -1,12 +1,23 @@
 # Get attachment
 
-Retrieve the properties and relationships of attachment object.
+Read the properties and relationships of an attachment, attached to an [event](../resources/event.md), 
+[message](../resources/message.md), or [post](../resources/post.md). 
+
+An attachment can be one of the following types:
+
+* A file ([fileAttachment](,,/resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](,,/resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](,,/resources/referenceAttachment.md) resource)
+
+All these types of attachment resources are derived from the [attachment](../resources/attachment.md)
+resource. 
+
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
 
-* If accessing attachments in Messages: *Mail.Read*
-* If accessing attachments in Events: *Calendars.Read*
-* If accessing attachments in Group Events or Posts: *Group.Read.All*
+* If accessing attachments in messages: *Mail.Read*
+* If accessing attachments in events: *Calendars.Read*
+* If accessing attachments in group events or posts: *Group.Read.All*
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
@@ -65,10 +76,11 @@ This method supports the [OData Query Parameters](http://graph.microsoft.io/docs
 Do not supply a request body for this method.
 ## Response
 If successful, this method returns a `200 OK` response code and [attachment](../resources/attachment.md) object in the response body.
+
 ## Example (file attachment)
 
 ##### Request
-Here is an example of the request.
+Here is an example of the request to get a file attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "get_file_attachment"
@@ -90,6 +102,7 @@ Content-type: application/json
 Content-length: 199
 
 {
+  "@odata.type": "#microsoft.graph.fileAttachment",
   "contentType": "contentType-value",
   "contentLocation": "contentLocation-value",
   "contentBytes": "contentBytes-value",
@@ -105,7 +118,7 @@ Content-length: 199
 ## Example (item attachment)
 
 ##### Request
-Here is an example of the request.
+Here is an example of the request to get an item attachment on an event.
 <!-- {
   "blockType": "request",
   "name": "get_item_attachment"
@@ -125,6 +138,7 @@ HTTP/1.1 200 OK
 Content-type: application/json
 
 {
+  "@odata.type": "#microsoft.graph.itemAttachment",
   "lastModifiedDateTime": "datetime-value",
   "name": "name-value",
   "contentType": "contentType-value",
@@ -133,6 +147,41 @@ Content-type: application/json
   "id": "id-value"
 }
 ```
+
+
+## Example (reference attachment)
+##### Request
+Here is an example of the request to get a reference attachment on an event.
+<!-- {
+  "blockType": "request",
+  "name": "get_reference_attachment"
+}-->
+```http
+GET https://graph.microsoft.com/v1.0/me/events/<id>/attachments/<id>
+```
+##### Response
+Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.referenceAttachment"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 215
+
+{
+  "@odata.type": "#microsoft.graph.referenceAttachment",
+  "contentType": "contentType-value",
+  "lastModifiedDateTime": "datetime-value",
+  "id": "id-value",
+  "isInline": false,
+  "name": "name-value",
+  "size": 99,
+}
+```
+
 
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/v1.0/api/attachment_get.md
+++ b/api-reference/v1.0/api/attachment_get.md
@@ -5,9 +5,9 @@ Read the properties and relationships of an attachment, attached to an [event](.
 
 An attachment can be one of the following types:
 
-* A file ([fileAttachment](,,/resources/fileattachment.md) resource)
-* An item (contact, event or message, represented by an [itemAttachment](,,/resources/itemattachment.md) resource)
-* A link to a file ([referenceAttachment](,,/resources/referenceAttachment.md) resource)
+* A file ([fileAttachment](../resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](../resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](../resources/referenceAttachment.md) resource)
 
 All these types of attachment resources are derived from the [attachment](../resources/attachment.md)
 resource. 

--- a/api-reference/v1.0/api/event_post_attachments.md
+++ b/api-reference/v1.0/api/event_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to an event. Since there
 is currently a limit of 4MB on the total size of each REST request, this limits the size of the attachment

--- a/api-reference/v1.0/api/eventmessage_post_attachments.md
+++ b/api-reference/v1.0/api/eventmessage_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to create a new Attachment.
 ## Prerequisites

--- a/api-reference/v1.0/api/message_post_attachments.md
+++ b/api-reference/v1.0/api/message_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to a message. 
 

--- a/api-reference/v1.0/api/post_post_attachments.md
+++ b/api-reference/v1.0/api/post_post_attachments.md
@@ -1,4 +1,4 @@
-# Add Attachment
+# Add attachment
 
 Use this API to add an [attachment](../resources/attachment.md) to a post. Since there
 is currently a limit of 4MB on the total size of each REST request, this limits the size of the attachment

--- a/api-reference/v1.0/resources/attachment.md
+++ b/api-reference/v1.0/resources/attachment.md
@@ -1,26 +1,37 @@
 # attachment resource type
 
-A file, item (contact, event or message), or link to a file, which is attached to an [event](../resources/event.md),
-[message](../resources/message.md), or [post](../resources/post.md). The  
-corresponding [fileAttachment](../resources/fileattachment.md), [itemAttachment](../resources/itemattachment.md), and
-[referenceAttachment](../resources/referenceattachment.md) resources are all derived from the **attachment**
-resource.
+You can add related content to an [event](../resources/event.md),
+[message](../resources/message.md), or [post](../resources/post.md) in the form of an attachment.
+
+**attachment** is the base resource for the following derived types of attachments:
+
+* A file ([fileAttachment](../resources/fileattachment.md) resource)
+* An item (contact, event or message, represented by an [itemAttachment](../resources/itemattachment.md) resource)
+* A link to a file ([referenceAttachment](../resources/referenceAttachment.md) resource)
+
 
 ## Methods
 
+The following methods apply to any of the derived types of attachments (**fileAttachment**,
+**itemAttachment**, or **referenceAttachment**).
+
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get attachment](../api/attachment_get.md) | [attachment](attachment.md) |Read properties and relationships of attachment object.|
+|[Get attachment](../api/attachment_get.md) | [attachment](attachment.md) |Read the properties and relationships of an attachment, attached to an event, message, or post.|
 |[Add attachment to an event](../api/event_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to an event.|
 |[Add attachment to a message](../api/message_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to a message.|
 |[Add attachment to a post](../api/post_post_attachments.md) | [attachment](attachment.md) |Add a file, item, or link attachment to a post.|
 |[List attachments of an event](../api/event_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for an event. |
 |[List attachments of a message](../api/message_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for a message. |
 |[List attachments of a post](../api/post_list_attachments.md) | [attachment](attachment.md) collection | Get a list of attachments for a post. |
-|[Delete](../api/attachment_delete.md) | None |Delete attachment object. |
+|[Delete](../api/attachment_delete.md) | None |Delete an attachment on an event, message, or post. |
 
 
 ## Properties
+
+The following are the base properties of any attachment resource. Refer to the specific type of attachment ([fileAttachment](../resources/fileattachment.md),
+[itemAttachment](../resources/itemattachment.md), or [referenceAttachment](../resources/referenceAttachment.md)) for additional properties.
+
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |contentType|String|The MIME type.|

--- a/api-reference/v1.0/resources/fileattachment.md
+++ b/api-reference/v1.0/resources/fileattachment.md
@@ -4,6 +4,7 @@ A file (such as a text file or Word document) attached to an event, message or p
 property contains the base64-encoded contents of the file.  
 
 When creating a file attachment, include the following in the request body:
+
 * `"@odata.type": "#microsoft.graph.fileAttachment"`
 * The required properties **name** and **contentBytes**.
 
@@ -13,7 +14,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get fileAttachment](../api/fileattachment_get.md) | [fileAttachment](fileattachment.md) |Read properties and relationships of fileAttachment object.|
+|[Get](../api/attachment_get.md) | [fileAttachment](fileattachment.md) |Read properties and relationships of fileAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete fileAttachment object. |
 
 

--- a/api-reference/v1.0/resources/itemattachment.md
+++ b/api-reference/v1.0/resources/itemattachment.md
@@ -8,7 +8,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get itemAttachment](../api/itemattachment_get.md) | [itemAttachment](itemattachment.md) |Read properties and relationships of itemAttachment object.|
+|[Get](../api/attachment_get.md) | [itemAttachment](itemattachment.md) |Read properties and relationships of itemAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete itemAttachment object. |
 
 ## Properties

--- a/api-reference/v1.0/resources/referenceattachment.md
+++ b/api-reference/v1.0/resources/referenceattachment.md
@@ -8,7 +8,7 @@ Derived from [attachment](attachment.md).
 
 | Method       | Return Type  |Description|
 |:---------------|:--------|:----------|
-|[Get referenceAttachment](../api/referenceattachment_get.md) | [referenceAttachment](referenceattachment.md) |Read properties and relationships of referenceAttachment object.|
+|[Get](../api/attachment_get.md) | [referenceAttachment](referenceattachment.md) |Read properties and relationships of referenceAttachment object.|
 |[Delete](../api/attachment_delete.md) | None |Delete referenceAttachment object. |
 
 


### PR DESCRIPTION
…o attach already exists, the action just attaches that object to a supporting resource. Reorganized content for the attachment resource and its methods, and unified GETting any attachment type in attachment_get.md, so to reduce duplication in multiple GET topics for each type of attachment.