### PR TITLE
Fixed Inacurrate Quote Limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+.vscode/settings.json

--- a/api-reference/v1.0/resources/webhooks.md
+++ b/api-reference/v1.0/resources/webhooks.md
@@ -14,7 +14,7 @@ Using the Microsoft Graph REST API, an app can subscribe to changes on the follo
 * User's personal OneDrive folders
 
 For instance, you can create a subscription to a specific folder:
-`me/mailfolders('inbox')/messages`
+`me/mailFolders('inbox')/messages`
 
 Or a specific ID:
 `users/{id}`, `groups/{id}`, `groups/{id}/conversations`
@@ -31,17 +31,18 @@ Or on a user's personal OneDrive:
 
 After Microsoft Graph accepts the subscription request, it pushes notifications to the URL specified in the subscription. The app then takes action according to its business logic. For example, it fetches more data, updates cache and views, etc.
 
-Apps need to renew their subscriptions before the expiration time. Otherwise, they need to create a new subscription. For a list of maximum expiration times, see [Maximum length of subscription per resource type](../api-reference/v1.0/resources/subscription.md#maximum-length-of-subscription-per-resource-type).
+Apps need to renew their subscriptions before the expiration time. Otherwise, they need to create a new subscription. For a list of maximum expiration times, see [Maximum length of subscription per resource type](./subscription.md#maximum-length-of-subscription-per-resource-type).
 
 Apps can also unsubscribe at any time to stop getting notifications.
 
-In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
+In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
 
-| Permission type                        | Supported resource types in v1.0                                                                                                                                                                                                                                                    |
-| :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Delegated - work or school account     | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [drive](../api-reference/v1.0/resources/drive.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
-| Delegated - personal Microsoft account | None                                                                                                                                                                                                                                                                                |
-| Application                            | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md)                                                    |
+| Permission type                        | Supported resource types in v1.0                                 |
+| :------------------------------------- | :--------------------------------------------------------------- |
+| Delegated - work or school account     | [contact][], [conversation][], [drive][], [event][], [message][] |
+| Delegated - personal Microsoft account | None                                                             |
+| Application                            | [contact][], [conversation][], [event][], [message][]            |
+
 
 ## Code samples
 
@@ -72,7 +73,7 @@ Microsoft Graph validates the notification URL in a subscription request before 
   POST https://{notificationUrl}?validationToken={TokenDefinedByMicrosoftGraph}
   ClientState: {Data sent in ClientState value in subscription request (if any)}
   ```
- 
+
 2. The client must provide a response with the following characteristics within 10 seconds:
 
   * A 200 (OK) status code.
@@ -95,9 +96,9 @@ Content-Type: application/json
 }
 ```
 
-The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` properties are required. See [subscription resource type](../api-reference/v1.0/resources/subscription.md) for property definitions and values. Although `clientState` is not required, you must include it to comply with our recommended notification handling process.
+The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` properties are required. See [subscription resource type](./subscription.md) for property definitions and values. Although `clientState` is not required, you must include it to comply with our recommended notification handling process.
 
-If successful, Microsoft Graph returns a `201 Created` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body.
+If successful, Microsoft Graph returns a `201 Created` code and a [subscription](./subscription.md) object in the body.
 
 ### Azure AD Resource Limitations
 
@@ -119,7 +120,7 @@ The client can renew a subscription with a specific expiration date of up to thr
 
 ### Subscription renewal example
 
-```http
+``` http
 PATCH https://graph.microsoft.com/v1.0/subscriptions/{id};
 Content-Type: application/json
 {
@@ -127,13 +128,13 @@ Content-Type: application/json
 }
 ```
 
-If successful, Microsoft Graph returns a `200 OK` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body. The subscription object includes the new expirationDateTime value. 
+If successful, Microsoft Graph returns a `200 OK` code and a [subscription](./subscription.md) object in the body. The subscription object includes the new expirationDateTime value. 
 
 ## Deleting a subscription
 
 The client can stop receiving notifications by deleting the subscription using its ID.
 
-```http
+``` http
 DELETE https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 
@@ -164,7 +165,7 @@ The notification object has the following properties:
 
 When the user receives an email, Microsoft Graph sends a notification like the following:
 
-```json
+``` json
 {
   "value":[
   {
@@ -203,8 +204,14 @@ Repeat for other notifications in the request.
 
 ## See also
 
-* [Subscription resource type](../api-reference/v1.0/resources/subscription.md)
-* [Get subscription](../api-reference/v1.0/api/subscription_get.md)
-* [Create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md)
+* [Subscription resource type](./subscription.md)
+* [Get subscription](../api/subscription_get.md)
+* [Create subscription](../api/subscription_post_subscriptions.md)
 * [Microsoft Graph Webhooks Sample for Node.js](https://github.com/OfficeDev/Microsoft-Graph-Nodejs-Webhooks)
 * [Microsoft Graph Webhooks Sample for ASP.NET](https://github.com/OfficeDev/Microsoft-Graph-ASPNET-Webhooks)
+
+[contact]: ./contact.md
+[conversation]: ./conversation.md
+[drive]: ./drive.md
+[event]: ./event.md
+[message]: ./message.md

--- a/api-reference/v1.0/resources/webhooks.md
+++ b/api-reference/v1.0/resources/webhooks.md
@@ -31,17 +31,17 @@ Or on a user's personal OneDrive:
 
 After Microsoft Graph accepts the subscription request, it pushes notifications to the URL specified in the subscription. The app then takes action according to its business logic. For example, it fetches more data, updates cache and views, etc.
 
-Apps need to renew their subscriptions before the expiration time. Otherwise, they need to create a new subscription. For a list of maximum expiration times, see [Maximum length of subscription per resource type](subscription.md#maximum-length-of-subscription-per-resource-type).
+Apps need to renew their subscriptions before the expiration time. Otherwise, they need to create a new subscription. For a list of maximum expiration times, see [Maximum length of subscription per resource type](../api-reference/v1.0/resources/subscription.md#maximum-length-of-subscription-per-resource-type).
 
 Apps can also unsubscribe at any time to stop getting notifications.
 
-In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
+In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
 
-| Permission type | Supported resource types in v1.0 |
-|:----------------|:---------------------------------|
-| Delegated - work or school account | [contact](contact.md), [conversation](conversation.md), [drive](drive.md), [event](event.md), [message](message.md) |
-| Delegated - personal Microsoft account | None |
-| Application | [contact](contact.md), [conversation](conversation.md), [event](event.md), [message](message.md) |
+| Permission type                        | Supported resource types in v1.0                                                                                                                                                                                                                                                    |
+| :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Delegated - work or school account     | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [drive](../api-reference/v1.0/resources/drive.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
+| Delegated - personal Microsoft account | None                                                                                                                                                                                                                                                                                |
+| Application                            | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md)                                                    |
 
 ## Code samples
 
@@ -50,7 +50,7 @@ The following code samples are available on GitHub.
 * [Microsoft Graph Webhooks Sample for Node.js](https://github.com/OfficeDev/Microsoft-Graph-Nodejs-Webhooks)
 * [Microsoft Graph Webhooks Sample for ASP.NET](https://github.com/OfficeDev/Microsoft-Graph-ASPNET-Webhooks)
 
-# Creating a subscription
+### Creating a subscription
 
 Creating a subscription is the first step to start receiving notifications for a resource. The subscription process is as follows:
 
@@ -62,7 +62,7 @@ Creating a subscription is the first step to start receiving notifications for a
 
 Client must store the subscription ID to correlate a notification with the corresponding subscription.
 
-## Notification URL validation
+### Notification URL validation
 
 Microsoft Graph validates the notification URL in a subscription request before creating the subscription. The validation process occurs as follows:
 
@@ -81,9 +81,9 @@ Microsoft Graph validates the notification URL in a subscription request before 
 
 The client should discard the validation token after providing it in the response.
 
-## Subscription request example
+### Subscription request example
 
-``` 
+``` http
 POST https://graph.microsoft.com/v1.0/subscriptions
 Content-Type: application/json
 {
@@ -95,32 +95,31 @@ Content-Type: application/json
 }
 ```
 
-The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` properties are required. See [subscription resource type](subscription.md) for property definitions and values. Although `clientState` is not required, you must include it to comply with our recommended notification handling process.
+The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` properties are required. See [subscription resource type](../api-reference/v1.0/resources/subscription.md) for property definitions and values. Although `clientState` is not required, you must include it to comply with our recommended notification handling process.
 
-If successful, Microsoft Graph returns a `201 Created` code and a [subscription](subscription.md) object in the body.
+If successful, Microsoft Graph returns a `201 Created` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body.
 
-## Limitations
+### Azure AD Resource Limitations
 
-Certain limits apply and may generate errors when exceeded:
+Certain limits apply to Azure AD based resources (users, groups) and may generate errors when exceeded:
 
-1) Maximum subscription quotas
+* Maximum subscription quotas:
 
-     Per App: 50,000 total subscriptions
-     Per Tenant: 35 total subscriptions across all apps
-     Per App and Tenant combination: 7 total subscriptions
+  * Per App: 50,000 total subscriptions
+  * Per Tenant: 35 total subscriptions across all apps
+  * Per App and Tenant combination: 7 total subscriptions
 
-2) Azure AD B2C tenants are not supported
+* Azure AD B2C tenants are not supported
 
