### PR TITLE
Fixed formatting

### DIFF
--- a/api-reference/beta/api/event_update.md
+++ b/api-reference/beta/api/event_update.md
@@ -46,7 +46,7 @@ In the request body, supply the values for relevant fields that should be update
 | body|ItemBody|The body of the message associated with the event.|
 | categories|String|The categories associated with the event.|
 | end|DateTimeTimeZone|The date and time that the event ends.<br/><br/>By default, the end time is in UTC. You can specify an optional time zone in EndTimeZone, express the end time in that time zone, and include a time offset from UTC. Note that if you use EndTimeZone, you must specify a value for StartTimeZone as well.<br/><br/>This example specifies February 25, 2015, 9:34pm in Pacific Standard Time: "2015-02-25T21:34:00-08:00". |
-| importance|String|The importance of the event: Low = 0, Normal = 1, High = 2. Possible values are: `Low`, `Normal`, `High`.|
+| importance|String|The importance of the event. Possible values are: `Low`, `Normal`, `High`.|
 | isAllDay|Boolean|Set to true if the event lasts all day.|
 | isReminderOn|Boolean|Set to true if an alert is set to remind the user of the event.|
 | onlineMeetingUrl|String|A URL for an online meeting.|

--- a/api-reference/beta/resources/event.md
+++ b/api-reference/beta/resources/event.md
@@ -86,7 +86,7 @@ Here is a JSON representation of the resource
 |hasAttachments|Boolean|Set to true if the event has attachments.|
 |iCalUId|String|A unique identifier that is shared by all instances of an event across different calendars.|
 |id|String| Read-only.|
-|importance|String|The importance of the event: Low = 0, Normal = 1, High = 2. Possible values are: `Low`, `Normal`, `High`.|
+|importance|String|The importance of the event. Possible values are: `Low`, `Normal`, `High`.|
 |isAllDay|Boolean|Set to true if the event lasts all day.|
 |isCancelled|Boolean|Set to true if the event has been canceled.|
 |isOrganizer|Boolean|Set to true if the message sender is also the organizer.|

--- a/api-reference/beta/resources/responsestatus.md
+++ b/api-reference/beta/resources/responsestatus.md
@@ -4,12 +4,12 @@
 
 The response status of a meeting request.
 
-
 ## Properties
-| Property	   | Type	|Description|
-|:---------------|:--------|:----------|
-|response|String|The response type: None = 0, Organizer = 1, TentativelyAccepted = 2, Accepted = 3, Declined = 4, NotResponded = 5. Possible values are: `None`, `Organizer`, `TentativelyAccepted`, `Accepted`, `Declined`, `NotResponded`.|
-|time|DateTimeOffset|The date and time that the response was returned. It uses ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
+
+| Property | Type           | Description |
+|:---------|:---------------|:------------|
+| response | String         | The response type. Possible values are: `None`, `Organizer`, `TentativelyAccepted`, `Accepted`, `Declined`, `NotResponded`.
+| time     | DateTimeOffset | The date and time that the response was returned. It uses ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`
 
 ## JSON representation
 
@@ -22,12 +22,12 @@ Here is a JSON representation of the resource
   ],
   "@odata.type": "microsoft.graph.responseStatus"
 }-->
+
 ```json
 {
   "response": "String",
   "time": "String (timestamp)"
 }
-
 ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/v1.0/api/event_update.md
+++ b/api-reference/v1.0/api/event_update.md
@@ -44,7 +44,7 @@ In the request body, supply the values for relevant fields that should be update
 |body|[ItemBody](../resources/itembody.md)|The body of the message associated with the event.|
 |categories|String|The categories associated with the event.|
 |end|[DateTimeTimeZone](../resources/datetimetimezone.md)|The date and time that the event ends.<br/><br/>By default, the end time is in UTC. You can specify an optional time zone in EndTimeZone, express the end time in that time zone, and include a time offset from UTC. Note that if you use EndTimeZone, you must specify a value for StartTimeZone as well.<br/><br/>This example specifies February 25, 2015, 9:34pm in Pacific Standard Time: "2015-02-25T21:34:00-08:00". |
-|importance|String|The importance of the event: Low = 0, Normal = 1, High = 2. Possible values are: `Low`, `Normal`, `High`.|
+|importance|String|The importance of the event. Possible values are: `Low`, `Normal`, `High`.|
 |isAllDay|Boolean|Set to true if the event lasts all day.|
 |isReminderOn|Boolean|Set to true if an alert is set to remind the user of the event.|
 |location|[Location](../resources/location.md)|The location of the event.|

--- a/api-reference/v1.0/resources/event.md
+++ b/api-reference/v1.0/resources/event.md
@@ -50,7 +50,7 @@ by providing a [delta](../api/event_delta.md) function.
 |hasAttachments|Boolean|Set to true if the event has attachments.|
 |iCalUId|String|A unique identifier that is shared by all instances of an event across different calendars.|
 |id|String| Read-only.|
-|importance|String|The importance of the event: Low = 0, Normal = 1, High = 2. Possible values are: `Low`, `Normal`, `High`.|
+|importance|String|The importance of the event. Possible values are: `Low`, `Normal`, `High`.|
 |isAllDay|Boolean|Set to true if the event lasts all day.|
 |isCancelled|Boolean|Set to true if the event has been canceled.|
 |isOrganizer|Boolean|Set to true if the message sender is also the organizer.|

--- a/api-reference/v1.0/resources/responsestatus.md
+++ b/api-reference/v1.0/resources/responsestatus.md
@@ -2,12 +2,12 @@
 
 The response status of a meeting request.
 
-
 ## Properties
-| Property	   | Type	|Description|
-|:---------------|:--------|:----------|
-|response|String|The response type: None = 0, Organizer = 1, TentativelyAccepted = 2, Accepted = 3, Declined = 4, NotResponded = 5. Possible values are: `None`, `Organizer`, `TentativelyAccepted`, `Accepted`, `Declined`, `NotResponded`.|
-|time|DateTimeOffset|The date and time that the response was returned. It uses ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
+
+| Property | Type           | Description |
+|:---------|:---------------|:------------|
+| response | String         | The response type. Possible values are: `None`, `Organizer`, `TentativelyAccepted`, `Accepted`, `Declined`, `NotResponded`.
+| time     | DateTimeOffset | The date and time that the response was returned. It uses ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`
 
 ## JSON representation
 
@@ -20,12 +20,12 @@ Here is a JSON representation of the resource
   ],
   "@odata.type": "microsoft.graph.responseStatus"
 }-->
+
 ```json
 {
   "response": "String",
   "time": "String (timestamp)"
 }
-
 ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79


### PR DESCRIPTION
The enum values were listed twice, in consecutive sentences. Removed duplicate to eliminate potential reader confusion.