### PR TITLE
Added in the beta version support for getting messages in text format…

### DIFF
--- a/api-reference/beta/api/message_get.md
+++ b/api-reference/beta/api/message_get.md
@@ -1,10 +1,24 @@
 # Get message
 
-Retrieve the properties and relationships of message object.
+Retrieve the properties and relationships of the [message](../resources/message.md) object.
 
 For example, you can get a message and expand all the [mention](../resources/mention.md) instances in the message.
 
 Since the **message** resource supports [extensions](../../../concepts/extensibility_overview.md), you can also use the `GET` operation to get custom properties and extension data in a **message** instance.
+
+### Get the message body in HTML or text format
+
+Message bodies can be in HTML or text format.
+
+You can use the `Prefer: outlook.body-content-type` header to specify the desired format returned in the **body** and **uniqueBody** properties in a `GET` request:
+
+- Specify `Prefer: outlook.body-content-type="text"` to get a message body returned in text format.
+- Specify `Prefer: outlook.body-content-type="html"`, or just skip the header, to return the message body in HTML format.
+
+If you specify either header, the response will include the corresponding `Preference-Applied` header as confirmation:
+
+- For text format requests: `Preference-Applied: outlook.body-content-type="text"`
+- For HTML format requests: `Preference-Applied: outlook.body-content-type="html"`
 
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
@@ -41,6 +55,7 @@ of each [mention](../resources/mention.md) in the message expanded.
 | Name       | Type | Description|
 |:-----------|:------|:----------|
 | Authorization  | string  | Bearer <token>. Required. |
+| Prefer: outlook.body-content-type | string | The format of the **body** and **uniqueBody** properties to be returned in. Values can be "text" or "html". Optional. |
 
 ## Request body
 Do not supply a request body for this method.
@@ -48,16 +63,17 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and [message](../resources/message.md) object in the response body.
 ## Example
 ##### Request 1
-The first example gets the specified message.
+The first example gets the specified message. It does not specify any header to indicate the desired format of the body to be returned.
 <!-- {
   "blockType": "request",
   "name": "get_message"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/me/messages/{id}
+GET https://graph.microsoft.com/beta/me/messages('AAMkAGI1AAAoZCfHAAA=')
 ```
 ##### Response 1
-Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+Here is an example of the response. The **body** and **uniqueBody** properties are returned in the default format of HTML.
+Note: The response object shown here is truncated for brevity. All of the properties will be returned from an actual call.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -66,18 +82,22 @@ Here is an example of the response. Note: The response object shown here may be 
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
-Content-length: 248
+Content-length: 5236
 
 {
-  "receivedDateTime": "2016-10-19T10:37:00Z",
-  "sentDateTime": "2016-10-19T10:37:00Z",
-  "hasAttachments": true,
-  "subject": "subject-value",
-  "body": {
-    "contentType": "",
-    "content": "content-value"
-  },
-  "bodyPreview": "bodyPreview-value"
+    "@odata.context":"https://graph.microsoft.com/beta/$metadata#users('cd209b0b-3f83-4c35-82d2-d88a61820480')/messages/$entity",
+    "@odata.etag":"W/\"CQAAABYAAABmWdbhEgBXTophjCWt81m9AAAoZYj4\"",
+    "id":"AAMkAGI1AAAoZCfHAAA=",
+    "subject":"Welcome to our group!",
+    "bodyPreview":"Welcome to our group, Dana! Hope you will enjoy working with us !\r\n",
+    "body":{
+        "contentType":"html",
+        "content":"<html>\r\n<head></head><body><p>Welcome to our group, Dana! Hope you will enjoy working with us </p></body></html>\r\n"
+    },
+    "uniqueBody":{
+        "contentType":"html",
+        "content":"<html>\r\n<head></head><body><p>Welcome to our group, Dana! Hope you will enjoy working with us </p></body></html>\r\n"
+    }
 }
 ```
 
@@ -185,6 +205,49 @@ Content-length: 248
       "application":null
     }
   ]
