### PR TITLE
Add missing endpoints in pattern 

### DIFF
--- a/api-reference/v1.0/api/item_createuploadsession.md
+++ b/api-reference/v1.0/api/item_createuploadsession.md
@@ -30,6 +30,7 @@ Once the last byte of the file has been uploaded the upload session is completed
 ```http
 POST /me/drive/root:/{path-to-item}:/createUploadSession
 POST /me/drive/items/{parent-item-id}:/{filename}:/createUploadSession
+POST /drives/{drive-id}/items/{parent-item-id}:/{filename}:/createUploadSession
 ```
 
 ### Request body

--- a/api-reference/v1.0/api/item_downloadcontent.md
+++ b/api-reference/v1.0/api/item_downloadcontent.md
@@ -18,7 +18,7 @@ One of the following permissions is required to call this API. To learn more, in
 ```http
 GET /me/drive/root:/{item-path}:/content
 GET /me/drive/items/{item-id}/content
-GET /drives/items/{item-id}/content
+GET /drives/{drive-id}/items/{item-id}/content
 GET /groups/{group-id}/drive/items/{item-id}/content
 ```
 

--- a/api-reference/v1.0/api/item_list_thumbnails.md
+++ b/api-reference/v1.0/api/item_list_thumbnails.md
@@ -33,6 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 ```http
 GET /me/drive/root:/{item-path}:/thumbnails
 GET /me/drive/items/{item-id}/thumbnails
+GET /drives/{drive-id}/items/{item-id}/thumbnails
 GET /groups/{group-id}/drive/items/{item-id}/thumbnails
 ```
 


### PR DESCRIPTION
Some pages have missing endpoint in pattern /drives/{drive-id}/items/{item-id}

I tried these missing endpoint, they do work from Graph API explorer.