### PR TITLE
Update v1 webhooks with content from beta

### DIFF
--- a/api-reference/beta/api/subscription_post_subscriptions.md
+++ b/api-reference/beta/api/subscription_post_subscriptions.md
@@ -117,17 +117,21 @@ Depending on the subscribed resource, an additional resourceData field may provi
 
 ```http
 {
-  "subscriptionId": "7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
-  "subscriptionExpirationDateTime": "2015-11-20T18:23:45.9356913Z",
-  "clientState": "subscription-identifier",
-  "changeType": "created",
-  "resource": "Users/ddfcd489-628b-7d04-b48b-20075df800e5@1717622f-1d94-c0d4-9d74-f907ad6677b4/messages/AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA=",
-  "resourceData": {
-    "@odata.type": "#Microsoft.Graph.Message",
-    "@odata.id": "Users/ddfcd489-628b-7d04-b48b-20075df800e5@1717622f-1d94-c0d4-9d74-f907ad6677b4/messages/AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA=",
-    "@odata.etag": "W/\"CQAAABYAAACoeN6SYXGLRrvRm+CYrrfQAACvvGdb\"",
-    "Id": "AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA="
-  }
+   "value":[
+      {
+         "subscriptionId":"7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
+         "subscriptionExpirationDateTime":"2015-11-20T18:23:45.9356913Z",
+         "clientState":"subscription-identifier",
+         "changeType":"Created",
+         "resource":"Users/ddfcd489-628b-7d04-b48b-20075df800e5@1717622f-1d94-c0d4-9d74-f907ad6677b4/messages/AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA=",
+         "resourceData":{
+            "@odata.type":"#Microsoft.Graph.Message",
+            "@odata.id":"Users/ddfcd489-628b-7d04-b48b-20075df800e5@1717622f-1d94-c0d4-9d74-f907ad6677b4/messages/AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA=",
+            "@odata.etag":"W/\"CQAAABYAAACoeN6SYXGLRrvRm+CYrrfQAACvvGdb\"",
+            "Id":"AAMkADMxZmEzMDM1LTFjODQtNGVkMC04YzY3LTBjZTRlNDFjNGE4MwBGAAAAAAAr-q_ZG7oXSaqxum7oZW5RBwCoeN6SYXGLRrvRm_CYrrfQAAAAAAEMAACoeN6SYXGLRrvRm_CYrrfQAACvtMe6AAA="
+         }
+      }
+   ]
 }
 ```
 When receiving notifications from Drive subscriptions the resourceData will be null and the [delta](driveitem_delta.md) API should be called to determine the changes that have occured. Here is an example of a Drive notification:

--- a/api-reference/beta/resources/subscription.md
+++ b/api-reference/beta/resources/subscription.md
@@ -67,9 +67,9 @@ None
 
 | Method                                                           | Return Type                     | Description                                                                                   |
 |:-----------------------------------------------------------------|:--------------------------------|:----------------------------------------------------------------------------------------------|
-| [Create subscription](../api/subscription_post_subscriptions.md) | [subscription](subscription.md) | Subscribes a listener application to receive notifications when Microsoft Graph data changes. |
+| [Create subscription](../api/subscription_post_subscriptions.md) | [subscription](subscription.md) | Subscribe a listener application to receive notifications when Microsoft Graph data changes. |
 | [Update subscription](../api/subscription_update.md)             | [subscription](subscription.md) | Renew a subscription by updating its expiration time.                                         |
-| [List subscriptions](../api/subscription_list.md)                | [subscription](subscription.md) | Lists active subscriptions. |
+| [List subscriptions](../api/subscription_list.md)                | [subscription](subscription.md) | List active subscriptions. |
 | [Get subscription](../api/subscription_get.md)                   | [subscription](subscription.md) | Read properties and relationships of subscription object.                                     |
 | [Delete subscription](../api/subscription_delete.md)             | None                            | Delete a subscription object.                                                                 |
 

--- a/api-reference/v1.0/api/subscription_delete.md
+++ b/api-reference/v1.0/api/subscription_delete.md
@@ -12,13 +12,15 @@ The following table lists the suggested permission needed for each resource. To 
 | Conversations               | Group.Read.All      |
 | Events                      | Calendars.Read      |
 | Messages                    | Mail.Read           |
