### PR TITLE
Revert "Fixed delta query syntax for drive items"

### DIFF
--- a/api-reference/beta/api/driveitem_delta.md
+++ b/api-reference/beta/api/driveitem_delta.md
@@ -101,7 +101,7 @@ Content-type: application/json
             "deleted": { }
         }
     ],
-    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/delta?token=1230919asd190410jlka"
+    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/delta(token=1230919asd190410jlka)"
 }
 ```
 
@@ -119,7 +119,7 @@ Here is an example request after the initial request.
 <!-- { "blockType": "request", "name": "get_item_delta_last" }-->
 
 ```http
-GET https://graph.microsoft.com/v1.0/me/drive/root/delta?token=1230919asd190410jlka
+GET https://graph.microsoft.com/v1.0/me/drive/root/delta(token='1230919asd190410jlka')
 ```
 
 ### Response
@@ -146,7 +146,7 @@ Content-type: application/json
             "file": { }
         }
     ],
-    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=1230919asd190410jlka"
+    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?(token='1230919asd190410jlka')"
 }
 ```
 

--- a/api-reference/v1.0/api/driveitem_delta.md
+++ b/api-reference/v1.0/api/driveitem_delta.md
@@ -99,7 +99,7 @@ Content-type: application/json
             "deleted": { }
         }
     ],
-    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/delta?token=1230919asd190410jlka"
+    "@odata.nextLink": "https://graph.microsoft.com/v1.0/me/drive/delta(token=1230919asd190410jlka)"
 }
 ```
 
@@ -117,7 +117,7 @@ Here is an example request after the initial request.
 <!-- { "blockType": "request", "name": "get_item_delta_last" }-->
 
 ```http
-GET https://graph.microsoft.com/v1.0/me/drive/root/delta?token=1230919asd190410jlka
+GET https://graph.microsoft.com/v1.0/me/drive/root/delta(token='1230919asd190410jlka')
 ```
 
 ### Response
@@ -144,7 +144,7 @@ Content-type: application/json
             "file": { }
         }
     ],
-    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?token=1230919asd190410jlka"
+    "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/drive/root/delta?(token='1230919asd190410jlka')"
 }
 ```
 


### PR DESCRIPTION
Reverts microsoftgraph/microsoft-graph-docs#2812


OneDrive delta token syntax  differs from MS Graph standard but is not incorrect, bug was mistakenly filed.
