### PR TITLE
getMemberGroups/checkMemberGroups permissions fix

### DIFF
--- a/api-reference/v1.0/api/group_checkmembergroups.md
+++ b/api-reference/v1.0/api/group_checkmembergroups.md
@@ -9,11 +9,13 @@ in an Office 365 Group is always direct.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
+>**Note:** This API currently requires the Directory.Read.All permission or higher. Using the Group.Read.All permission will return an error. This is a known bug.
+
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Not supported.    |
+|Delegated (work or school account) | *Group.Read.All*, Directory.Read.All |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Not supported. |
+|Application | *Group.Read.All*, Directory.Read.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/group_getmembergroups.md
+++ b/api-reference/v1.0/api/group_getmembergroups.md
@@ -8,11 +8,13 @@ always direct.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
+>**Note:** This API currently requires the Directory.Read.All permission or higher. Using the Group.Read.All permission will return an error. This is a known bug.
+
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Group.Read.All, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
+|Delegated (work or school account) | *Group.Read.All*, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Group.Read.All, Directory.Read.All, Directory.ReadWrite.All |
+|Application | *Group.Read.All*, Directory.Read.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/user_checkmembergroups.md
+++ b/api-reference/v1.0/api/user_checkmembergroups.md
@@ -9,11 +9,13 @@ in an Office 365 Group is always direct.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
+>**Note:** This API currently requires the Directory.Read.All permission or higher. Using the User.Read.All or User.ReadWrite.All permissions will return an error. This is a known bug.
+
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | User.Read.All, User.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
+|Delegated (work or school account) | *User.Read.All*, *User.ReadWrite.All*, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | User.Read.All, User.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
+|Application | *User.Read.All*, *User.ReadWrite.All*, Directory.Read.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/user_getmembergroups.md
+++ b/api-reference/v1.0/api/user_getmembergroups.md
@@ -8,7 +8,7 @@ always direct.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
->**Note:** This API currently requires the Directory.Read.All permission or higher. Using the User.Read, Group.Read.All, or User.ReadBasic.All permissions will return an error. This is a known bug.
+>**Note:** This API currently requires the Directory.Read.All permission or higher. Using the User.Read or User.ReadBasic.All permissions in combination with the Group.Read.All permission will return an error. This is a known bug.
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|

--- a/api-reference/v1.0/api/user_getmembergroups.md
+++ b/api-reference/v1.0/api/user_getmembergroups.md
@@ -8,11 +8,13 @@ always direct.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
+>**Note:** This API currently requires the Directory.Read.All permission or higher. Using the User.Read, Group.Read.All, or User.ReadBasic.All permissions will return an error. This is a known bug.
+
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | User.Read and Group.Read.All, User.ReadBasic.All and Group.Read.All, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
+|Delegated (work or school account) | *User.Read and Group.Read.All*, *User.ReadBasic.All and Group.Read.All*, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | User.ReadBasic.All and Group.Read.All, Directory.Read.All, Directory.ReadWrite.All |
+|Application | *User.ReadBasic.All and Group.Read.All*, Directory.Read.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
Edited permissions documentation for APIs affected by a known bug that causes Directory.Read.All to be the required minimum permission for certain operations with groups, rather than lower-level permissions as intended. Since this bug may not be fixed immediately, we decided to note it in the documentation until fixed.