### PR TITLE
Remove anchors from  URLs

### DIFF
--- a/api-reference/beta/api/contactfolder_delta.md
+++ b/api-reference/beta/api/contactfolder_delta.md
@@ -3,7 +3,7 @@
 Get a set of contact folders that have been added, deleted, or removed from the user's mailbox.
 
 A **delta** function call for contact folders in a mailbox is similar to a GET request, except that by appropriately 
-applying [state tokens](../../../concepts/delta_query_overview.md#state-tokens) in one or more of these calls, 
+applying [state tokens](../../../concepts/delta_query_overview.md) in one or more of these calls, 
 you can query for incremental changes in the contact folders. This allows you to maintain and synchronize 
 a local store of a user's contact folders without having to fetch all the contact folders of that mailbox from the server every time.
 

--- a/api-reference/beta/api/event_delta.md
+++ b/api-reference/beta/api/event_delta.md
@@ -5,7 +5,7 @@ of the user's primary calendar.
 
 A **delta** function call for events is similar to a `GET /calendarview` request for 
 a range of dates in the user's primary calendar, except that by appropriately 
-applying [state tokens](../../../concepts/delta_query_overview.md#state-tokens) in one or more of these calls, 
+applying [state tokens](../../../concepts/delta_query_overview.md) in one or more of these calls, 
 you can query for incremental changes in that calender view. This allows you to maintain and synchronize 
 a local store of a user's events in the primary calendar, without having to fetch all the events of that calendar 
 from the server every time.
@@ -53,7 +53,7 @@ The following example shows how to make a single **delta** function call, and li
 in the response body to 2.
 
 To track changes in a calendar view, you would make one or more **delta** function calls, with 
-appropriate [state tokens](../../../concepts/delta_query_overview.md#state-tokens), to get the set of incremental changes since the last delta query. 
+appropriate [state tokens](../../../concepts/delta_query_overview.md), to get the set of incremental changes since the last delta query. 
 
 <!-- {
   "blockType": "request",

--- a/api-reference/beta/api/group_delta.md
+++ b/api-reference/beta/api/group_delta.md
@@ -1,6 +1,6 @@
 # group: delta
 
-[Delta query](../../../concepts/delta_query_overview.md) enables applications to discover newly created, updated, or deleted entities without performing a full read of the target resource with every request. To discover changes to groups, perform a request using the *delta* function. See [Using Delta Query](../../../concepts/delta_query_overview.md#using-delta-query) for details.
+[Delta query](../../../concepts/delta_query_overview.md) enables applications to discover newly created, updated, or deleted entities without performing a full read of the target resource with every request. To discover changes to groups, perform a request using the *delta* function. See [Using Delta Query](../../../concepts/delta_query_overview.md) for details.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ If successful, this method returns `200, OK` response code and [group](../resour
 - If a deltaLink URL is returned, there is no more data about the existing state of the resource to be returned. For future requests, the application uses the deltaLink URL to learn about changes to the resource.
 
 See:
-- [Using Delta Query](../../../concepts/delta_query_overview.md#using-delta-query) for more details
+- [Using Delta Query](../../../concepts/delta_query_overview.md) for more details
 - [Get incremental changes for groups](../../../concepts/delta_query_groups.md) for an example requests.
     
 ### Example

--- a/api-reference/beta/api/mailfolder_delta.md
+++ b/api-reference/beta/api/mailfolder_delta.md
@@ -3,7 +3,7 @@
 Get a set of mail folders that have been added, deleted, or removed from the user's mailbox.
 
 A **delta** function call for mail folders in a mailbox is similar to a GET request, except that by appropriately 
-applying [state tokens](../../../concepts/delta_query_overview.md#state-tokens) in one or more of these calls, 
+applying [state tokens](../../../concepts/delta_query_overview.md) in one or more of these calls, 
 you can query for incremental changes in the mail folders. This allows you to maintain and synchronize 
 a local store of a user's mail folders without having to fetch all the mail folders of that mailbox from the server every time.
 

--- a/api-reference/beta/api/user_delta.md
+++ b/api-reference/beta/api/user_delta.md
@@ -1,6 +1,6 @@
 # user: delta
 
-[Delta query](../../../concepts/delta_query_overview.md) enables applications to discover newly created, updated, or deleted entities without performing a full read of the target resource with every request. To discover changes to users, perform a request using the *delta* function. See [Using Delta Query](../../../concepts/delta_query_overview.md#using-delta-query) for details.
+[Delta query](../../../concepts/delta_query_overview.md) enables applications to discover newly created, updated, or deleted entities without performing a full read of the target resource with every request. To discover changes to users, perform a request using the *delta* function. See [Using Delta Query](../../../concepts/delta_query_overview.md) for details.
 
 ### Prerequisites
 
@@ -37,7 +37,7 @@ If successful, this method returns `200, OK` response code and [user](../resourc
 - If a deltaLink URL is returned, there is no more data about the existing state of the resource to be returned. For future requests, the application uses the deltaLink URL to learn about changes to the resource.
 
 See:
-- [Using Delta Query](../../../concepts/delta_query_overview.md#using-delta-query) for more details
+- [Using Delta Query](../../../concepts/delta_query_overview.md) for more details
 - [Get incremental changes for users](../../../concepts/delta_query_users.md) for an example requests.
 
 ### Example

--- a/concepts/delta_query_groups.md
+++ b/concepts/delta_query_groups.md
@@ -11,7 +11,7 @@ Tracking group changes is a round of one or more GET requests with the **delta**
 request much like the way you [list groups](../api-reference/beta/api/group_list.md), except that you include the following:
 
 - The **delta** function.
-- A [state token](./delta_query_overview.md#state-tokens) (_deltaToken_ or _skipToken_) from the previous GET **delta** function call.
+- A [state token](./delta_query_overview.md) (_deltaToken_ or _skipToken_) from the previous GET **delta** function call.
 
 ## Example
 

--- a/concepts/delta_query_users.md
+++ b/concepts/delta_query_users.md
@@ -9,7 +9,7 @@ Delta query supports both full synchronization that retrieves all of the users i
 Tracking user changes is a round of one or more GET requests with the **delta** function. You make a GET request much like the way you [list users](../api-reference/beta/api/user_list.md), except that you include the following:
 
 - The **delta** function.
-- A [state token](./delta_query_overview.md#state-tokens) (_deltaToken_ or _skipToken_) from the previous GET **delta** function call.
+- A [state token](./delta_query_overview.md) (_deltaToken_ or _skipToken_) from the previous GET **delta** function call.
 
 ## Example
 


### PR DESCRIPTION
Removed URL anchors for validation issues

@Lauragra - Ok to merge.  To fix validation issues.