-3) Consumer account Users not supported
+* Consumer account Users not supported
 
-
-# Renewing a subscription
+## Renewing a subscription
 
 The client can renew a subscription with a specific expiration date of up to three days from the time of request. The expirationDateTime property is required.
 
-## Subscription renewal example
+### Subscription renewal example
 
-```
+```http
 PATCH https://graph.microsoft.com/v1.0/subscriptions/{id};
 Content-Type: application/json
 {
@@ -128,23 +127,23 @@ Content-Type: application/json
 }
 ```
 
-If successful, Microsoft Graph returns a `200 OK` code and a [subscription](subscription.md) object in the body. The subscription object includes the new expirationDateTime value. 
+If successful, Microsoft Graph returns a `200 OK` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body. The subscription object includes the new expirationDateTime value. 
 
-# Deleting a subscription
+## Deleting a subscription
 
 The client can stop receiving notifications by deleting the subscription using its ID.
 
-```
+```http
 DELETE https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 
 If successful, Microsoft Graph returns a `204 No Content` code.
 
-# Notifications
+## Notifications
 
 The client starts receiving notifications after creating the subscription. Microsoft Graph sends a POST request to the notification URL when changes happen to the resource. The client only gets notifications according to the specified change type, such as *created*.
 
-## Notification properties
+### Notification properties
 
 The notification object has the following properties:
 
@@ -159,14 +158,13 @@ The notification object has the following properties:
   * @odata.etag - The HTTP entity tag that represents a version of the object.
   * id - The identifier of the object.
 
-
 > Note: The Id value provided in resourceData is valid at the time the notification was queued. Some actions, such as moving a message to another folder, may result in a resource's Id being changed. 
 
-## Notification example
+### Notification example
 
 When the user receives an email, Microsoft Graph sends a notification like the following:
 
-```
+```json
 {
   "value":[
   {
@@ -189,7 +187,7 @@ When the user receives an email, Microsoft Graph sends a notification like the f
 
 Note the value object contains a list. If there are many queued notifications, Microsoft Graph sends them in a single request.
 
-## Processing the notification
+### Processing the notification
 
 After your application starts receiving notifications it must process them. The following are the minimum tasks that your app must perform to process a notification:
 
@@ -197,15 +195,16 @@ After your application starts receiving notifications it must process them. The 
   > Note: If this isn't true, you shouldn't consider this a valid notification. You should also investigate where the notification comes from and take appropriate action.
 
 2. Update your application based on your business logic.
+
 3. Send a `202 - Accepted` status code in your response to Microsoft Graph. If Microsoft Graph doesn't receive a 2xx class code, it will retry resending the notification a number of times.
   > You should send a `202 - Accepted` status code even if the clientState property doesn't match the one submitted with the subscription request.
 
 Repeat for other notifications in the request.
 
-# Additional resources
+## See also
 
-* [Subscription resource type](subscription.md)
-* [Get subscription](../api/subscription_get.md)
-* [Create subscription](../api/subscription_post_subscriptions.md)
+* [Subscription resource type](../api-reference/v1.0/resources/subscription.md)
+* [Get subscription](../api-reference/v1.0/api/subscription_get.md)
+* [Create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md)
 * [Microsoft Graph Webhooks Sample for Node.js](https://github.com/OfficeDev/Microsoft-Graph-Nodejs-Webhooks)
 * [Microsoft Graph Webhooks Sample for ASP.NET](https://github.com/OfficeDev/Microsoft-Graph-ASPNET-Webhooks)

--- a/concepts/people_example.md
+++ b/concepts/people_example.md
@@ -8,7 +8,7 @@ To call the People API in Microsoft Graph, your app will need the appropriate pe
 * People.Read - Use to make general People API calls; for example, https://graph.microsoft.com/v1.0/me/people/. People.Read requires end user consent.
 * People.Read.All - Required to retrieve the people most relevant to a specified user in the signed-in user’s organization (https://graph.microsoft.com/v1.0/users('{id}')/people) calls. People.Read.All requires admin consent.
 ## Browse people
-The requests in this section get the people most relevant to the signed-in user (`/me`). These requests require the People.Read permission. By default, each response returns 10 records, but you can change this by using the *$top* query parameter. 
+The requests in this section get the people most relevant to the signed-in user (`/me`), or to a specific user in the signed-in user’s organization. These requests require the People.Read or People.Read.All permission respectively. By default, each response returns 10 records, but you can change this by using the *$top* query parameter. 
 ### Get a collection of relevant people 
 The following request gets the people most relevant to the signed-in user (`/me`), based on communication and collaboration patterns and business relationships. 
 
@@ -655,6 +655,133 @@ Content-type: application/json
     ]
 }
 ```
