### PR TITLE
Clean up default $select description

### DIFF
--- a/api-reference/beta/api/user_list.md
+++ b/api-reference/beta/api/user_list.md
@@ -2,30 +2,39 @@
 
 Retrieve a list of user objects.
 
-> Note: Listing users returns a default set of properties only (*businessPhones, displayName, givenName, id, jobTitle, mail, mobilePhone, officeLocation, preferredLanguage, surname, userPrincipalName*). Use `$select` to get the other properties and relationships for the [user](../resources/user.md) object.
-
 ## Prerequisites
+
 One of the following **scopes** is required to execute this API:
 *User.ReadBasic.All; User.Read.All; User.ReadWrite.All; Directory.Read.All; Directory.ReadWrite.All; Directory.AccessAsUser.All*
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /users
 ```
+
 ## Optional query parameters
+
 This method supports the [OData Query Parameters](http://developer.microsoft.com/en-us/graph/docs/overview/query_parameters) to help customize the response.
+
 ## Request headers
-| Header       | Value|
-|:-----------|:------|
-| Authorization  | Bearer {token}. Required.  |
-| Content-Type   | application/json | 
+| Header        | Value                      |
+|:--------------|:---------------------------|
+| Authorization | Bearer <token> (required)  |
+| Content-Type  | application/json           | 
 
 ## Request body
+
 Do not supply a request body for this method.
+
 ## Response
+
 If successful, this method returns a `200 OK` response code and collection of [user](../resources/user.md) objects in the response body.
+
 ## Example
+
 ##### Request
+
 Here is an example of the request.
 <!-- {
   "blockType": "request",
@@ -34,7 +43,9 @@ Here is an example of the request.
 ```http
 GET https://graph.microsoft.com/beta/users
 ```
+
 ##### Response
+
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user_list.md
+++ b/api-reference/beta/api/user_list.md
@@ -20,7 +20,7 @@ This method supports the [OData Query Parameters](http://developer.microsoft.com
 ## Request headers
 | Header        | Value                      |
 |:--------------|:---------------------------|
-| Authorization | Bearer <token> (required)  |
+| Authorization | Bearer {token} (required)  |
 | Content-Type  | application/json           | 
 
 ## Request body

--- a/api-reference/v1.0/api/user_list.md
+++ b/api-reference/v1.0/api/user_list.md
@@ -2,41 +2,46 @@
 
 Retrieve a list of user objects.
 
-> Note: Listing users returns a default set of properties only (*businessPhones, displayName, givenName, id, jobTitle, mail, mobilePhone, officeLocation, preferredLanguage, surname, userPrincipalName*). Use `$select` to get the other properties and relationships for the [user](../resources/user.md) object. However, only the following properties can be selected for individual users, e.g. /v1.0/me?$select=aboutMe, and not for collections of users, e.g. /v1.0/users?$select=aboutMe:
->* aboutMe
->* birthday
->* hireDate
->* interests
->* mySite
->* pastProjects
->* preferredName
->* responsibilities
->* schools
->* skills
->* mailboxSettings
-
 ## Prerequisites
+
 One of the following **scopes** is required to execute this API:
 *User.ReadBasic.All; User.Read.All; User.ReadWrite.All; Directory.Read.All; Directory.ReadWrite.All; Directory.AccessAsUser.All*
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /users
 ```
+
 ## Optional query parameters
+
 This method supports the [OData Query Parameters](http://developer.microsoft.com/en-us/graph/docs/overview/query_parameters) to help customize the response.
+
+By default, only a limited set of properties are returned (_businessPhones, displayName, givenName, id, jobTitle, mail, mobilePhone, officeLocation, preferredLanguage, surname, userPrincipalName_). 
+
+To return an alternative property set, you must specify the desired set of [user](../resources/user.md) properties using the ODATA `$select` query parameter. For example, to return _displayName_, _givenName_, _id_ and _postalCode_, you would use the add the following to your query `$select=displayName,givenName,postalCode`
+
+> Note: Certain properties cannot be returned within a user collection. The following properties are only supported when [retrieving an single user](./user_get.md): _aboutMe, birthday, hireDate, interests, mySite, pastProjects, preferredName, responsibilities, schools, skills, mailboxSettings_
+
 ## Request headers
-| Header       | Value|
-|:-----------|:------|
-| Authorization  | Bearer {token}. Required.  |
-| Content-Type   | application/json | 
+
+| Header        | Value                      |
+|:--------------|:---------------------------|
+| Authorization | Bearer <token> (required)  |
+| Content-Type  | application/json           | 
 
 ## Request body
+
 Do not supply a request body for this method.
+
 ## Response
+
 If successful, this method returns a `200 OK` response code and collection of [user](../resources/user.md) objects in the response body.
+
 ## Example
+
 ##### Request
+
 Here is an example of the request.
 <!-- {
   "blockType": "request",
@@ -45,7 +50,9 @@ Here is an example of the request.
 ```http
 GET https://graph.microsoft.com/v1.0/users
 ```
+
 ##### Response
+
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/user_list.md
+++ b/api-reference/v1.0/api/user_list.md
@@ -27,7 +27,7 @@ To return an alternative property set, you must specify the desired set of [user
 
 | Header        | Value                      |
 |:--------------|:---------------------------|
-| Authorization | Bearer <token> (required)  |
+| Authorization | Bearer {token} (required)  |
 | Content-Type  | application/json           | 
 
 ## Request body


### PR DESCRIPTION
Reformatted and reworded how we describe the default $select statment applied to user_list. 

I also removed this information from the beta endpoint as within beta we return the entire user object rather than a default property set. 