### PR TITLE
Removed the content property from response sample

### DIFF
--- a/api-reference/beta/api/section_post_pages.md
+++ b/api-reference/beta/api/section_post_pages.md
@@ -89,7 +89,6 @@ Content-length: 312
     }
   },
   "contentUrl": "contentUrl-value",
-  "content": "content-value",
   "lastModifiedTime": "2016-10-19T10:37:00Z"
 }
 ```


### PR DESCRIPTION
The content property is never returned as part of the Page object.