### PR TITLE
Added note on uniqueBody property

### DIFF
--- a/api-reference/v1.0/resources/message.md
+++ b/api-reference/v1.0/resources/message.md
@@ -62,7 +62,7 @@ A message in a mailFolder.
 |sentDateTime|DateTimeOffset|The date and time the message was sent.|
 |subject|String|The subject of the message.|
 |toRecipients|[recipient](recipient.md) collection|The To: recipients for the message.|
-|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message.|
+|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message. uniqueBody is not provided by default but can be retrieved for a given message by use of the ?$select=uniqueBody query.|
 |webLink|String|The URL to open the message in Outlook Web App.<br><br>You can append an ispopout argument to the end of the URL to change how the message is displayed. If ispopout is not present or if it is set to 1, then the message is shown in a popout window. If ispopout is set to 0, then the browser will show the message in the Outlook Web App review pane.<br><br>The message will open in the browser if you are logged in to your mailbox via Outlook Web App. You will be prompted to login if you are not already logged in with the browser.<br><br>This URL can be accessed from within an iFrame.|
 
 **Removing script from the Body property**


### PR DESCRIPTION
uniqueBody is not provided in messages by default, but needs to be requested by the use of the $select query operator. Added a note to this effect.