### PR TITLE
Update user.md

### DIFF
--- a/api-reference/v1.0/resources/user.md
+++ b/api-reference/v1.0/resources/user.md
@@ -114,7 +114,7 @@ This resource supports:
 |contactFolders|[ContactFolder](contactfolder.md) collection|The user's contacts folders. Read-only. Nullable.|
 |contacts|[Contact](contact.md) collection|The user's contacts. Read-only. Nullable.|
 |createdObjects|[directoryObject](directoryobject.md) collection|Directory objects that were created by the user. Read-only. Nullable.|
-|directReports|[directoryObject](directoryobject.md) collection|The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. |
+|directReports|[directoryObject](directoryobject.md) collection|The users and contacts that report to the user. (The users and contacts that have their manager property set to this user.) Read-only. Nullable. Does not support $expand and $count |
 |drive|[drive](drive.md)|The user's OneDrive. Read-only.|
 |drives|[drive](drive.md) collection. | A collection of drives available for this user. Read-only. |
 |events|[Event](event.md) collection|The user's events. Default is to show Events under the Default Calendar. Read-only. Nullable.|


### PR DESCRIPTION
Documenting that the relation directReports does not support the odata query parameters $expand and $count. MS Graph explorer itself states that $count is not supported, whereas $expand is just ignored for the directReports relation by MS Graph