### PR TITLE
Typo for two words

### DIFF
--- a/api-reference/v1.0/api/item_createuploadsession.md
+++ b/api-reference/v1.0/api/item_createuploadsession.md
@@ -142,7 +142,7 @@ The **nextExpectedRanges** property indicates ranges of the file that have not b
 * On successful fragment writes, it will return the next range to start from (eg. "523-").
 * On failures when the client sent a fragment the server had already received, the server will respond with `HTTP 416 Requested Range Not Satisfiable`. 
   You can [request upload status](#resuming-an-in-progress-upload) to get a more detailed list of missing ranges.
-* Including the Authorization header when issuing the `PUT` call may result in a `HTTP 401 Unauthoized` response. The Authoization header and bearer token should only be sent when issueing the `POST` during the first step. It should be not be included when issueing the `PUT`.   
+* Including the Authorization header when issuing the `PUT` call may result in a `HTTP 401 Unauthorized` response. The Authorization header and bearer token should only be sent when issueing the `POST` during the first step. It should be not be included when issueing the `PUT`.   
 
 
 ## Completing a file


### PR DESCRIPTION
Unauthorized and Authorization are incorrectly spelled.