+| Groups                      | Group.Read.All      |
+| Users                       | User.Read.All       |
 | Drive  (User's OneDrive)    | Files.ReadWrite     |
 | Drives (Sharepoint shared content and drives) | Files.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /subscriptions/{subscriptionId}
+DELETE /subscriptions/{id}
 ```
 ## Request headers
 | Name       | Type | Description|
@@ -39,7 +41,7 @@ Here is an example of the request.
   "name": "delete_subscription"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/subscriptions/{subscriptionId}
+DELETE https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 ##### Response
 Here is an example of the response.

--- a/api-reference/v1.0/api/subscription_get.md
+++ b/api-reference/v1.0/api/subscription_get.md
@@ -11,13 +11,15 @@ The following table lists the suggested permission needed for each resource. To 
 | Conversations               | Group.Read.All      |
 | Events                      | Calendars.Read      |
 | Messages                    | Mail.Read           |
+| Groups                      | Group.Read.All      |
+| Users                       | User.Read.All       |
 | Drive  (User's OneDrive)    | Files.ReadWrite     |
 | Drives (Sharepoint shared content and drives) | Files.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /subscriptions/{subscriptionId}
+GET /subscriptions/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](http://developer.microsoft.com/en-us/graph/docs/overview/query_parameters) to help customize the response.
@@ -41,7 +43,7 @@ Here is an example of the request.
   "name": "get_subscription"
 }-->
 ```http
-GET https://graph.microsoft.com/v1.0/subscriptions/{subscriptionId}
+GET https://graph.microsoft.com/v1.0/subscriptions/{id}
 ```
 ##### Response
 Here is an example of the response.
@@ -58,10 +60,12 @@ Content-length: 252
 {
   "id":"7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
   "resource":"me/messages",
+  "applicationId" : "string",
   "changeType":"created,updated",
   "clientState":"subscription-identifier",
   "notificationUrl":"https://webhook.azurewebsites.net/api/send/myNotifyClient",
-  "expirationDateTime":"2016-11-20T18:23:45.9356913Z"
+  "expirationDateTime":"2016-11-20T18:23:45.9356913Z",
+  "creatorId": "string"
 }
 ```
 

--- a/api-reference/v1.0/api/subscription_list.md
+++ b/api-reference/v1.0/api/subscription_list.md
@@ -1,0 +1,102 @@
+# List subscriptions
+
+Retrieve the properties and relationships of webhook subscriptions, based on the app ID, the user, and the user's role with a tenant.
+
+## Permissions
+
+This API supports the following permission scopes; to learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
+
+| Permission type  | Permissions (from least to most privileged)  |
+|:---------------- |:-------------------------------------------- |
+| [Delegated](../../../concepts/auth_v2_user.md) (work or school account) | Role required to [create subscription](subscription_get.md) or Subscriptions.Read.All (see below). |
+| [Delegated](../../../concepts/auth_v2_user.md) (personal Microsoft account) | Role required to [create subscription](./subscription_get.md) or Subscriptions.Read.All (see below). |
+| [Application](../../../concepts/auth_v2_service.md) | Role required to [create subscription](./subscription_get.md). |
+
+Response results are based on the context of the calling app, which includes:
+
+- The permission type, e.g. whether the application is making request for itself (application permission) or a delegated request on behalf of a user.
+- For delegated permissions requiring admin access, whether the user has granted the app the Subscriptions.Read.All scope permission when requested.
+- Whether the user account is an Azure AD account (work or school) or a personal Microsoft account.
+- For Azure AD user accounts, whether the user is an administrator of the tenant (based on current role settings).
+
+The following table shows the context required for common tasks:
+
+| Task | Required Context |
+|:-----|:---------------- |
+| Retrieve the subscriptions the current app has made on behalf of the current user (work/school account). | Delegated permission.<br/><br/>Role required to [create subscription](subscription_get.md); user can be admin or non-admin.|
+| Retrieve the subscriptions the current app has made within a tenant for itself or for any user. | Application permission.<br /><br />Subscription.Read.All scope for admin work/school account. |
+| Retrieve the subscriptions that any app has made on behalf of the current user. | Delegated permission.<br /><br/>Subscriptions.Read.All permission required.|
+| Retrieve all subscriptions within a given tenant, regardless of app or user (highly privileged operation). | Delegated permission (requires admin user).<br /><br/>Subscription.Read.All required. |
+| Retrieve subscriptions made by the current app for a personal account user. | Delegated permission.<br /><br/>Role required to [create subscription](subscription_get.md).| 
+| Retrieve all subscriptions for a personal Microsoft account, regardless of app. | Delegated permission.<br /><br/>Subscriptions.Read.All for personal account. |
+
+## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /subscriptions
+```
+## Optional query parameters
+This method does not support the [OData Query Parameters](http://developer.microsoft.com/en-us/graph/docs/overview/query_parameters) to help customize the response.
+
+## Request headers
+| Name       | Type | Description|
+|:-----------|:------|:----------|
+| Authorization  | string  | Bearer {token}. Required. |
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a list of [subscription](../resources/subscription.md) objects in the response body.
+## Example
+##### Request
+<!-- {
+  "blockType": "request",
+  "name": "get_subscriptions"
+}-->
+```http
+GET https://graph.microsoft.com/v1.0/subscriptions
+```
+##### Response
+Here's an an example of the response.  Note that it may be truncated for brevity.  All supported properties appropriate for the request and the calling context will be returned from an actual call.
+
+<!-- {
+  "blockType": "response",
+  "truncated": false,
+  "@odata.type": "microsoft.graph.subscription",
+  "isCollection": true
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 586
+
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#subscriptions",
+    "value": [
+        {
+            "id": "0fc0d6db-0073-42e5-a186-853da75fb308",
+            "resource": "Users",
+            "applicationId": "24d3b144-21ae-4080-943f-7067b395b913",
+            "changeType": "updated,deleted",
+            "clientState": null,
+            "notificationUrl": "https://webhookappexample.azurewebsites.net/api/notifications",
+            "expirationDateTime": "2018-03-12T05:00:00Z",
+            "creatorId": "8ee44408-0679-472c-bc2a-692812af3437"
+        }
+    ]
+}
+```
+
+
+<!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
+2015-10-25 14:57:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "List subscriptions",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": ""
+}-->
+When a request returns multiple pages of data, the response includes an `@odata.nextLink` property to help you manage the results.  To learn more, see [Paging Microsoft Graph data in your app](../../../concepts/paging.md). 

