### PR TITLE
Unsupported endpoint removal: Phase 1.

### DIFF
--- a/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_create.md
+++ b/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_create.md
@@ -3,6 +3,8 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Create a new [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) object.
+
+> **Note:** This is not supported and should not be used. 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_delete.md
+++ b/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_delete.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Deletes a [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md).
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_update.md
+++ b/api-reference/v1.0/api/intune_mam_androidmanagedappregistration_update.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Update the properties of a [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) object.
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_create.md
+++ b/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_create.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Create a new [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) object.
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_delete.md
+++ b/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_delete.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Deletes a [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md).
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_update.md
+++ b/api-reference/v1.0/api/intune_mam_iosmanagedappregistration_update.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Update the properties of a [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) object.
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_managedappstatusraw_create.md
+++ b/api-reference/v1.0/api/intune_mam_managedappstatusraw_create.md
@@ -3,6 +3,8 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Create a new [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) object.
+
+> **Note:** This is not supported and should not be used. 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_managedappstatusraw_delete.md
+++ b/api-reference/v1.0/api/intune_mam_managedappstatusraw_delete.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Deletes a [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md).
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_managedappstatusraw_update.md
+++ b/api-reference/v1.0/api/intune_mam_managedappstatusraw_update.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Update the properties of a [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) object.
+
+> **Note:** This is not supported and should not be used. 
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
@@ -4,7 +4,7 @@
 
 Create a new [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedappprotection.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
@@ -4,7 +4,7 @@
 
 Create a new [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_create.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Create a new [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
@@ -4,7 +4,7 @@
 
 Deletes a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md).
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Deletes a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md).
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_delete.md
@@ -4,7 +4,7 @@
 
 Deletes a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md).
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedappprotection.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
@@ -4,7 +4,7 @@
 
 Read properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. > **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
@@ -4,7 +4,7 @@
 
 Read properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. > **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. > **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedappprotection.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_get.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Read properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
@@ -4,7 +4,7 @@
 
 List properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) objects.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
@@ -4,7 +4,7 @@
 
 List properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) objects.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedappprotection.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_list.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 List properties and relationships of the [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) objects.
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
@@ -4,7 +4,7 @@
 
 Update the properties of a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedappprotection.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
@@ -3,6 +3,9 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 Update the properties of a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 

--- a/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
+++ b/api-reference/v1.0/api/intune_mam_targetedmanagedapppolicyassignment_update.md
@@ -4,7 +4,7 @@
 
 Update the properties of a [targetedManagedAppPolicyAssignment](../resources/intune_mam_targetedmanagedapppolicyassignment.md) object.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](../resources/intune_mam_iosmanagedappprotection.md) or [Android managed app protection](../resources/intune_mam_androidmanagedapppproction.md) instead.
 
 ## Prerequisites
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).

