### PR TITLE
Updated correct permission policy for the call

### DIFF
--- a/api-reference/beta/api/grouplifecyclepolicy_renewgroup.md
+++ b/api-reference/beta/api/grouplifecyclepolicy_renewgroup.md
@@ -11,9 +11,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Directory.ReadWrite.All    |
+|Delegated (work or school account) | Directory.ReadWrite.All, Group.ReadWrite.All    |
 |Delegated (personal Microsoft account) | Not supported |
-|Application | Not supported |
+|Application | Directory.ReadWrite.All, Group.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/grouplifecyclepolicy_renewgroup.md
+++ b/api-reference/beta/api/grouplifecyclepolicy_renewgroup.md
@@ -11,9 +11,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Directory.ReadWrite.All, Group.ReadWrite.All    |
+|Delegated (work or school account) | Group.ReadWrite.All, Directory.ReadWrite.All |
 |Delegated (personal Microsoft account) | Not supported |
-|Application | Directory.ReadWrite.All, Group.ReadWrite.All |
+|Application | Group.ReadWrite.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
Renewing a groups expiration life cycle policy requires either `Directory.ReadWrite.All` or `Group.ReadWrite.All`.

Renewing also works fine using app-only, not only using delegated.