### PR TITLE
Change example query type

### DIFF
--- a/api-reference/beta/api/insights_list_trending.md
+++ b/api-reference/beta/api/insights_list_trending.md
@@ -16,9 +16,9 @@ This method supports the [OData Query Parameters](http://developer.microsoft.com
 
 For example, you can use the `$filter` query parameter to filter trending items based on the Container Type:
 
-`https://graph.microsoft.com/beta/me/insights/trending?$filter=ResourceVisualization/ContainerType eq 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'`
+`https://graph.microsoft.com/beta/me/insights/trending?$filter=ResourceVisualization/MediaType eq 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'`
 
-See the available Container Types and Types you can filter by in [resourceVisualization](../resources/insights_resourceVisualization.md).
+See the available Media Types and Types you can filter by in [resourceVisualization](../resources/insights_resourceVisualization.md).
 
 
 ## Request headers


### PR DESCRIPTION
The example with ContainerType for me throws an error:

 "A binary operator with incompatible types was detected. Found operand types 'microsoft.graph.containerType' and 'Edm.String' for operator kind 'Equal'.",

And when you look at whats returned from Trending it is media type that has the application/vnd.openxmlformats-officedocument.wordprocessingml.document, not container type. If I switch the example to use MediaType it works. So thought I'd propose this as a change. So just to be cleared this query works for me on media type:

https://graph.microsoft.com/beta/me/insights/trending?$filter=ResourceVisualization/MediaType eq 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'

Where as the example one threw an error for me

https://graph.microsoft.com/beta/me/insights/trending?$filter=ResourceVisualization/ContainerType eq 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'