### PR TITLE
added retry-after supported resources for 429

### DIFF
--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -31,14 +31,14 @@ When you implement error handling, use the HTTP error code 429 to detect throttl
 3. If the request fails again with a 429 error code, you are still being throttled. Continue to use the recommended Retry-After delay and retry the request until it succeeds.
 
 The following resources currently provide a retry-after header:
-- [User](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user)
-- [Photo](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/profilephoto)
-- [Mail](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/message)
-- [Calendar (users and groups)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/event)
-- [Contact](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/contact)
-- [Attachment](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/attachment)
-- [Group conversations](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/conversation)
-- [People and social](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/social_overview)
-- [Drive resources (OneDrive)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/drive)
+- [User](../api-reference/v1.0/resources/user)
+- [Photo](../api-reference/v1.0/resources/profilephoto)
+- [Mail](../api-reference/v1.0/resources/message)
+- [Calendar (users and groups)](../api-reference/v1.0/resources/event)
+- [Contact](../api-reference/v1.0/resources/contact)
+- [Attachment](../api-reference/v1.0/resources/attachment)
+- [Group conversations](../api-reference/v1.0/resources/conversation)
+- [People and social](../api-reference/beta/resources/social_overview)
+- [Drive resources (OneDrive)](../api-reference/v1.0/resources/drive)
 
 For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://msdn.microsoft.com/en-us/library/office/dn589798.aspx).

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -30,4 +30,15 @@ When you implement error handling, use the HTTP error code 429 to detect throttl
 2. Retry the request.
 3. If the request fails again with a 429 error code, you are still being throttled. Continue to use the recommended Retry-After delay and retry the request until it succeeds.
 
+The following resources currently provide a retry-after header:
+- [User resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user)
+- [Photo resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/profilephoto)
+- [Mail resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/message)
+- [Calendar resources (users and groups)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/event)
+- [Contact resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/contact)
+- [Attachment resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/attachment)
+- [Group conversations](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/conversation)
+- [People and social resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/social_overview)
+- [Drive resources (OneDrive)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/drive)
+
 For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://msdn.microsoft.com/en-us/library/office/dn589798.aspx).

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -31,14 +31,14 @@ When you implement error handling, use the HTTP error code 429 to detect throttl
 3. If the request fails again with a 429 error code, you are still being throttled. Continue to use the recommended Retry-After delay and retry the request until it succeeds.
 
 The following resources currently provide a retry-after header:
-- [User resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user)
-- [Photo resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/profilephoto)
-- [Mail resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/message)
-- [Calendar resources (users and groups)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/event)
-- [Contact resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/contact)
-- [Attachment resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/attachment)
+- [User](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/user)
+- [Photo](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/profilephoto)
+- [Mail](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/message)
+- [Calendar (users and groups)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/event)
+- [Contact](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/contact)
+- [Attachment](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/attachment)
 - [Group conversations](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/conversation)
-- [People and social resources](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/social_overview)
+- [People and social](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/social_overview)
 - [Drive resources (OneDrive)](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/drive)
 
 For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://msdn.microsoft.com/en-us/library/office/dn589798.aspx).

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -31,14 +31,14 @@ When you implement error handling, use the HTTP error code 429 to detect throttl
 3. If the request fails again with a 429 error code, you are still being throttled. Continue to use the recommended Retry-After delay and retry the request until it succeeds.
 
 The following resources currently provide a retry-after header:
-- [User](../api-reference/v1.0/resources/user)
-- [Photo](../api-reference/v1.0/resources/profilephoto)
-- [Mail](../api-reference/v1.0/resources/message)
-- [Calendar (users and groups)](../api-reference/v1.0/resources/event)
-- [Contact](../api-reference/v1.0/resources/contact)
-- [Attachment](../api-reference/v1.0/resources/attachment)
-- [Group conversations](../api-reference/v1.0/resources/conversation)
-- [People and social](../api-reference/beta/resources/social_overview)
-- [Drive resources (OneDrive)](../api-reference/v1.0/resources/drive)
+- [User](../api-reference/v1.0/resources/user.md)
+- [Photo](../api-reference/v1.0/resources/profilephoto.md)
+- [Mail](../api-reference/v1.0/resources/message.md)
+- [Calendar (users and groups)](../api-reference/v1.0/resources/event.md)
+- [Contact](../api-reference/v1.0/resources/contact.md)
+- [Attachment](../api-reference/v1.0/resources/attachment.md)
+- [Group conversations](../api-reference/v1.0/resources/conversation.md)
+- [People and social](../api-reference/beta/resources/social_overview.md)
+- [Drive (OneDrive)](../api-reference/v1.0/resources/drive.md)
 
 For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://msdn.microsoft.com/en-us/library/office/dn589798.aspx).


### PR DESCRIPTION
retry-after header is not supported by all resources due to implementation of the underlaying API's
this PR documents which resources are supported at the moment
https://stackoverflow.com/questions/47146598/not-receiving-retry-after-headers-from-ms-graph-api
https://blogs.msdn.microsoft.com/exchangedev/2017/04/07/throttling-coming-to-outlook-api-and-microsoft-graph/
https://officespdev.uservoice.com/forums/224641-feature-requests-and-feedback/suggestions/32797489-consistent-retry-after-information-accross-differe
https://github.com/microsoftgraph/msgraph-sdk-javascript/issues/42