### PR TITLE
Fixed the response example

### DIFF
--- a/api-reference/v1.0/api/message_send.md
+++ b/api-reference/v1.0/api/message_send.md
@@ -49,7 +49,7 @@ Here is an example of the response.
   "truncated": true
 } -->
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 202 Accepted
 ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79


### PR DESCRIPTION
The response example was showing `200 OK` even though the document and the API returns `202 Accepted`. Fixed the response example.