### PR TITLE
Fixed/Clearified Create plannerPlan requirments

### DIFF
--- a/api-reference/beta/api/planner_post_plans.md
+++ b/api-reference/beta/api/planner_post_plans.md
@@ -5,28 +5,34 @@
 Use this API to create a new **plannerPlan**.
 
 ## Permissions
+
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
-|Permission type      | Permissions (from least to most privileged)              |
-|:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Group.ReadWrite.All    |
-|Delegated (personal Microsoft account) | Not supported.    |
-|Application | Not supported. |
+| Permission type                        | Permissions (from least to most privileged) |
+| :------------------------------------- | :------------------------------------------ |
+| Delegated (work or school account)     | Group.ReadWrite.All                         |
+| Delegated (personal Microsoft account) | Not supported.                              |
+| Application                            | Not supported.                              |
 
 ## HTTP request
-<!-- { "blockType": "ignored" } -->
-```http
-POST /planner/plans
 
+<!-- { "blockType": "ignored" } -->
+``` http
+POST /planner/plans
 ```
+
 ## Request headers
-| Name       | Description|
-|:---------------|:----------|
-| Authorization  | Bearer {token}. Required. |
+
+| Name          | Description               |
+| :------------ | :------------------------ |
+| Authorization | Bearer {token}. Required. |
 
 ## Request body
+
 In the request body, supply a JSON representation of [plannerPlan](../resources/plannerplan.md) object.
 The **plannerPlan** owner property must be set to an id of a [group](../resources/group.md) object.
+
+>**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
 
 ## Response
 
@@ -35,13 +41,15 @@ If successful, this method returns `201 Created` response code and [plannerPlan]
 This method can return any of the [HTTP status codes](../../../concepts/errors.md). The most common errors that apps should handle for this method are the 400, 403 and 404 responses. For more information about these errors, see [Common Planner error conditions](../resources/planner_overview.md#common-planner-error-conditions).
 
 ## Example
-##### Request
+
+### Request
+
 Here is an example of the request.
 <!-- {
   "blockType": "request",
   "name": "create_plannerplan_from_planner"
 }-->
-```http
+``` http
 POST https://graph.microsoft.com/beta/planner/plans
 Content-type: application/json
 Content-length: 381
@@ -51,15 +59,18 @@ Content-length: 381
   "title": "title-value"
 }
 ```
+
 In the request body, supply a JSON representation of [plannerPlan](../resources/plannerplan.md) object.
-##### Response
+
+### Response
+
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
 <!-- {
   "blockType": "response",
   "truncated": true,
   "@odata.type": "microsoft.graph.plannerPlan"
 } -->
-```http
+``` http
 HTTP/1.1 200 OK
 Content-type: application/json
 Content-length: 357

--- a/api-reference/beta/resources/planner_overview.md
+++ b/api-reference/beta/resources/planner_overview.md
@@ -11,7 +11,7 @@ Before you get started with Planner API, it is worth understanding how the main 
 Office 365 groups are the owners of the plans in the Planner API.
 To [get the plans owned by a group](../api/plannergroup_list_plans.md), make the following HTTP request.
 
-```http
+``` http
 GET /groups/{id}/planner/plans
 ```
 
@@ -26,7 +26,7 @@ To [create a task in a plan](../api/planner_post_tasks.md), set the `planId` pro
 Tasks currently cannot be created without plans.
 To [retrieve the tasks in a plan](../api/plannerplan_list_tasks.md), make the following HTTP request.
 
-```http
+``` http
 GET /planner/plans/{id}/tasks
 ```
 

--- a/api-reference/beta/resources/planner_overview.md
+++ b/api-reference/beta/resources/planner_overview.md
@@ -16,7 +16,7 @@ GET /groups/{id}/planner/plans
 
 When [creating a new plan](../api/planner_post_plans.md), give the plan a group owner by setting the `owner` property on a plan object. A plan must be owned by a group. A group can own multiple plans.
 
->**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
+>**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
 
 ## Plans
 [Plans](plannerplan.md) are the containers of [tasks](plannertask.md). 