--- a/api-reference/v1.0/api/subscription_post_subscriptions.md
+++ b/api-reference/v1.0/api/subscription_post_subscriptions.md
@@ -10,10 +10,12 @@ Creating a subscription requires read scope to the resource. For example, to get
 | Conversations               | Group.Read.All      |
 | Events                      | Calendars.Read      |
 | Messages                    | Mail.Read           |
+| Groups                      | Group.Read.All      |
+| Users                       | User.Read.All       |
 | Drive  (User's OneDrive)    | Files.ReadWrite     |
 | Drives (Sharepoint shared content and drives) | Files.ReadWrite.All |
 
- ***Note:*** The /v1.0 endpoint allows Application permissions for most resources. Conversations in a Group and OneDrive drive root items are not supported with Application permissions.
+ ***Note:*** The /v1.0 endpoint allows application permissions for most resources. Conversations in a Group and OneDrive drive root items are not supported with application permissions.
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
@@ -62,6 +64,8 @@ The following are valid values for the resource property of the subscription:
 |Mail|me/mailfolders('inbox')/messages<br />me/messages|
 |Contacts|me/contacts|
 |Calendars|me/events|
+|Users|users|
+|Groups|groups|
 |Conversations|groups('*{id}*')/conversations|
 |Drives|me/drive/root|
 
@@ -74,14 +78,19 @@ Here is an example of the response. Note: The response object shown here may be 
 } -->
 ```http
 HTTP/1.1 201 Created
+Content-type: application/json
+Content-length: 252
 
 {
-  "id":"7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
-  "resource":"me/mailFolders('Inbox')/messages",
-  "changeType":"created, updated",
-  "clientState":"subscription-identifier",
-  "notificationUrl":"https://webhook.azurewebsites.net/api/send/myNotifyClient",
-  "expirationDateTime":"2016-11-20T18:23:45.9356913Z"
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#subscriptions/$entity",
+  "id": "7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
+  "resource": "me/mailFolders('Inbox')/messages",
+  "applicationId": "24d3b144-21ae-4080-943f-7067b395b913",
+  "changeType": "created,updated",
+  "clientState": "subscription-identifier",
+  "notificationUrl": "https://webhook.azurewebsites.net/api/send/myNotifyClient",
+  "expirationDateTime": "2016-11-20T18:23:45.9356913Z",
+  "creatorId": "8ee44408-0679-472c-bc2a-692812af3437"
 }
 ```
 ## Subscription validation