+
+### Browse another user’s relevant people
+The following request gets the people most relevant to another person in the signed-in user's organization. This request requires the People.Read.All permission. All the query parameters described in the above sections apply as well.
+
+In this example, Roscoe Seidel's relevant people are displayed.
+
+```http
+GET https://graph.microsoft.com/v1.0/users('roscoes@contoso.com')/people/
+```
+
+The following example shows the response. By default, each response returns 10 records. You can change this using the *$top* parameter. The example below uses *$top* to limit the response to three records.
+
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+
+{
+     "value": [
+        {
+            "id": "56155636-703F-47F2-B657-C83F01F49BBC",
+            "displayName": "Clifton Clemente",
+            "givenName": "Clifton",
+            "surname": "Clemente",
+            "birthday": "",
+            "personNotes": "",
+            "isFavorite": false,
+            "jobTitle": "Director",
+            "companyName": null,
+            "yomiCompany": "",
+            "department": "Legal",
+            "officeLocation": "19/2106",
+            "profession": "",
+            "userPrincipalName": "Cliftonc@contoso.onmicrosoft.com",
+            "imAddress": "sip:Cliftonc@contoso.onmicrosoft.com",
+            "scoredEmailAddresses": [
+                {
+                    "address": "Cliftonc@contoso.onmicrosoft.com",
+                    "relevanceScore": 20
+                }
+            ],
+            "phones": [
+                {
+                    "type": "Business",
+                    "number": "+1 309 555 0101"
+                }
+            ],
+            "postalAddresses": [],
+            "websites": [],
+            "personType": {
+                "class": "Person",
+                "subclass": "OrganizationUser"
+            }
+        },
+        {
+            "id": "6BF27D5A-AB4F-4C43-BED0-7DAD9EB0C1C4",
+            "displayName": "Sheree Mitchell",
+            "givenName": "Sheree",
+            "surname": "Mitchell",
+            "birthday": "",
+            "personNotes": "",
+            "isFavorite": false,
+            "jobTitle": "Product Manager",
+            "companyName": null,
+            "yomiCompany": "",
+            "department": "Sales & Marketing",
+            "officeLocation": "20/2107",
+            "profession": "",
+            "userPrincipalName": "Shereem@contoso.onmicrosoft.com",
+            "imAddress": "sip:shereem@contoso.onmicrosoft.com",
+            "scoredEmailAddresses": [
+                {
+                    "address": "Shereem@contoso.onmicrosoft.com",
+                    "relevanceScore": 10
+                }
+            ],
+            "phones": [
+                {
+                    "type": "Business",
+                    "number": "+1 918 555 0107"
+                }
+            ],
+            "postalAddresses": [],
+            "websites": [],
+            "personType": {
+                "class": "Person",
+                "subclass": "OrganizationUser"
+            }
+        },
+        {
+            "id": "B3E5302D-EAF0-4E8B-8C6C-A2AE64B4B163",
+            "displayName": "Vincent Matney",
+            "givenName": "Vincent",
+            "surname": "Matney",
+            "birthday": "",
+            "personNotes": "",
+            "isFavorite": false,
+            "jobTitle": "CVP Engineering",
+            "companyName": null,
+            "yomiCompany": "",
+            "department": "Engineering",
+            "officeLocation": "23/2102",
+            "profession": "",
+            "userPrincipalName": "Vincentm@contoso.onmicrosoft.com",
+            "imAddress": "sip:vincentm@contoso.onmicrosoft.com",
+            "scoredEmailAddresses": [
+                {
+                    "address": "Vincentm@contoso.onmicrosoft.com",
+                    "relevanceScore": 10
+                }
+            ],
+            "phones": [
+                {
+                    "type": "Business",
+                    "number": "+1 502 555 0102"
+                }
+            ],
+            "postalAddresses": [],
+            "websites": [],
+            "personType": {
+                "class": "Person",
+                "subclass": "OrganizationUser"
+            }
+        }
+    ]
+}
+```
+
 ## Search people
 The requests in this section allow you to search for people relevant to the signed-in user (`/me`) and other users in the signed-in user’s organization. These requests require the People.Read permission, with the exception of searching other users’ relevant people, which requires People.Read.All. By default, each response returns 10 records, but you can change this by using the *$top* parameter. 
 ### Use search to select people 
@@ -809,126 +936,3 @@ GET https://graph.microsoft.com/v1.0/me/people/?$search="tyl topic:pizza"
 
 This request essentially conducts two searches: a fuzzy search against **displayName** and **emailAddress** properties of the signed-in user's relevant people, and a topic search for "pizza" against the user's relevant people. The results are then ranked, ordered, and returned. Note that the search is not restrictive; you might get results that contain people that fuzzy match "tyl", or that are interested in "pizza", or both.
 
-### Search other user’s relevant people
-The following request gets the people most relevant to another person in the signed-in user's organization. This request requires the People.Read.All permission. In this example, Roscoe Seidel's relevant people are displayed.
-
-```http
-GET https://graph.microsoft.com/v1.0/users('roscoes@contoso.com')/people/
-```
-
-The following example shows the response. By default, each response returns 10 records. You can change this using the *$top* parameter. The example below uses *$top* to limit the response to three records.
-
-```http
-HTTP/1.1 200 OK
-Content-type: application/json
-
-{
-     "value": [
-        {
-            "id": "56155636-703F-47F2-B657-C83F01F49BBC",
-            "displayName": "Clifton Clemente",
-            "givenName": "Clifton",
-            "surname": "Clemente",
-            "birthday": "",
-            "personNotes": "",
-            "isFavorite": false,
-            "jobTitle": "Director",
-            "companyName": null,
-            "yomiCompany": "",
-            "department": "Legal",
-            "officeLocation": "19/2106",
-            "profession": "",
-            "userPrincipalName": "Cliftonc@contoso.onmicrosoft.com",
-            "imAddress": "sip:Cliftonc@contoso.onmicrosoft.com",
-            "scoredEmailAddresses": [
-                {
-                    "address": "Cliftonc@contoso.onmicrosoft.com",
-                    "relevanceScore": 20
-                }
-            ],
-            "phones": [
-                {
-                    "type": "Business",
-                    "number": "+1 309 555 0101"
-                }
-            ],
-            "postalAddresses": [],
-            "websites": [],
-            "personType": {
-                "class": "Person",
-                "subclass": "OrganizationUser"
-            }
-        },
-        {
-            "id": "6BF27D5A-AB4F-4C43-BED0-7DAD9EB0C1C4",
-            "displayName": "Sheree Mitchell",
-            "givenName": "Sheree",
-            "surname": "Mitchell",
-            "birthday": "",
-            "personNotes": "",
-            "isFavorite": false,
-            "jobTitle": "Product Manager",
-            "companyName": null,
-            "yomiCompany": "",
-            "department": "Sales & Marketing",
-            "officeLocation": "20/2107",
-            "profession": "",
-            "userPrincipalName": "Shereem@contoso.onmicrosoft.com",
-            "imAddress": "sip:shereem@contoso.onmicrosoft.com",
-            "scoredEmailAddresses": [
-                {
-                    "address": "Shereem@contoso.onmicrosoft.com",
-                    "relevanceScore": 10
-                }
-            ],
-            "phones": [
-                {
-                    "type": "Business",
-                    "number": "+1 918 555 0107"
-                }
-            ],
-            "postalAddresses": [],
-            "websites": [],
-            "personType": {
-                "class": "Person",
-                "subclass": "OrganizationUser"
-            }
-        },
-        {
-            "id": "B3E5302D-EAF0-4E8B-8C6C-A2AE64B4B163",
-            "displayName": "Vincent Matney",
-            "givenName": "Vincent",
-            "surname": "Matney",
-            "birthday": "",
-            "personNotes": "",
-            "isFavorite": false,
-            "jobTitle": "CVP Engineering",
-            "companyName": null,
-            "yomiCompany": "",
-            "department": "Engineering",
-            "officeLocation": "23/2102",
-            "profession": "",
-            "userPrincipalName": "Vincentm@contoso.onmicrosoft.com",
-            "imAddress": "sip:vincentm@contoso.onmicrosoft.com",
-            "scoredEmailAddresses": [
-                {
-                    "address": "Vincentm@contoso.onmicrosoft.com",
-                    "relevanceScore": 10
-                }
-            ],
-            "phones": [
-                {
-                    "type": "Business",
-                    "number": "+1 502 555 0102"
-                }
-            ],
-            "postalAddresses": [],
-            "websites": [],
-            "personType": {
-                "class": "Person",
-                "subclass": "OrganizationUser"
-            }
-        }
-    ]
-}
-```

--- a/concepts/social-intel-concept-overview.md
+++ b/concepts/social-intel-concept-overview.md
@@ -5,7 +5,7 @@ The hundreds of millions of users of Microsoft 365 cloud services form part of t
 - "Who should this user contact for information on this topic?"
 - "Which documents are most interesting to this person?"
 
-You can use the people API and insights API in Microsoft Graph to build smarter apps that can access the relevant people and documents for a user.
+You can use the people API and insights API in Microsoft Graph to build smarter apps that can, respectively, access the relevant people and documents for a user.
 
 The people API returns people ordered by relevance to a user, based on that user's contacts, social networks, organization directory, and recent communications on email and Skype. This is particularly useful for people-picking scenarios.
 
@@ -17,13 +17,13 @@ The insights API uses advanced analytics and machine learning to provide the mos
 
 The people API returns data of a single entity, [person](../api-reference/v1.0/resources/person.md), which includes typical data of an individual in today's business world. What makes this **person** data especially useful is its _relevance_ with respect to a Microsoft Graph user. Relevance is noted in a relevance score of each person, calculated based on the user's communication and collaboration patterns and business relationships. There are 3 main types of application of this _relevance_ data.
 
-### Browse people relevant to the signed-in user
+### Browse people by relevance
 
-With [authorization](people_example.md#authorization) by the signed-in user, you can get a collection of **person** objects, starting by default with the most relevant to the signed-in user. You can further [customize](people_example.md#browse-people) the collection of **person** objects to be returned in the response by specifying query parameters.
+You can browse people who are related to the signed-in user or to some other user in the signed-in user's organization, provided you have got the appropriate [authorization](people_example.md#authorization). You get a collection of **person** objects that are ordered by relevance. You can further [customize](people_example.md#browse-people) the collection of **person** objects that is returned in the response by specifying the query parameters `top`, `skip`, `orderby`, `select`, and `filter`.
 
 ### Fuzzy searches based on people criteria
 
-The people API lets you search for people relevant to the signed-in user or other users in the signed-in user’s organization, provided that respectively, your app has got permissions by the signed-in user or by the administrator. (Read more on [people permissions](permissions_reference.md#people-permissions).)
+The people API lets you search for people relevant to the signed-in user, provided that your app has got permissions by that user. (Read more on [people permissions](permissions_reference.md#people-permissions).)
 
 Fuzzy searches return results based on an exact match and also on inferences about the intent of the search. To illustrate this, the following example returns **person** objects relevant to the signed-in user whose name, _or email address_, contains a word that starts with 'j'.
 
@@ -43,7 +43,7 @@ The following example illustrates inferences about the intent of a search on the
 GET /me/people/?$search="topic:beetle" 
 ```
 
