### PR TITLE
Corrected the URL for patch operation

### DIFF
--- a/api-reference/beta/api/organization_update.md
+++ b/api-reference/beta/api/organization_update.md
@@ -49,7 +49,7 @@ Here is an example of the request.
   "name": "update_organization"
 }-->
 ```http
-PATCH https://graph.microsoft.com/beta/organization
+PATCH https://graph.microsoft.com/beta/organization/<tenant-id>
 Content-type: application/json
 Content-length: 411
 


### PR DESCRIPTION
Please note that the patch operation doesn't work on URL https://graph.microsoft.com/beta/organization
instead it works for https://graph.microsoft.com/beta/organization/<tenant-id>