### PR TITLE
Provide the address with specific value

### DIFF
--- a/api-reference/v1.0/api/tablecollection_add.md
+++ b/api-reference/v1.0/api/tablecollection_add.md
@@ -41,7 +41,7 @@ Content-type: application/json
 Content-length: 54
 
 {
-  "address": "address-value",
+  "address": "Sheet1!A1:D5",
   "hasHeaders": true
 }
 ```


### PR DESCRIPTION
Following [this doc](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/tablecollection_add), I were not clear about the `address` how it should write, and asked on [Stack Overflow](http://stackoverflow.com/questions/43689614/failed-to-add-table-using-microsoft-graph).
After all, it is an example, maybe we should just give a specific value which is easy to understand.