-A fuzzy search in the topic data index return instances that mean the beetle insect, the iconic Volkswagen Beetle car, and other definitions.
+A fuzzy search in the topic data index return instances that mean the beetle insect, the iconic Volkswagen Beetle car, the Beatles band, and other definitions.
 
 
 ## Why integrate with document-based insights (preview)?

--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -37,11 +37,11 @@ Apps can also unsubscribe at any time to stop getting notifications.
 
 In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
 
-| Permission type | Supported resource types in v1.0 |
-|:----------------|:---------------------------------|
-| Delegated - work or school account | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [drive](../api-reference/v1.0/resources/drive.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
-| Delegated - personal Microsoft account | None |
-| Application | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
+| Permission type                        | Supported resource types in v1.0                                                                                                                                                                                                                                                    |
+| :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Delegated - work or school account     | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [drive](../api-reference/v1.0/resources/drive.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
+| Delegated - personal Microsoft account | None                                                                                                                                                                                                                                                                                |
+| Application                            | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md)                                                    |
 
 ## Code samples
 
@@ -50,7 +50,7 @@ The following code samples are available on GitHub.
 * [Microsoft Graph Webhooks Sample for Node.js](https://github.com/OfficeDev/Microsoft-Graph-Nodejs-Webhooks)
 * [Microsoft Graph Webhooks Sample for ASP.NET](https://github.com/OfficeDev/Microsoft-Graph-ASPNET-Webhooks)
 
-# Creating a subscription
+### Creating a subscription
 
 Creating a subscription is the first step to start receiving notifications for a resource. The subscription process is as follows:
 
@@ -62,7 +62,7 @@ Creating a subscription is the first step to start receiving notifications for a
 
 Client must store the subscription ID to correlate a notification with the corresponding subscription.
 
-## Notification URL validation
+### Notification URL validation
 
 Microsoft Graph validates the notification URL in a subscription request before creating the subscription. The validation process occurs as follows:
 
@@ -81,9 +81,9 @@ Microsoft Graph validates the notification URL in a subscription request before 
 
 The client should discard the validation token after providing it in the response.
 
-## Subscription request example
+### Subscription request example
 
-``` 
+``` http
 POST https://graph.microsoft.com/v1.0/subscriptions
 Content-Type: application/json
 {
@@ -99,28 +99,27 @@ The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` proper
 
 If successful, Microsoft Graph returns a `201 Created` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body.
 
-## Limitations
+### Azure AD Resource Limitations
 
-Certain limits apply and may generate errors when exceeded:
+Certain limits apply to Azure AD based resources (users, groups) and may generate errors when exceeded:
 
-1) Maximum subscription quotas
+* Maximum subscription quotas:
 
-     Per App: 50,000 total subscriptions
-     Per Tenant: 35 total subscriptions across all apps
-     Per App and Tenant combination: 7 total subscriptions
+  * Per App: 50,000 total subscriptions
+  * Per Tenant: 35 total subscriptions across all apps
+  * Per App and Tenant combination: 7 total subscriptions
 
-2) Azure AD B2C tenants are not supported
+* Azure AD B2C tenants are not supported
 
-3) Consumer account Users not supported
+* Consumer account Users not supported
 
-
-# Renewing a subscription
+## Renewing a subscription
 
 The client can renew a subscription with a specific expiration date of up to three days from the time of request. The expirationDateTime property is required.
 
-## Subscription renewal example
+### Subscription renewal example
 
-```
+```http
 PATCH https://graph.microsoft.com/v1.0/subscriptions/{id};
 Content-Type: application/json
 {
@@ -130,21 +129,21 @@ Content-Type: application/json
 
 If successful, Microsoft Graph returns a `200 OK` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body. The subscription object includes the new expirationDateTime value. 
 
-# Deleting a subscription
+## Deleting a subscription
 
 The client can stop receiving notifications by deleting the subscription using its ID.
 
-```
+```http
 DELETE https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 
 If successful, Microsoft Graph returns a `204 No Content` code.
 
-# Notifications
+## Notifications
 
 The client starts receiving notifications after creating the subscription. Microsoft Graph sends a POST request to the notification URL when changes happen to the resource. The client only gets notifications according to the specified change type, such as *created*.
 
-## Notification properties
+### Notification properties
 
 The notification object has the following properties:
 
@@ -159,14 +158,13 @@ The notification object has the following properties:
   * @odata.etag - The HTTP entity tag that represents a version of the object.
   * id - The identifier of the object.
 
-
 > Note: The Id value provided in resourceData is valid at the time the notification was queued. Some actions, such as moving a message to another folder, may result in a resource's Id being changed. 
 
-## Notification example
+### Notification example
 
 When the user receives an email, Microsoft Graph sends a notification like the following:
 
-```
+```json
 {
   "value":[
   {
@@ -189,7 +187,7 @@ When the user receives an email, Microsoft Graph sends a notification like the f
 
 Note the value object contains a list. If there are many queued notifications, Microsoft Graph sends them in a single request.
 
-## Processing the notification
+### Processing the notification
 
 After your application starts receiving notifications it must process them. The following are the minimum tasks that your app must perform to process a notification:
 
@@ -197,12 +195,13 @@ After your application starts receiving notifications it must process them. The 
   > Note: If this isn't true, you shouldn't consider this a valid notification. You should also investigate where the notification comes from and take appropriate action.
 
 2. Update your application based on your business logic.
+
 3. Send a `202 - Accepted` status code in your response to Microsoft Graph. If Microsoft Graph doesn't receive a 2xx class code, it will retry resending the notification a number of times.
   > You should send a `202 - Accepted` status code even if the clientState property doesn't match the one submitted with the subscription request.
 
 Repeat for other notifications in the request.
 
-# See also
+## See also
 
 * [Subscription resource type](../api-reference/v1.0/resources/subscription.md)
 * [Get subscription](../api-reference/v1.0/api/subscription_get.md)

--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -14,7 +14,7 @@ Using the Microsoft Graph REST API, an app can subscribe to changes on the follo
 * User's personal OneDrive folders
 
 For instance, you can create a subscription to a specific folder:
-`me/mailfolders('inbox')/messages`
+`me/mailFolders('inbox')/messages`
 
 Or a specific ID:
 `users/{id}`, `groups/{id}`, `groups/{id}/conversations`
@@ -37,11 +37,12 @@ Apps can also unsubscribe at any time to stop getting notifications.
 
 In general, subscription operations require read permission to the resource. For example, to get notifications for messages, your app needs the `Mail.Read` permission. The [create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md) article lists permissions needed for each resource type. The following table lists the types of permissions your app can request to use webhooks for specific resource types. 
 
-| Permission type                        | Supported resource types in v1.0                                                                                                                                                                                                                                                    |
-| :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Delegated - work or school account     | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [drive](../api-reference/v1.0/resources/drive.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md) |
-| Delegated - personal Microsoft account | None                                                                                                                                                                                                                                                                                |
-| Application                            | [contact](../api-reference/v1.0/resources/contact.md), [conversation](../api-reference/v1.0/resources/conversation.md), [event](../api-reference/v1.0/resources/event.md), [message](../api-reference/v1.0/resources/message.md)                                                    |
+| Permission type                        | Supported resource types in v1.0                                 |
+| :------------------------------------- | :--------------------------------------------------------------- |
+| Delegated - work or school account     | [contact][], [conversation][], [drive][], [event][], [message][] |
+| Delegated - personal Microsoft account | None                                                             |
+| Application                            | [contact][], [conversation][], [event][], [message][]            |
+
 
 ## Code samples
 
@@ -72,7 +73,7 @@ Microsoft Graph validates the notification URL in a subscription request before 
   POST https://{notificationUrl}?validationToken={TokenDefinedByMicrosoftGraph}
   ClientState: {Data sent in ClientState value in subscription request (if any)}
   ```
- 
+
 2. The client must provide a response with the following characteristics within 10 seconds:
 
   * A 200 (OK) status code.
@@ -119,7 +120,7 @@ The client can renew a subscription with a specific expiration date of up to thr
 
 ### Subscription renewal example
 
-```http
+``` http
 PATCH https://graph.microsoft.com/v1.0/subscriptions/{id};
 Content-Type: application/json
 {
@@ -133,7 +134,7 @@ If successful, Microsoft Graph returns a `200 OK` code and a [subscription](../a
 
 The client can stop receiving notifications by deleting the subscription using its ID.
 
-```http
+``` http
 DELETE https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 
@@ -164,7 +165,7 @@ The notification object has the following properties:
 
 When the user receives an email, Microsoft Graph sends a notification like the following:
 
-```json
+``` json
 {
   "value":[
   {
@@ -208,3 +209,9 @@ Repeat for other notifications in the request.
 * [Create subscription](../api-reference/v1.0/api/subscription_post_subscriptions.md)
 * [Microsoft Graph Webhooks Sample for Node.js](https://github.com/OfficeDev/Microsoft-Graph-Nodejs-Webhooks)
 * [Microsoft Graph Webhooks Sample for ASP.NET](https://github.com/OfficeDev/Microsoft-Graph-ASPNET-Webhooks)
+
+[contact]: ../api-reference/v1.0/resources/contact.md
+[conversation]: ../api-reference/v1.0/resources/conversation.md
+[drive]: ../api-reference/v1.0/resources/drive.md
+[event]: ../api-reference/v1.0/resources/event.md
+[message]: ../api-reference/v1.0/resources/message.md


### PR DESCRIPTION
The "Limitations" secion of the webhooks document inaccuratly implied these limits applied to webhooks in general. They actually only apply to AAD based resources and are not applicable to others (i.e. Mail, Events, etc.).  This was causing some devs to make incorrect design assumptions (see https://stackoverflow.com/questions/50275993/how-to-increase-microsoft-graph-api-subscription-limits).

I also cleaned up some formatting inconsitencies (ie H1s following H2s, inconsitant language spesification, etc).