### PR TITLE
Update group_post_owners.md

### DIFF
--- a/api-reference/beta/api/group_post_owners.md
+++ b/api-reference/beta/api/group_post_owners.md
@@ -42,7 +42,7 @@ Content-type: application/json
 Content-length: 30
 
 {
-  "@oadata.id": "https://graph.microsoft.com/beta/users/{id}"
+  "@odata.id": "https://graph.microsoft.com/beta/users/{id}"
 }
 ```
 In the request body, supply a JSON representation of [user](../resources/user.md) object to be added.


### PR DESCRIPTION
Removing typo of 'a' in 'oadata.id' to 'odata.id' to successfully post owner membership to group.