### PR TITLE
Update mailfolder.md

### DIFF
--- a/api-reference/v1.0/resources/mailfolder.md
+++ b/api-reference/v1.0/resources/mailfolder.md
@@ -3,7 +3,7 @@
 A mail folder in a user's mailbox, such as Inbox and Drafts. Mail folders can contain messages, other Outlook items, and child mail folders.
 
 Outlook creates certain folders for users by default. Instead of using the corresponding folder **id** value, for convenience, you can use 
-the following well-known folder names when accessing these folders in a **mailFolder** collection: `ArchiveRoot`, `ConversationHistory`, `DeletedItems`, 
+the following well-known folder names when accessing these folders in a **mailFolder** collection: `Archive`, `ConversationHistory`, `DeletedItems`, 
 `Drafts`, `Inbox`, `JunkEmail`, `Outbox`, and `SentItems`.
 
 This resource supports using [delta query](../../../concepts/delta_query_overview.md) to track incremental additions, deletions, and updates, 


### PR DESCRIPTION
There is no folder named ArchiveRoot, but there is Archive.
My bad that my comment wasn't really good explanation of the problem.
What I wanted to say that there isn't https://graph.microsoft.com/v1.0/me/mailFolders/ArchiveRoot endpoint. There is https://graph.microsoft.com/v1.0/me/mailFolders/Archive Endpoint.
So, ArchiveRoot folder name is wrong and it shouldn't be on the documention where it currently stands.