--- a/api-reference/beta/resources/planner_overview.md
+++ b/api-reference/beta/resources/planner_overview.md
@@ -7,6 +7,7 @@ You can use the Planner API in Microsoft Graph to create tasks and assign them t
 Before you get started with Planner API, it is worth understanding how the main objects relate to each other as well as to Office 365 groups.
 
 ## Groups
+
 Office 365 groups are the owners of the plans in the Planner API.
 To [get the plans owned by a group](../api/plannergroup_list_plans.md), make the following HTTP request.
 
@@ -19,6 +20,7 @@ When [creating a new plan](../api/planner_post_plans.md), give the plan a group 
 >**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
 
 ## Plans
+
 [Plans](plannerplan.md) are the containers of [tasks](plannertask.md). 
 To [create a task in a plan](../api/planner_post_tasks.md), set the `planId` property on the task object to the ID of the plan while creating the task.
 Tasks currently cannot be created without plans.
@@ -29,22 +31,25 @@ GET /planner/plans/{id}/tasks
 ```
 
 ## Tasks
+
 Each task can be assigned to a user by adding an [assignment](plannerassignment.md) in the [assignments](plannerassignments.md) property on the task object.
 The ID of the user to assign the task is the name of the open property on `assignments`, and the `orderHint` property on the assignment must be specified.
 
 ## Task and plan details 
+
 Planner resources are arranged into basic task and plan objects and detail task and plan objects. Basic objects provide access to common properties of the resources, suitable for list views, while the detail objects provide access to large properties of the resources suitable for drill down views.
 
 ## Visualization
+
 Aside from task and plan data, the Planner API also provides resources to provide common visualization of data across clients. Several types of visualization data are available for tasks:
 
-| Tasks are shown as | Tasks are ordered with information from|
-|:-------------------|:---------------------------------------|
-|Flat list (tasks in a plan)| `orderHint` property on tasks|
-|Flat list (tasks assigned to a user)| `assigneePriority` property on tasks|
-|Board view with columns for assignees (assigned to task board)| [assignedToTaskBoardTaskFormat](plannerassignedToTaskBoardTaskFormat.md) object|
-|Board view with columns for progress of the task towards completion (progress task board)| [progressTaskBoardTaskFormat](plannerprogressTaskBoardTaskFormat.md) object|
-|Board view with custom columns of tasks (bucket task board):|[bucketTaskBoardTaskFormat](plannerbucketTaskBoardTaskFormat.md) object|
+| Tasks are shown as                                                                        | Tasks are ordered with information from                                         |
+| :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| Flat list (tasks in a plan)                                                               | `orderHint` property on tasks                                                   |
+| Flat list (tasks assigned to a user)                                                      | `assigneePriority` property on tasks                                            |
+| Board view with columns for assignees (assigned to task board)                            | [assignedToTaskBoardTaskFormat](plannerassignedToTaskBoardTaskFormat.md) object |
+| Board view with columns for progress of the task towards completion (progress task board) | [progressTaskBoardTaskFormat](plannerprogressTaskBoardTaskFormat.md) object     |
+| Board view with custom columns of tasks (bucket task board):                              | [bucketTaskBoardTaskFormat](plannerbucketTaskBoardTaskFormat.md) object         |
 
 The custom columns in the bucket task board are represented by [bucket](plannerbucket.md) objects, and their order by `orderHint` property on the object.
 
@@ -56,11 +61,11 @@ Planner's delta query supports querying objects that the user is subscribed to.
 
 Users are subscribed to the following objects.
 
-|Planner resource type|Subscribed instances|
-|:--------------------|:-------------------|
-|Tasks | <ul><li>Created by the user</li><li>Assigned to the user</li><li>Belong to a plan that the user owns</li><li>Contained in a plan shared with the user through the plan's **SharedWith** collection</li> |
-|Plans | <ul><li>Shared with the user through the plan's **SharedWith** collection</li></ul> |
-|Buckets | <ul><li>Contained in a plan shared with the user through the plan's **SharedWith** collection</li></ul> | 
+| Planner resource type | Subscribed instances                                                                                                                                                                                    |
+| :-------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Tasks                 | <ul><li>Created by the user</li><li>Assigned to the user</li><li>Belong to a plan that the user owns</li><li>Contained in a plan shared with the user through the plan's **SharedWith** collection</li> |
+| Plans                 | <ul><li>Shared with the user through the plan's **SharedWith** collection</li></ul>                                                                                                                     |
+| Buckets               | <ul><li>Contained in a plan shared with the user through the plan's **SharedWith** collection</li></ul>                                                                                                 |  |
 
 ### <a name="objectcache">Populate the object cache for delta queries</a>
 
@@ -116,21 +121,25 @@ In addition to [general errors](../../../concepts/errors.md) that apply to Micro
 ### 400 Bad request
 
 There are several common cases where the `POST` and `PATCH` requests can get a 400 status code. Common problems include:
+
 * Open Type properties are not of correct types.
 * The type isn't specified.
 * The request does not contain any properties.
 
-**Example**
+#### Example
 
 [plannerAssignments](plannerAssignments.md) properties with complex values need to declare `@odata.type` property with value `microsoft.graph.plannerAssignment`.
+
 * Order hint values do not have the [correct format](planner_order_hint_format.md).
 
    For example, an order hint value is being set directly to the value returned to the client.
+
 * The data is logically inconsistent.
 
    For example, start date of task is later than due date of the task.
 
 ### Planner error status codes
+
 In addition to general error status codes, Planner indicates special error conditions by returning the following codes.
 
 #### 403 Forbidden
@@ -138,22 +147,22 @@ In addition to general error status codes, Planner indicates special error condi
 The Planner API returns the **403** status code when a service-defined limit has been exceeded. In this case, the `code` property on the error resource type indicates the type of the limit exceeded by the request.
 The possible values for the limit types include:
 
-| Value  | Description|
-|:------------------|:----------|
-|MaximumProjectsOwnedByUser|The maximum number of Plans owned by a group limit has been exceeded. This limit is based on the `owner` property on the [plannerPlan](plannerPlan.md) resource.|
-|MaximumProjectsSharedWithUser|The maximum number of Plans shared with a user limit has been exceeded.  This limit is based on the `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource.|
-|MaximumTasksCreatedByUser|The maximum number of Tasks created by a user limit has been exceeded. This limit is based on the `createdBy` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumTasksAssignedToUser|The maximum number of Tasks assigned to a user limit has been exceeded. This limit is based on the `assignments` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumTasksInProject|The maximum number of Tasks in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumActiveTasksInProject|The maximum number of Tasks that aren't completed in a Plan limit has been exceeded. This limit is based on the `planId` and `percentComplete` properties on the [plannerTask](plannerTask.md) resource.|
-|MaximumBucketsInProject|The maximum number of Buckets in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerBucket](plannerBucket.md) resource.|
-|MaximumUsersSharedWithProject|The `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource contains too many values.|
-|MaximumReferencesOnTask|The `references` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.|
-|MaximumChecklistItemsOnTask|The `checklist` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.|
-|MaximumAssigneesInTasks|The `assignments` property on the [plannerTask](plannerTask.md) resource contains too many values.|
-|MaximumFavoritePlansForUser| The `favoritePlanReferences` property on the [plannerUser](plannerUser.md) resource contains too many values.|
-|MaximumRecentPlansForUser| The `recentPlanReferences` property on the [plannerUser](plannerUser.md) resource contains too many values.|
-|MaximumContextsOnPlan| The `contexts` proeprty on the [plannerPlan](plannerPlan.md) resource contains too many values.|
+| Value                         | Description                                                                                                                                                                                              |
+| :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MaximumProjectsOwnedByUser    | The maximum number of Plans owned by a group limit has been exceeded. This limit is based on the `owner` property on the [plannerPlan](plannerPlan.md) resource.                                         |
+| MaximumProjectsSharedWithUser | The maximum number of Plans shared with a user limit has been exceeded.  This limit is based on the `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource.                   |
+| MaximumTasksCreatedByUser     | The maximum number of Tasks created by a user limit has been exceeded. This limit is based on the `createdBy` property on the [plannerTask](plannerTask.md) resource.                                    |
+| MaximumTasksAssignedToUser    | The maximum number of Tasks assigned to a user limit has been exceeded. This limit is based on the `assignments` property on the [plannerTask](plannerTask.md) resource.                                 |
+| MaximumTasksInProject         | The maximum number of Tasks in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerTask](plannerTask.md) resource.                                               |
+| MaximumActiveTasksInProject   | The maximum number of Tasks that aren't completed in a Plan limit has been exceeded. This limit is based on the `planId` and `percentComplete` properties on the [plannerTask](plannerTask.md) resource. |
+| MaximumBucketsInProject       | The maximum number of Buckets in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerBucket](plannerBucket.md) resource.                                         |
+| MaximumUsersSharedWithProject | The `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource contains too many values.                                                                                          |
+| MaximumReferencesOnTask       | The `references` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.                                                                                          |
+| MaximumChecklistItemsOnTask   | The `checklist` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.                                                                                           |
+| MaximumAssigneesInTasks       | The `assignments` property on the [plannerTask](plannerTask.md) resource contains too many values.                                                                                                       |
+| MaximumFavoritePlansForUser   | The `favoritePlanReferences` property on the [plannerUser](plannerUser.md) resource contains too many values.                                                                                            |
+| MaximumRecentPlansForUser     | The `recentPlanReferences` property on the [plannerUser](plannerUser.md) resource contains too many values.                                                                                              |
+| MaximumContextsOnPlan         | The `contexts` property on the [plannerPlan](plannerPlan.md) resource contains too many values.                                                                                                          |
 
 #### 412 Precondition Failed
 

--- a/api-reference/v1.0/api/planner_post_plans.md
+++ b/api-reference/v1.0/api/planner_post_plans.md
@@ -3,28 +3,35 @@
 Use this API to create a new **plannerPlan**.
 
 ## Permissions
+
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
-|Permission type      | Permissions (from least to most privileged)              |
-|:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Group.ReadWrite.All    |
-|Delegated (personal Microsoft account) | Not supported.    |
-|Application | Not supported. |
+| Permission type                        | Permissions (from least to most privileged) |
+| :------------------------------------- | :------------------------------------------ |
+| Delegated (work or school account)     | Group.ReadWrite.All                         |
+| Delegated (personal Microsoft account) | Not supported.                              |
+| Application                            | Not supported.                              |
 
 ## HTTP request
-<!-- { "blockType": "ignored" } -->
-```http
-POST /planner/plans
 
