### PR TITLE
remove "api" from getMailTips

### DIFF
--- a/api-reference/beta/api/user_getmailtips.md
+++ b/api-reference/beta/api/user_getmailtips.md
@@ -74,7 +74,7 @@ HTTP/1.1 200 OK
 Content-type: application/json
 
 {
-    "@odata.context":"https://graph.microsoft.com/api/beta/$metadata#Collection(microsoft.graph.mailTips)",
+    "@odata.context":"https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.mailTips)",
     "value":[
         {
             "emailAddress":{


### PR DESCRIPTION
The "api" should be removed from the POST