### PR TITLE
remove previous-page parameter (not used in most Graph endpoints)

### DIFF
--- a/concepts/paging.md
+++ b/concepts/paging.md
@@ -1,4 +1,3 @@
-
 # Paging Microsoft Graph data in your app 
 
 Some queries against Microsoft Graph return multiple pages of data either due to server-side paging or due to the use of the `$top` query parameter to specifically limit the page size in a request. When a result set spans multiple pages, Microsoft Graph returns an `@odata.nextLink` property in the response that contains a URL to the next page of results. 
@@ -30,5 +29,3 @@ Paging behavior varies across different Microsoft Graph APIs. Consider the follo
 - Different APIs might have different default and maximum page sizes.
 - Different APIs might behave differently if you specify a page size (via the `$top` query parameter) that exceeds the maximum page size for that API. Depending on the API, the requested page size might be ignored, it might default to the maximum page size for that API, or Microsoft Graph might return an error. 
 - Not all resources or relationships support paging. For example, queries against [directoryRoles](../api-reference/v1.0/resources/directoryrole.md) do not support paging. This includes reading role objects themselves as well as role members.
-- Some Microsoft Graph APIs support backward paging by appending the `previous-page` query parameter (`&previous-page=true`) to the URL value of the `@odata:nextLink` property. After you append this parameter to a request, the `@odata:nextLink` URL value in subsequent responses will include it. You can continue to page backward until a response with an empty result is returned. Paging further will return an error. Alternatively, you can resume paging forward from the current response by removing the `previous-page` parameter when you send the request for the next page of results. 
-


### PR DESCRIPTION
Remove previous-page parameter, which is not supported in most Graph paginated responses (e.g., messages).