+}
+```
+
+
+##### Request 3
+The third example shows how to use a `Prefer: outlook.body-content-type="text"` header to get the **body** and **uniqueBody** of the specified message in text format.
+<!-- {
+  "blockType": "request",
+  "name": "get_message_in_text"
+}-->
+```http
+Prefer: outlook.body-content-type="text"
+
+GET https://graph.microsoft.com/beta/me/messages('AAMkAGI1AAAoZCfHAAA=')?$select=subject,body,bodyPreview,uniqueBody
+```
+##### Response 3
+Here is an example of the response. 
+Note: The response includes a `Preference-Applied: outlook.body-content-type` header to acknowledge the `Prefer: outlook.body-content-type` request header.
+<!-- {
+  "blockType": "response",
+  "truncated": false,
+  "@odata.type": "microsoft.graph.message"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Preference-Applied: outlook.body-content-type="text"
+Content-length: 1550
+
+{
+    "@odata.context":"https://graph.microsoft.com/beta/$metadata#users('cd209b0b-3f83-4c35-82d2-d88a61820480')/messages(subject,body,bodyPreview,uniqueBody)/$entity",
+    "@odata.etag":"W/\"CQAAABYAAABmWdbhEgBXTophjCWt81m9AAAoZYj4\"",
+    "id":"AAMkAGI1AAAoZCfHAAA=",
+    "subject":"Welcome to our group!",
+    "bodyPreview":"Welcome to our group, Dana! Hope you will enjoy working with us !\r\n\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\n\r\nTh",
+    "body":{
+        "contentType":"text",
+        "content":"Welcome to our group, Dana! Hope you will enjoy working with us [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] !\r\n\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\n\r\nThanks!\r\n\r\n"
+    },
+    "uniqueBody":{
+        "contentType":"text",
+        "content":"Welcome to our group, Dana! Hope you will enjoy working with us [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] !\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\nThanks!\r\n"
+    }
 }
 ```
 

--- a/api-reference/beta/api/user_list_messages.md
+++ b/api-reference/beta/api/user_list_messages.md
@@ -7,6 +7,23 @@ In particular, you can filter on the messages and get only those that include a 
 Note that by default, the `GET /me/messages` operation does not return the **mentions** property. Use the `$expand` query parameter 
 to [find details of each mention in a message](../api/message_get.md#request-2).
 
+### List message bodies in HTML or text format
+
+Message bodies can be in HTML or text format.
+
+You can use the `Prefer: outlook.body-content-type` header to specify the desired format returned in the **body** and **uniqueBody** properties in a `GET` request:
+
+- Specify `Prefer: outlook.body-content-type="text"` to get message bodies returned in text format.
+- Specify `Prefer: outlook.body-content-type="html"`, or just skip the header, to return message bodies in HTML format.
+
+<!--
+If you specify either header, the response will include the corresponding `Preference-Applied` header as confirmation:
+
+- For text format requests: `Preference-Applied: outlook.body-content-type="text"`
+- For HTML format requests: `Preference-Applied: outlook.body-content-type="html"`
+
+-->
+
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
 *Mail.Read; Mail.ReadWrite*
@@ -46,7 +63,7 @@ the signed-in user.
 | Header       | Value |
 |:---------------|:--------|
 | Authorization  | Bearer <token>. Required.  |
-| Content-Type   | application/json  | 
+| Prefer: outlook.body-content-type | string | The format of the **body** and **uniqueBody** properties to be returned in. Values can be "text" or "html". Optional. | 
 
 ## Request body
 Do not supply a request body for this method.
@@ -157,6 +174,85 @@ Content-length: 987
       }
     }
   ]
