### PR TITLE
fixed wrong link

### DIFF
--- a/api-reference/v1.0/api/user_list_people.md
+++ b/api-reference/v1.0/api/user_list_people.md
@@ -21,7 +21,7 @@ GET /users/{id | userPrincipalName}/people
 ```
 
 ## Optional query parameters
-This method supports the [OData Query Parameters](../../../concepts/people_example.md) to help customize the response.
+This method supports the [OData Query Parameters](../../../concepts/query_parameters.md) to help customize the response.
 
 |Name|Value|Description| 
 |:---------------|:--------|:-------| 


### PR DESCRIPTION
OData Query Parameters link was pointing to the wrong page (to /concepts/people_example.md).