--- a/api-reference/v1.0/resources/intune_mam_androidmanagedappregistration.md
+++ b/api-reference/v1.0/resources/intune_mam_androidmanagedappregistration.md
@@ -12,9 +12,6 @@ Inherits from [managedAppRegistration](../resources/intune_mam_managedappregistr
 |:---|:---|:---|
 |[List androidManagedAppRegistrations](../api/intune_mam_androidmanagedappregistration_list.md)|[androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) collection|List properties and relationships of the [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) objects.|
 |[Get androidManagedAppRegistration](../api/intune_mam_androidmanagedappregistration_get.md)|[androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md)|Read properties and relationships of the [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) object.|
-|[Create androidManagedAppRegistration](../api/intune_mam_androidmanagedappregistration_create.md)|[androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md)|Create a new [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) object.|
-|[Delete androidManagedAppRegistration](../api/intune_mam_androidmanagedappregistration_delete.md)|None|Deletes a [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md).|
-|[Update androidManagedAppRegistration](../api/intune_mam_androidmanagedappregistration_update.md)|[androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md)|Update the properties of a [androidManagedAppRegistration](../resources/intune_mam_androidmanagedappregistration.md) object.|
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/v1.0/resources/intune_mam_iosmanagedappregistration.md
+++ b/api-reference/v1.0/resources/intune_mam_iosmanagedappregistration.md
@@ -12,9 +12,6 @@ Inherits from [managedAppRegistration](../resources/intune_mam_managedappregistr
 |:---|:---|:---|
 |[List iosManagedAppRegistrations](../api/intune_mam_iosmanagedappregistration_list.md)|[iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) collection|List properties and relationships of the [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) objects.|
 |[Get iosManagedAppRegistration](../api/intune_mam_iosmanagedappregistration_get.md)|[iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md)|Read properties and relationships of the [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) object.|
-|[Create iosManagedAppRegistration](../api/intune_mam_iosmanagedappregistration_create.md)|[iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md)|Create a new [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) object.|
-|[Delete iosManagedAppRegistration](../api/intune_mam_iosmanagedappregistration_delete.md)|None|Deletes a [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md).|
-|[Update iosManagedAppRegistration](../api/intune_mam_iosmanagedappregistration_update.md)|[iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md)|Update the properties of a [iosManagedAppRegistration](../resources/intune_mam_iosmanagedappregistration.md) object.|
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/v1.0/resources/intune_mam_managedappstatusraw.md
+++ b/api-reference/v1.0/resources/intune_mam_managedappstatusraw.md
@@ -11,9 +11,6 @@ Inherits from [managedAppStatus](../resources/intune_mam_managedappstatus.md)
 |:---|:---|:---|
 |[List managedAppStatusRaws](../api/intune_mam_managedappstatusraw_list.md)|[managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) collection|List properties and relationships of the [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) objects.|
 |[Get managedAppStatusRaw](../api/intune_mam_managedappstatusraw_get.md)|[managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md)|Read properties and relationships of the [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) object.|
-|[Create managedAppStatusRaw](../api/intune_mam_managedappstatusraw_create.md)|[managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md)|Create a new [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) object.|
-|[Delete managedAppStatusRaw](../api/intune_mam_managedappstatusraw_delete.md)|None|Deletes a [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md).|
-|[Update managedAppStatusRaw](../api/intune_mam_managedappstatusraw_update.md)|[managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md)|Update the properties of a [managedAppStatusRaw](../resources/intune_mam_managedappstatusraw.md) object.|
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/v1.0/resources/intune_mam_targetedmanagedapppolicyassignment.md
+++ b/api-reference/v1.0/resources/intune_mam_targetedmanagedapppolicyassignment.md
@@ -4,7 +4,7 @@
 
 The type for deployment of groups or apps.
 
-> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedappprotection.md) instead.
 ## Methods
 |Method|Return Type|Description|
 |:---|:---|:---|

--- a/api-reference/v1.0/resources/intune_mam_targetedmanagedapppolicyassignment.md
+++ b/api-reference/v1.0/resources/intune_mam_targetedmanagedapppolicyassignment.md
@@ -3,6 +3,8 @@
 > **Note:** Using the Microsoft Graph APIs to configure Intune controls and policies still requires that the Intune service is [correctly licensed](https://go.microsoft.com/fwlink/?linkid=839381) by the customer.
 
 The type for deployment of groups or apps.
+
+> **Note:** This is not supported and should not be used. Use [iOS managed app protection](intune_mam_iosmanagedappprotection.md) or [Android managed app protection](intune_mam_androidmanagedapppproction.md) instead.
 ## Methods
 |Method|Return Type|Description|
 |:---|:---|:---|


### PR DESCRIPTION
Several endpoints were inadvertently documented for v1.0; this was an error.  However, we cannot simply remove the pages from the project (for that would orphan the existing webpages).

Before we can remove the unsupported pages, we need to update the webpages with an appropriate message.  

This PR does that; a later one will remove the unsupported endpoints from the TOC and the category index page.
