### PR TITLE
Updated calendar_list_calendarview.md example

### DIFF
--- a/api-reference/beta/api/calendar_list_calendarview.md
+++ b/api-reference/beta/api/calendar_list_calendarview.md
@@ -61,7 +61,7 @@ Here is an example of the request.
   "name": "get_calendarview"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/me/calendar/calendarView
+GET https://graph.microsoft.com/beta/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/v1.0/api/calendar_list_calendarview.md
+++ b/api-reference/v1.0/api/calendar_list_calendarview.md
@@ -65,7 +65,7 @@ Here is an example of the request.
   "name": "get_calendarview"
 }-->
 ```http
-GET https://graph.microsoft.com/v1.0/me/calendar/calendarView
+GET https://graph.microsoft.com/v1.0/me/calendar/calendarView?startDateTime=2017-01-01T19:00:00.0000000&endDateTime=2017-01-07T19:00:00.0000000
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.


### PR DESCRIPTION
The example is missing the startDateTime and endDateTime query parameter. The existing example will fail. Added the missing query parameters.