### PR TITLE
fixed #1691

### DIFF
--- a/api-reference/v1.0/api/chartfill_clear.md
+++ b/api-reference/v1.0/api/chartfill_clear.md
@@ -24,6 +24,7 @@ POST /workbook/worksheets/{id|name}/charts(<name>)/legend/format/fill/clear
 | Authorization  | Bearer {token}. Required. |
 
 ## Request body
+Do not supply a request body for this method.
 
 ## Response
 

--- a/api-reference/v1.0/api/filter_clear.md
+++ b/api-reference/v1.0/api/filter_clear.md
@@ -23,6 +23,7 @@ POST /workbook/worksheets/{id|name}/tables/{id|name}/columns/{id|name}/filter/cl
 | Authorization  | Bearer {token}. Required. |
 
 ## Request body
+Do not supply a request body for this method.
 
 ## Response
 

--- a/api-reference/v1.0/api/group_subscribebymail.md
+++ b/api-reference/v1.0/api/group_subscribebymail.md
@@ -24,6 +24,7 @@ POST /groups/{id}/subscribeByMail
 | Authorization  | Bearer {token}. Required.  |
 
 ## Request body
+Do not supply a request body for this method.
 
 ## Response
 If successful, this method returns `200, OK` response code. It does not return anything in the response body.

--- a/api-reference/v1.0/api/group_unsubscribebymail.md
+++ b/api-reference/v1.0/api/group_unsubscribebymail.md
@@ -23,6 +23,7 @@ POST /groups/{id}/unsubscribeByMail
 | Authorization  | Bearer {token}. Required.  |
 
 ## Request body
+Do not supply a request body for this method.
 
 ## Response
 If successful, this method returns `200, OK` response code. It does not return anything in the response body.


### PR DESCRIPTION
Fixes Issue #1691 

Replaced empty 'request body' section with default text
used in other pages
"Do not supply a request body for this method."
 for consistency

After verifying that the specified request bodies for these methods should be empty.

