### PR TITLE
Update group.md

### DIFF
--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -55,7 +55,7 @@ by providing a [delta](../api/group_delta.md) function.
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|allowExternalSenders|Boolean|Default is **false**. Indicates if people external to the organization can send messages to the group. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group.|
+|allowExternalSenders|Boolean|Default is **false**. Indicates if people external to the organization can send messages to the group.|
 |autoSubscribeNewMembers|Boolean|Default is **false**. Indicates if new members added to the group will be auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group.|
 |classification|String|Describes a classification for the group (such as low, medium or high business impact). Valid values for this property are defined by creating a ClassificationList [setting](directorySetting.md) value, based on the [template definition](directorySettingTemplate.md).|
 |description|String|An optional description for the group.|
@@ -131,7 +131,7 @@ Here is a JSON representation of the resource
 ```json
 {
   "accessType": "string",
-  "allowExternalSenders": true,
+  "allowExternalSenders": false,
   "autoSubscribeNewMembers": true,
   "description": "string",
   "displayName": "string",

--- a/api-reference/v1.0/resources/group.md
+++ b/api-reference/v1.0/resources/group.md
@@ -45,7 +45,7 @@ Inherits from [directoryObject](directoryobject.md).
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|allowExternalSenders|Boolean|Default is **false**. Indicates if people external to the organization can send messages to the group. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group.|
+|allowExternalSenders|Boolean|Default is **false**. Indicates if people external to the organization can send messages to the group.|
 |autoSubscribeNewMembers|Boolean|Default is **false**. Indicates if new members added to the group will be auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group.|
 |description|String|An optional description for the group. |
 |displayName|String|The display name for the group. This property is required when a group is created and it cannot be cleared during updates. Supports $filter and $orderby.|
@@ -109,7 +109,7 @@ Here is a JSON representation of the resource
 
 ```json
 {
-  "allowExternalSenders": true,
+  "allowExternalSenders": false,
   "autoSubscribeNewMembers": true,
   "description": "string",
   "displayName": "string",


### PR DESCRIPTION
Removing a note that allowExternalSenders can be set with a PATCH request for the group as it's not currently supported.
https://github.com/microsoftgraph/microsoft-graph-docs/issues/762