+<!-- { "blockType": "ignored" } -->
+``` http
+POST /planner/plans
 ```
+
 ## Request headers
-| Name       | Description|
-|:---------------|:----------|
-| Authorization  | Bearer {token}. Required. |
+
+| Name          | Description               |
+| :------------ | :------------------------ |
+| Authorization | Bearer {token}. Required. |
 
 ## Request body
+
 In the request body, supply a JSON representation of [plannerPlan](../resources/plannerplan.md) object.
 The **plannerPlan** owner property must be set to an id of a [group](../resources/group.md) object.
+
+>**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
+
 
 ## Response
 
@@ -33,13 +40,16 @@ If successful, this method returns `201 Created` response code and [plannerPlan]
 This method can return any of the [HTTP status codes](../../../concepts/errors.md). The most common errors that apps should handle for this method are the 400, 403 and 404 responses. For more information about these errors, see [Common Planner error conditions](../resources/planner_overview.md#common-planner-error-conditions).
 
 ## Example
-##### Request
+
+### Request
+
 Here is an example of the request.
+
 <!-- {
   "blockType": "request",
   "name": "create_plannerplan_from_planner"
 }-->
-```http
+``` http
 POST https://graph.microsoft.com/v1.0/planner/plans
 Content-type: application/json
 Content-length: 381
@@ -49,15 +59,19 @@ Content-length: 381
   "title": "title-value"
 }
 ```
+
 In the request body, supply a JSON representation of [plannerPlan](../resources/plannerplan.md) object.
-##### Response
+
+### Response
+
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+
 <!-- {
   "blockType": "response",
   "truncated": true,
   "@odata.type": "microsoft.graph.plannerPlan"
 } -->
-```http
+``` http
 HTTP/1.1 200 OK
 Content-type: application/json
 Content-length: 357

--- a/api-reference/v1.0/resources/planner_overview.md
+++ b/api-reference/v1.0/resources/planner_overview.md
@@ -1,47 +1,53 @@
 ﻿# Use the Planner REST API
+
 You can use the Planner API in Microsoft Graph to create tasks and assign them to users in a group in Office 365.
 
 Before you get started with Planner API, it is worth understanding how the main objects relate to each other as well as to Office 365 groups.
 
 ## Groups
+
 Office 365 groups are the owners of the plans in the Planner API.
 To [get the plans owned by a group](../api/plannergroup_list_plans.md), make the following HTTP request.
 
-```http
+``` http
 GET /groups/{id}/planner/plans
 ```
 
 When [creating a new plan](../api/planner_post_plans.md), make a group its owner by setting the `owner` property on a plan object. Plans must be owned by groups.
 
