### PR TITLE
Update to event documentation

### DIFF
--- a/api-reference/v1.0/api/user_post_events.md
+++ b/api-reference/v1.0/api/user_post_events.md
@@ -1,6 +1,6 @@
 # Create Event
 
-Create an [event](../resources/event.md) in the user's default calendar. 
+Create an [event](../resources/event.md) in the user's default calendar or one of their custom calendars by `calendarId`.
 
 You can specify the time zone for each of the start and end times of the event as part of these values, as the 
 **start** and **end** properties are of [DateTimeTimeZone](../resources/datetimetimezone.md) type. 


### PR DESCRIPTION
Specify that you CAN create events on other calendars besides the default.  That threw me off, it wasn't until I studied the HTTP requests below that I saw that first sentence to be misleading.