### PR TITLE
Adding .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# These files are text and should be normalized (convert crlf => lf)
+*.md    text
+*.yml   text
+*.ps1   text
+*.cmd   text
+*.json  text
+*.xml   text


### PR DESCRIPTION
This should prevent Windows users from inadvertently converting all line endings in a file to CRLF in the repository, causing diffs in pull requests to look like the entire file was changed.