### PR TITLE
Removed allowExternalSenders in group_update.md as a property that ca…

### DIFF
--- a/api-reference/beta/api/group_update.md
+++ b/api-reference/beta/api/group_update.md
@@ -19,7 +19,6 @@ In the request body, supply the values for relevant fields that should be update
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|allowExternalSenders|Boolean|Default is **false**. Indicates if external members can send email to group.|
 |autoSubscribeNewMembers|Boolean|Default is **false**. Indicates if new members added to the group will be auto-subscribed to receive email notifications.|
 |description|String|An optional description for the group. |
 |displayName|String|The display name for the group. This property is required when a group is created and it cannot be cleared during updates. Supports $filter and $orderby.|

--- a/api-reference/v1.0/api/group_update.md
+++ b/api-reference/v1.0/api/group_update.md
@@ -19,7 +19,6 @@ In the request body, supply the values for relevant fields that should be update
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|allowExternalSenders|Boolean|Default is **false**. Indicates if external members can send email to group.|
 |autoSubscribeNewMembers|Boolean|Default is **false**. Indicates if new members added to the group will be auto-subscribed to receive email notifications.|
 |description|String|An optional description for the group. |
 |displayName|String|The display name for the group. This property is required when a group is created and it cannot be cleared during updates. Supports $filter and $orderby.|
@@ -33,10 +32,10 @@ In the request body, supply the values for relevant fields that should be update
 
 **Note**
 
-- You can update **allowExternalSenders** and **autoSubscribeNewMembers** by specifying only one or both these properties in their own PATCH request, 
+- You can update **autoSubscribeNewMembers** by specifying it in its own PATCH request, 
 without including the other properties in the table above.
 - Only a subset of the group API pertaining to core group administration and management support application 
-and delegated permissions. All other members of the group API, including updating  **allowExternalSenders** and **autoSubscribeNewMembers**, 
+and delegated permissions. All other members of the group API, including updating  **autoSubscribeNewMembers**, 
 support only delegated permissions. See [known issues](https://graph.microsoft.io/en-us/docs/overview/release_notes#group-permission-scopes) for examples.
 
 ## Response

--- a/overview/release_notes.md
+++ b/overview/release_notes.md
@@ -64,8 +64,9 @@ getting attachments of group posts currently return the error message "The OData
 and is expected to be widely available by the end of January 2016.
 
 
-#### Setting the **allowExternalSenders** property
-There is currently an issue that prevents setting the **allowExternalSenders** property of a group in a POST or PATCH operation, in both `/v1.0` and `/beta`. 
+#### Setting the allowExternalSenders property
+There is currently an issue that prevents setting the **allowExternalSenders** property of a group 
+in a POST or PATCH operation, in both `/v1.0` and `/beta`.
 
 
 ## Contacts


### PR DESCRIPTION
…n be updated. Currently this is not supported. Left this issue in the Known Issues topic though, to call out this current behavior to reduce confusion.