+}
+```
+
+##### Request 3
+The third example shows how to use a `Prefer: outlook.body-content-type="text"` header to get the **body** and **uniqueBody** properties of each message in text format.
+<!-- {
+  "blockType": "request",
+  "name": "get_messages_in_text"
+}-->
+```http
+Prefer: outlook.body-content-type="text"
+
+GET https://graph.microsoft.com/beta/me/messages?$select=subject,body,bodyPreview,uniqueBody
+```
+##### Response 3
+Here is an example of the response. 
+
+<!--
+Note: The response includes a `Preference-Applied: outlook.body-content-type` header to acknowledge the `Prefer: outlook.body-content-type` request header.
+-->
+
+<!-- {
+  "blockType": "response",
+  "truncated": false,
+  "@odata.type": "microsoft.graph.message",
+  "isCollection": true
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 2704
+
+{
+    "@odata.context":"https://graph.microsoft.com/beta/$metadata#users('cd209b0b-3f83-4c35-82d2-d88a61820480')/messages(subject,body,bodyPreview,uniqueBody)",
+    "value":[
+        {
+            "@odata.type":"#microsoft.graph.eventMessageRequest",
+            "@odata.etag":"W/\"CwAAABYAAABmWdbhEgBXTophjCWt81m9AAAoZYj5\"",
+            "id":"AAMkAGIAAAoZCfIAAA=",
+            "subject":"Orientation ",
+            "bodyPreview":"Dana, this is the time you selected for our orientation. Please bring the notes I sent you.",
+            "body":{
+                "contentType":"text",
+                "content":"Dana, this is the time you selected for our orientation. Please bring the notes I sent you.\r\n"
+            },
+            "uniqueBody":{
+                "contentType":"text",
+                "content":"Dana, this is the time you selected for our orientation. Please bring the notes I sent you.\r\n"
+            }
+        },
+        {
+            "@odata.etag":"W/\"CQAAABYAAABmWdbhEgBXTophjCWt81m9AAAoZYj4\"",
+            "id":"AAMkAGIAAAoZCfHAAA=",
+            "subject":"Welcome to our group!",
+            "bodyPreview":"Welcome to our group, Dana! Hope you will enjoy working with us !\r\n\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\n\r\nTh",
+            "body":{
+                "contentType":"text",
+                "content":"Welcome to our group, Dana! Hope you will enjoy working with us [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] !\r\n\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\n\r\nThanks!\r\n\r\n"
+            },
+            "uniqueBody":{
+                "contentType":"text",
+                "content":"Welcome to our group, Dana! Hope you will enjoy working with us [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] [\ud83d\ude0a] !\r\nWould you like to choose a day for our orientation from the available times below:\r\n\r\nDate\r\n        Time\r\n\r\nApril 14, 2017\r\n        1-3pm\r\n\r\nApril 21, 2017\r\n        10-12noon\r\n\r\n\r\nThanks!\r\n"
+            }
+        },
+        {
+            "@odata.etag":"W/\"CQAAABYAAABmWdbhEgBXTophjCWt81m9AAAAAAjr\"",
+            "id":"AQMkAGIAAAIJTQAAAA==",
+            "subject":"Welcome aboard!",
+            "bodyPreview":"Welcome to the Support group!",
+            "body":{
+                "contentType":"text",
+                "content":"Welcome to the Support group!\r\n"
+            },
+            "uniqueBody":{
+                "contentType":"text",
+                "content":"Welcome to the Support group!\r\n"
+            }
+        }
+    ]
 }
 ```
 

--- a/api-reference/beta/resources/message.md
+++ b/api-reference/beta/resources/message.md
@@ -66,8 +66,8 @@ Here is a JSON representation of the resource
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |bccRecipients|[recipient](recipient.md) collection|The Bcc: recipients for the message.|
-|body|[itemBody](itembody.md)|The body of the message.|
-|bodyPreview|String|The first 255 characters of the message body.|
+|body|[itemBody](itembody.md)|The body of the message. It can be in HTML or text format.|
+|bodyPreview|String|The first 255 characters of the message body. It is in text format.|
 |categories|String collection|The categories associated with the message.|
 |ccRecipients|[recipient](recipient.md) collection|The Cc: recipients for the message.|
 |changeKey|String|The version of the message.|
@@ -93,25 +93,25 @@ Here is a JSON representation of the resource
 |sentDateTime|DateTimeOffset|The date and time the message was sent.|
 |subject|String|The subject of the message.|
 |toRecipients|[recipient](recipient.md) collection|The To: recipients for the message.|
-|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message.|
+|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message. **uniqueBody** is not returned by default but can be retrieved for a given message by use of the `?$select=uniqueBody` query. It can be in HTML or text format.|
 |unsubscribeData|String|The valid entries parsed from the List-Unsubscribe header.  This is the data for the mail command in the List-Unsubscribe header if UnsubscribeEnabled property is true.|
 |unsubscribeEnabled|Boolean|Indicates whether the message is enabled for unsubscribe.  Its valueTrue if the list-Unsubscribe header conforms to rfc-2369.|
 |webLink|String|The URL to open the message in Outlook Web App.<br><br>You can append an ispopout argument to the end of the URL to change how the message is displayed. If ispopout is not present or if it is set to 1, then the message is shown in a popout window. If ispopout is set to 0, then the browser will show the message in the Outlook Web App review pane.<br><br>The message will open in the browser if you are logged in to your mailbox via Outlook Web App. You will be prompted to login if you are not already logged in with the browser.<br><br>This URL can be accessed from within an iFrame.|
 
