### PR TITLE
Clarified in Known Issues topic the circumstances that GET /me/events…

### DIFF
--- a/concepts/known_issues.md
+++ b/concepts/known_issues.md
@@ -102,20 +102,25 @@ When attempting to access events in a calendar that has been shared by another u
 GET \users('{id}')\calendars('{id}')\events
 ```
 
-You may get HTTP 500 with the error code `ErrorInternalServerTransientError`.
+You may get HTTP 500 with the error code `ErrorInternalServerTransientError`. The error occurs because:
 
-Historically, there are two ways that calendar sharing has been implemented, which, for the purpose of differentiating them, 
-are referred to as the "old" implementation and "new" implementation. The error occurs because: 
+- Historically, there are two ways that calendar sharing has been implemented, which, for the purpose of differentiating them, 
+are referred to as the "old" approach and "new" approach.
+- The new approach is currently available for sharing calendars with view or edit permissions, but not with delegate permissions. 
+- You can use the calendar REST API to view or edit shared calendars only if the calendars were shared using the **new** approach. 
+- You cannot use the calendar REST API to view or edit such calendars (or their events) if the calendars were shared using the **old** approach.
 
-- Currently, only Outlook on the web, Outlook on iOS, and Outlook on Android support sharing calendars on Office 365 in the new way.
-- You can use the calendar REST API to view or edit shared calendars, only if the calendars were shared in the new way. 
-- You cannot use the calendar REST API to view or edit calendars (or their events) that have been shared in the old way.
 
-To work around this, the calendar owner should re-share the calendar in Outlook on the web, Outlook on iOS, or Outlook on Android, and you 
-should re-accept the calendar using Outlook on the web. After re-accepting, one way to verify if the calendar has been shared using the new model is 
-to successfully view the shared calendar in Outlook on iOS or Outlook on Android.
+If a calendar was shared with view or edit permissions but using the old approach, you can now work around the error and manually upgrade the calendar sharing to use the new approach. 
+Over time, Outlook will autmatically upgrade all shared calendars to use the new approach, including calendars shared with delegate permissions. 
 
-A calendar shared with you in the new way appears as just another calendar in your mailbox. You can use the calendar REST API to view or edit 
+To manually upgrade a shared calendar to use the new approach, follow these steps:
+1.	The recipient removes the calendar that was previously shared to them.
+2.	The calendar owner re-shares the calendar in Outlook on the web, Outlook on iOS, or Outlook on Android.
+3.	The recipient re-accepts the shared calendar using Outlook on the web. (It will be possible to use other Outlook clients soon.)
+4.	The recipient verifies that the calendar has been re-shared successfully using the new approach by being able to view the shared calendar in Outlook on iOS or Outlook on Android.
+
+A calendar shared with you in the new approach appears as just another calendar in your mailbox. You can use the calendar REST API to view or edit 
 events in the shared calendar, as if it's your own calendar. As an example:
 
 ```http


### PR DESCRIPTION
… would get an HTTP 500 error when the user has been shared a calendar.