### PR TITLE
Johnau appveyorfix

### DIFF
--- a/api-reference/v1.0/api/photo_get.md
+++ b/api-reference/v1.0/api/photo_get.md
@@ -62,7 +62,7 @@ Content-length: 53
 ##### Request
 Here is an example of the request for the photo bytes.
 <!-- {
-  "blockType": "ignored",
+  "blockType": "request",
   "name": "get_photo"
 }-->
 ```http

--- a/api-reference/v1.0/api/photo_get.md
+++ b/api-reference/v1.0/api/photo_get.md
@@ -71,7 +71,7 @@ GET https://graph.microsoft.com/v1.0/users/{id|userPrincipalName}/photo/$value
 ##### Response
 Here is an example of the response.
 
-<!-- { "blockType": "ignored", "@odata.type": "stream" } -->
+<!-- { "blockType": "response", "@odata.type": "stream" } -->
 
 ```http
 HTTP/1.1 200 OK

--- a/api-reference/v1.0/config/oneapi-design-v1.json
+++ b/api-reference/v1.0/config/oneapi-design-v1.json
@@ -20,10 +20,10 @@
         "Content-Range",
         "Range"
       ],
-      "contentTypes": ["application/json", "multipart/related", "text/plain"]
+      "contentTypes": ["application/json", "multipart/related", "text/plain", "image/jpeg"]
     },
     "httpResponse": {
-      "contentTypes": ["application/json", "multipart/related", "text/plain"],
+      "contentTypes": ["application/json", "multipart/related", "text/plain", "image/jpeg"],
       "standardHeaders":
       [
         "Content-Range"


### PR DESCRIPTION
photo_get.md:  set Appveyor HTML blocks for 2nd request/response example to "request" & "response". They were set to "ignored".  Fixed Appveyor configuration to accept Content-type image/jpeg