-**Removing script from the Body property**
+**Removing script from the body property**
 
-The message body can be either HTML or text. If the body is HTML, by default, any potentially unsafe HTML (for example, JavaScript) embedded in the Body property would be removed before the body content is returned in a REST response.
+The message body can be either HTML or text. If the body is HTML, by default, any potentially unsafe HTML (for example, JavaScript) embedded in the **body** property would be removed before the body content is returned in a REST response.
 To get the entire, original HTML content, include the following HTTP request header:
 ```
 Prefer: outlook.allow-unsafe-html
 ```
 
-**Setting the From and Sender properties**
+**Setting the from and sender properties**
 
 When a message is being composed, in most cases, the From and Sender properties represent the same signed-in user, unless either is updated as described in the following scenarios:
 
-- The **From** property can be changed if the Exchange administrator has assigned **SendAs** rights of the mailbox to some other users. The administrator can do this by selecting **Mailbox Permissions** of the mailbox owner in the Azure Management Portal, or by using the Exchange Admin Center or a Windows PowerShell Add-ADPermission cmdlet. Then, you can programmatically set the **From** property to one of these users who have **SendAs** rights for that mailbox.
-- The **Sender** property can be changed if the mailbox owner has delegated one or more users to be able to send messages from that mailbox. The mailbox owner can delegate in Outlook. When a delegate sends a message on behalf of the mailbox owner, the **Sender** property is set to the delegate’s account, and the **From** property remains as the mailbox owner. Programmatically, you can set the **Sender** property to a user who has got delegate right for that mailbox.
+- The **from** property can be changed if the Exchange administrator has assigned **sendAs** rights of the mailbox to some other users. The administrator can do this by selecting **Mailbox Permissions** of the mailbox owner in the Azure Management Portal, or by using the Exchange Admin Center or a Windows PowerShell Add-ADPermission cmdlet. Then, you can programmatically set the **from** property to one of these users who have **sendAs** rights for that mailbox.
+- The **sender** property can be changed if the mailbox owner has delegated one or more users to be able to send messages from that mailbox. The mailbox owner can delegate in Outlook. When a delegate sends a message on behalf of the mailbox owner, the **sender** property is set to the delegate’s account, and the **from** property remains as the mailbox owner. Programmatically, you can set the **sender** property to a user who has got delegate right for that mailbox.
 
 ## Relationships
 | Relationship | Type	|Description|