--- a/api-reference/v1.0/api/subscription_update.md
+++ b/api-reference/v1.0/api/subscription_update.md
@@ -14,13 +14,15 @@ The following table lists the suggested permission needed for each resource. To 
 | Conversations               | Group.Read.All      |
 | Events                      | Calendars.Read      |
 | Messages                    | Mail.Read           |
+| Groups                      | Group.Read.All      |
+| Users                       | User.Read.All       |
 | Drive  (User's OneDrive)    | Files.ReadWrite     |
 | Drives (Sharepoint shared content and drives) | Files.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /subscriptions/{subscriptionId}
+PATCH /subscriptions/{id}
 ```
 
 ## Request headers
@@ -39,7 +41,7 @@ Here is an example of the request.
   "name": "update_subscription"
 }-->
 ```http
-PATCH https://graph.microsoft.com/v1.0/subscriptions/{subscriptionId}
+PATCH https://graph.microsoft.com/v1.0/subscriptions/{id}
 Content-type: application/json
 
 {
@@ -62,10 +64,12 @@ Content-length: 252
 {
   "id":"7f105c7d-2dc5-4530-97cd-4e7ae6534c07",
   "resource":"me/messages",
+  "applicationId": "24d3b144-21ae-4080-943f-7067b395b913",
   "changeType":"created,updated",
   "clientState":"subscription-identifier",
   "notificationUrl":"https://webhook.azurewebsites.net/api/send/myNotifyClient",
-  "expirationDateTime":"2016-11-22T18:23:45.9356913Z"
+  "expirationDateTime":"2016-11-22T18:23:45.9356913Z",
+  "creatorId": "8ee44408-0679-472c-bc2a-692812af3437"
 }
 ```
 

--- a/api-reference/v1.0/resources/subscription.md
+++ b/api-reference/v1.0/resources/subscription.md
@@ -1,9 +1,10 @@
 # Subscription Resource Type
-A subscription allows a client app to receive notifications about data on the Microsoft Graph. Currently, subscriptions are enabled for the following datasets:
+A subscription allows a client app to receive notifications about changes to data on the Microsoft Graph. Currently, subscriptions are enabled for the following datasets:
 
-1. Mail, events, and contacts from Outlook
+1. Mail, events, and contacts from Outlook.
 1. Conversations from Office Groups.
-1. Drive root items from OneDrive 
+1. Drive root items from OneDrive.
+1. Users and Groups from Azure Active Directory.
 
 
 ## JSON representation
@@ -23,30 +24,36 @@ Here is a JSON representation of the resource.
   "changeType": "string",
   "notificationUrl": "string",
   "resource": "string",
-  "expirationDateTime": "string (timestamp)",
+  "applicationId" : "string",
+  "expirationDateTime": "String (timestamp)",
   "id": "string (identifier)",
-  "clientState": "string"
+  "clientState": "string",
+  "creatorId": "string"
 }
 
 ```
 ## Properties
-| Property	   | Type	|Description|
-|:---------------|:--------|:----------|
-|changeType|string|Indicates the type of change in the subscribed resource that will raise a notification. The supported values are: `created`, `updated`, `deleted`. Multiple values can be combined using a comma-separated list.|
-|notificationUrl|string|The URL of the endpoint that will receive the notifications. This URL has to make use of the HTTPS protocol.|
-|resource|string|Specifies the resource that will be monitored for changes. Do not include the base URL ("https://graph.microsoft.com/v1.0/").|
-|expirationDateTime|[dateTime](http://tools.ietf.org/html/rfc3339)|Specifies the date and time when the webhook subscription expires. The time is in UTC, and can be an amount of time from subscription creation that varies for the resource subscribed to.  See the table below for maximum supported subscription length of time. |
-|clientState|string|Specifies the value of the `clientState` property sent by the service in each notification. The maximum length is 128 characters. The client can check that the notification came from the service by comparing the value of the `clientState` property sent with the subscription with the value of the `clientState` property received with each notification.|
-|id|string|Unique identifier for the subscription. Read-only.|
+
+| Property           | Type           | Description                                                                                                                                                                                                                                                                                                                                                      |
+|:-------------------|:---------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| changeType         | string         | Indicates the type of change in the subscribed resource that will raise a notification. The supported values are: `created`, `updated`, `deleted`. Multiple values can be combined using a comma-separated list. Drive root Item notifications require the use of `updated` only.                                                                                                                                                 |
+| notificationUrl    | string         | The URL of the endpoint that will receive the notifications. This URL has to make use of the HTTPS protocol.                                                                                                                                                                                                                                                     |
+| resource           | string         | Specifies the resource that will be monitored for changes. Do not include the base URL (`https://graph.microsoft.com/{version}/`).                                                                                                                                                                                                                               |
+| expirationDateTime | DateTimeOffset | Specifies the date and time when the webhook subscription expires. The time is in UTC, and can be an amount of time from subscription creation that varies for the resource subscribed to.  See the table below for maximum supported subscription length of time.                                                                                                                              |
+| clientState        | string         | Specifies the value of the `clientState` property sent by the service in each notification. The maximum length is 255 characters. The client can check that the notification came from the service by comparing the value of the `clientState` property sent with the subscription with the value of the `clientState` property received with each notification. |
+| id                 | string         | Unique identifier for the subscription. Read-only.                                                                                                                                                                                                                                                                                                               |
+| applicationId      | string         | Identifier of the application used to create the subscription. |
+| creatorId      | string         | Identifier of the user or service principal that created the subscription.<br/><br/>If the app used delegated permissions to create the subscription, this field contains the id of the signed-in user the app called on behalf of.<br/>If the app used application permissions, this field contains the id of the service principal corresponding to the app. |
 
 ## Maximum length of subscription per resource type
-| Resource | Maximum Expiration Time |
-|:---------------------|:--------------------|
-|Mail| 4230 minutes.|
-|Calendar| 4230 minutes.|
-|Contacts| 4230 minutes.|
-|Group conversations| 4230 minutes.|
-|Drive root items| 43200 minutes. Existing applications and new applications should not exceed the supported value. Higher values won't be permitted in upcoming releases. |
+
+| Resource            | Maximum Expiration Time |
+|:--------------------|:------------------------|
+| Mail                | 4230 minutes.           |
+| Calendar            | 4230 minutes.           |
+| Contacts            | 4230 minutes.           |
+| Group conversations | 4230 minutes.           |
+| Drive root items    | 43200 minutes. Existing applications and new applications should not exceed the supported value. Higher values won't be permitted in upcoming releases. |
 
 ## Relationships
 None
@@ -54,12 +61,13 @@ None
 
 ## Methods
 
-| Method		   | Return Type	|Description|
-|:---------------|:--------|:----------|
-|[Create subscription](../api/subscription_post_subscriptions.md) | [subscription](subscription.md) |Subscribes a listener application to receive notifications when Microsoft Graph data changes.|
-|[Update subscription](../api/subscription_update.md) | [subscription](subscription.md) |Renews a subscription by updating its expiration time.|
-|[Get subscription](../api/subscription_get.md) | [subscription](subscription.md) |Reads properties and relationships of subscription object.|
-|[Delete subscription](../api/subscription_delete.md) | None |Deletes a subscription object.|
+| Method                                                           | Return Type                     | Description                                                                                   |
+|:-----------------------------------------------------------------|:--------------------------------|:----------------------------------------------------------------------------------------------|
+| [Create subscription](../api/subscription_post_subscriptions.md) | [subscription](subscription.md) | Subscribe a listener application to receive notifications when Microsoft Graph data changes. |
+| [Update subscription](../api/subscription_update.md)             | [subscription](subscription.md) | Renew a subscription by updating its expiration time.                                         |
+| [List subscriptions](../api/subscription_list.md)                | [subscription](subscription.md) | List active subscriptions. |
+| [Get subscription](../api/subscription_get.md)                   | [subscription](subscription.md) | Read properties and relationships of subscription object.                                     |
+| [Delete subscription](../api/subscription_delete.md)             | None                            | Delete a subscription object.                                                                 |
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->


### PR DESCRIPTION
We are about to publish new beta functionality (List subscriptions) into v1.0. This change updates v1.0 reference docs with the new functionality. A few minor fixes are also included for /beta articles (mostly, consistency).