### PR TITLE
Update list_create.md

### DIFF
--- a/api-reference/beta/api/list_create.md
+++ b/api-reference/beta/api/list_create.md
@@ -43,7 +43,7 @@ POST /sites/{site-id}/lists
 Content-Type: application/json
 
 {
-  "name": "Books",
+  "displayName": "Books",
   "columns": [
     {
       "name": "Author",


### PR DESCRIPTION
If you try to provision a list by specifying the name, you get this error: "Cannot define a 'name' for a list as it is assigned by the server. Instead, provide 'displayName'". Using displayName instead works just fine.