--- a/api-reference/v1.0/api/message_get.md
+++ b/api-reference/v1.0/api/message_get.md
@@ -4,6 +4,8 @@ Retrieve the properties and relationships of a [message](../resources/message.md
 
 Since the **message** resource supports [extensions](../../../concepts/extensibility_overview.md), you can also use the `GET` operation to get custom properties and extension data in a **message** instance.
 
+Currently, this operation returns message bodies in only HTML format.
+
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
 *Mail.Read*  

--- a/api-reference/v1.0/api/user_list_messages.md
+++ b/api-reference/v1.0/api/user_list_messages.md
@@ -1,6 +1,9 @@
 # List messages
 
 Get the messages in the signed-in user's mailbox (including the Deleted Items and Clutter folders).
+
+Currently, this operation returns message bodies in only HTML format.
+
 ## Prerequisites
 One of the following **scopes** is required to execute this API:
 *Mail.Read; Mail.ReadWrite*
@@ -28,7 +31,7 @@ This method supports the [OData Query Parameters](http://developer.microsoft.com
 | Header       | Value |
 |:---------------|:--------|
 | Authorization  | Bearer <token>. Required.  |
-| Content-Type   | application/json  | 
+ 
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/resources/message.md
+++ b/api-reference/v1.0/resources/message.md
@@ -40,8 +40,8 @@ This resource lets you add your own data to custom properties using [extensions]
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |bccRecipients|[recipient](recipient.md) collection|The Bcc: recipients for the message.|
-|body|[itemBody](itembody.md)|The body of the message.|
-|bodyPreview|String|The first 255 characters of the message body.|
+|body|[itemBody](itembody.md)|The body of the message. It can be in HTML or text format.|
+|bodyPreview|String|The first 255 characters of the message body. It is in text format.|
 |categories|String collection|The categories associated with the message.|
 |ccRecipients|[recipient](recipient.md) collection|The Cc: recipients for the message.|
 |changeKey|String|The version of the message.|
@@ -65,23 +65,23 @@ This resource lets you add your own data to custom properties using [extensions]
 |sentDateTime|DateTimeOffset|The date and time the message was sent.|
 |subject|String|The subject of the message.|
 |toRecipients|[recipient](recipient.md) collection|The To: recipients for the message.|
-|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message. uniqueBody is not provided by default but can be retrieved for a given message by use of the ?$select=uniqueBody query.|
+|uniqueBody|[itemBody](itembody.md)|The part of the body of the message that is unique to the current message. **uniqueBody** is not returned by default but can be retrieved for a given message by use of the `?$select=uniqueBody` query. It can be in HTML or text format.|
 |webLink|String|The URL to open the message in Outlook Web App.<br><br>You can append an ispopout argument to the end of the URL to change how the message is displayed. If ispopout is not present or if it is set to 1, then the message is shown in a popout window. If ispopout is set to 0, then the browser will show the message in the Outlook Web App review pane.<br><br>The message will open in the browser if you are logged in to your mailbox via Outlook Web App. You will be prompted to login if you are not already logged in with the browser.<br><br>This URL can be accessed from within an iFrame.|
 
-**Removing script from the Body property**
+**Removing script from the body property**
 
-The message body can be either HTML or text. If the body is HTML, by default, any potentially unsafe HTML (for example, JavaScript) embedded in the Body property would be removed before the body content is returned in a REST response.
+The message body can be either HTML or text. If the body is HTML, by default, any potentially unsafe HTML (for example, JavaScript) embedded in the **body** property would be removed before the body content is returned in a REST response.
 To get the entire, original HTML content, include the following HTTP request header:
 ```
 Prefer: outlook.allow-unsafe-html
 ```
 
-**Setting the From and Sender properties**
+**Setting the from and sender properties**
 
 When a message is being composed, in most cases, the From and Sender properties represent the same signed-in user, unless either is updated as described in the following scenarios:
 
-- The **From** property can be changed if the Exchange administrator has assigned **SendAs** rights of the mailbox to some other users. The administrator can do this by selecting **Mailbox Permissions** of the mailbox owner in the Azure Management Portal, or by using the Exchange Admin Center or a Windows PowerShell Add-ADPermission cmdlet. Then, you can programmatically set the **From** property to one of these users who have **SendAs** rights for that mailbox.
-- The **Sender** property can be changed if the mailbox owner has delegated one or more users to be able to send messages from that mailbox. The mailbox owner can delegate in Outlook. When a delegate sends a message on behalf of the mailbox owner, the **Sender** property is set to the delegate’s account, and the **From** property remains as the mailbox owner. Programmatically, you can set the **Sender** property to a user who has got delegate right for that mailbox.
+- The **from** property can be changed if the Exchange administrator has assigned **sendAs** rights of the mailbox to some other users. The administrator can do this by selecting **Mailbox Permissions** of the mailbox owner in the Azure Management Portal, or by using the Exchange Admin Center or a Windows PowerShell Add-ADPermission cmdlet. Then, you can programmatically set the **from** property to one of these users who have **sendAs** rights for that mailbox.
+- The **sender** property can be changed if the mailbox owner has delegated one or more users to be able to send messages from that mailbox. The mailbox owner can delegate in Outlook. When a delegate sends a message on behalf of the mailbox owner, the **sender** property is set to the delegate’s account, and the **from** property remains as the mailbox owner. Programmatically, you can set the **sender** property to a user who has got delegate right for that mailbox.
 
 ## Relationships
 | Relationship | Type	|Description|


### PR DESCRIPTION
…, using a request header. Added examples. Clarified in the v1 version that getting messages always returns in HTML format.