### PR TITLE
/drives path is not valid for a group

### DIFF
--- a/api-reference/v1.0/api/drive_list.md
+++ b/api-reference/v1.0/api/drive_list.md
@@ -14,7 +14,7 @@ One of the following **scopes** is required to execute this API:
 ```http
 GET /drives
 GET /me/drives
-GET /groups/{id}/drives
+GET /groups/{id}/drive
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
/drives path is not valid for a group. it should be /drive which returns the default document library.

Issuing a request against /drives will result in 400
https://graph.microsoft.com/v1.0/groups/{groupId}/drives
client-request-id: 1f5353f3-a0fe-4713-924d-ef247e4cbc8d
content-type: application/json
cache-control: private
request-id: 1f5353f3-a0fe-4713-924d-ef247e4cbc8d
Status Code: 400
```
{
    "error": {
        "code": "BadRequest",
        "message": "Unsupported segment type. ODataQuery: groups/adf3cd07-b2d5-4427-b859-eab8492e7e77/drives",
        "innerError": {
            "request-id": "1f5353f3-a0fe-4713-924d-ef247e4cbc8d",
            "date": "2017-03-06T22:35:32"
        }
    }
}
```