->**Note:** The user who is creating the plan must be a member of the group. When you create a new group using the API, you are not automatically added to the group as a member. This has to be done using a separate API call.
+>**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using [Create group](../api/group_post_groups.md), you are not added to the group as a member. After the group is created, add yourself as a member by using [group post members](../api/group_post_members.md).
 
 ## Plans
+
 [Plans](plannerplan.md) are the containers of [tasks](plannertask.md). 
 To [create a task in a plan](../api/planner_post_tasks.md), set the `planId` property on the task object to the ID of the plan while creating the task.
 Tasks currently cannot be created without plans.
 To [retrieve the tasks in a plan](../api/plannerplan_list_tasks.md), make the following HTTP request.
 
-```http
+``` http
 GET /planner/plans/{id}/tasks
 ```
 
 ## Tasks
+
 Each task can be assigned to a user by adding an [assignment](plannerassignment.md) in the [assignments](plannerassignments.md) property on the task object.
 The ID of the user to assign the task is the name of the open property on `assignments`, and the `orderHint` property on the assignment must be specified.
 
 ## Task and plan details 
+
 Planner resources are arranged into basic objects and detail objects. Basic objects provide access to common properties of the resources, suitable for list views, while the detail objects provide access to large properties of the resources suitable for drill down views.
 
 ## Visualization
+
 Aside from task and plan data, the Planner API also provides resources to provide common visualization of data across clients. Several types of visualization data are available for tasks:
 
-| Tasks are shown as	  | Tasks are ordered with information from|
-|:------------------|:----------|
-|Flat list (tasks in a plan)| `orderHint` property on tasks|
-|Flat list (tasks assigned to a user)| `assigneePriority` property on tasks|
-|Board view with columns for assignees (assigned to task board)| [assignedToTaskBoardTaskFormat](plannerassignedToTaskBoardTaskFormat.md) object|
-|Board view with columns for progress of the task towards completion (progress task board)| [progressTaskBoardTaskFormat](plannerprogressTaskBoardTaskFormat.md) object|
-|Board view with custom columns of tasks (bucket task board):|[bucketTaskBoardTaskFormat](plannerbucketTaskBoardTaskFormat.md) object|
+| Tasks are shown as                                                                        | Tasks are ordered with information from                                         |
+| :---------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ |
+| Flat list (tasks in a plan)                                                               | `orderHint` property on tasks                                                   |
+| Flat list (tasks assigned to a user)                                                      | `assigneePriority` property on tasks                                            |
+| Board view with columns for assignees (assigned to task board)                            | [assignedToTaskBoardTaskFormat](plannerassignedToTaskBoardTaskFormat.md) object |
+| Board view with columns for progress of the task towards completion (progress task board) | [progressTaskBoardTaskFormat](plannerprogressTaskBoardTaskFormat.md) object     |
+| Board view with custom columns of tasks (bucket task board):                              | [bucketTaskBoardTaskFormat](plannerbucketTaskBoardTaskFormat.md) object         |
 
 The custom columns in the bucket task board are represented by [bucket](plannerbucket.md) objects, and their order by `orderHint` property on the object.
 
@@ -61,6 +67,7 @@ In addition to [general errors](../../../concepts/errors.md) that apply to Micro
 ### 400 Bad request
 
 There are several common cases where the `POST` and `PATCH` requests can get a 400 status code. Common problems include:
+
 * Open Type properties are not of correct types, or the type isn't specified, or they do not contain any properties. For example, [plannerAssignments](plannerAssignments.md) properties with complex values need to declare `@odata.type` property with value `microsoft.graph.plannerAssignment`.
 * Order hint values do not have the [correct format](planner_order_hint_format.md). For example, an order hint value is being set directly to the value returned to the client.
 * The data is logically inconsistent. For example, start date of task is later than due date of the task.
@@ -70,19 +77,19 @@ There are several common cases where the `POST` and `PATCH` requests can get a 4
 In addition to the general errors, the Planner API also returns this status code when a service-defined limit has been exceeded. If this is the case, the `code` property on the error resource type will indicate the type of the limit exceeded by the request.
 The possible values for the limit types include:
 
-| Value  | Description|
-|:------------------|:----------|
-|MaximumProjectsOwnedByUser|The maximum number of Plans owned by a group limit has been exceeded. This limit is based on the `owner` property on the [plannerPlan](plannerPlan.md) resource.|
-|MaximumProjectsSharedWithUser|The maximum number of Plans shared with a user limit has been exceeded.  This limit is based on the `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource.|
-|MaximumTasksCreatedByUser|The maximum number of Tasks created by a user limit has been exceeded. This limit is based on the `createdBy` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumTasksAssignedToUser|The maximum number of Tasks assigned to a user limit has been exceeded. This limit is based on the `assignments` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumTasksInProject|The maximum number of Tasks in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerTask](plannerTask.md) resource.|
-|MaximumActiveTasksInProject|The maximum number of Tasks that aren't completed in a Plan limit has been exceeded. This limit is based on the `planId` and `percentComplete` properties on the [plannerTask](plannerTask.md) resource.|
-|MaximumBucketsInProject|The maximum number of Buckets in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerBucket](plannerBucket.md) resource.|
-|MaximumUsersSharedWithProject|The `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource contains too many values.|
-|MaximumReferencesOnTask|The `references` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.|
-|MaximumChecklistItemsOnTask|The `checklist` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.|
-|MaximumAssigneesInTasks|The `assignments` property on the [plannerTask](plannerTask.md) resource contains too many values.|
+| Value                         | Description                                                                                                                                                                                              |
+| :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MaximumProjectsOwnedByUser    | The maximum number of Plans owned by a group limit has been exceeded. This limit is based on the `owner` property on the [plannerPlan](plannerPlan.md) resource.                                         |
+| MaximumProjectsSharedWithUser | The maximum number of Plans shared with a user limit has been exceeded.  This limit is based on the `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource.                   |
+| MaximumTasksCreatedByUser     | The maximum number of Tasks created by a user limit has been exceeded. This limit is based on the `createdBy` property on the [plannerTask](plannerTask.md) resource.                                    |
+| MaximumTasksAssignedToUser    | The maximum number of Tasks assigned to a user limit has been exceeded. This limit is based on the `assignments` property on the [plannerTask](plannerTask.md) resource.                                 |
+| MaximumTasksInProject         | The maximum number of Tasks in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerTask](plannerTask.md) resource.                                               |
+| MaximumActiveTasksInProject   | The maximum number of Tasks that aren't completed in a Plan limit has been exceeded. This limit is based on the `planId` and `percentComplete` properties on the [plannerTask](plannerTask.md) resource. |
+| MaximumBucketsInProject       | The maximum number of Buckets in a Plan limit has been exceeded. This limit is based on the `planId` property on the [plannerBucket](plannerBucket.md) resource.                                         |
+| MaximumUsersSharedWithProject | The `sharedWith` property on the [plannerPlanDetails](plannerPlanDetails.md) resource contains too many values.                                                                                          |
+| MaximumReferencesOnTask       | The `references` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.                                                                                          |
+| MaximumChecklistItemsOnTask   | The `checklist` property on the [plannerTaskDetails](plannerTaskDetails.md) resource contains too many values.                                                                                           |
+| MaximumAssigneesInTasks       | The `assignments` property on the [plannerTask](plannerTask.md) resource contains too many values.                                                                                                       |
 
 ### 412 Precondition Failed 
 


### PR DESCRIPTION
The current beta Planner Overview documentation includes the following Note:

>**Note:** The user who is creating the plan must be a member of the group that will own the plan. When you create a new group by using Create group, you are not added to the group as a member. After the group is created, add yourself as a member by using group post members.

This is an important piece of information but a little too buried in its current location. I've copied this note to the "Planner Overview" in v1 and the "Create plannerPlan" in both v1 and Beta. This addresses Issue #2673 