### PR TITLE
Deprecating some Teams APIs

### DIFF
--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -15,19 +15,19 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 ### Microsoft Teams APIs
 | **Change type** | **Version**   | **Description**                          |
 | :-------------- | :------------ | :--------------------------------------- |
-|Deletion|beta|Removed DELETE /groups/{id}/team/channels/{id}, use DELETE /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed GET /groups/{id}/team/channels/{id}, use GET /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed PATCH /groups/{id}/team/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed POST /groups/{id}/team/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead |
-|Deletion|beta|Removed GET /groups/{id}/team/channels, use GET /teams/{id}/channels instead |
-|Deletion|beta|Removed DELETE /groups/{id}/channels/{id} , use DELETE /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed GET /groups/{id}/channels/{id}, use GET /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed PATCH /groups/{id}/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead |
-|Deletion|beta|Removed POST /groups/{id}/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead |
-|Deletion|beta|Removed GET /groups/{id}/channels, use GET /teams/{id}/channels instead |
-|Deletion|beta|Removed POST /groups/{id}/team/channels, use POST /teams/{id}/channels instead |
-|Deletion|beta|Removed GET /groups/{id}/team, use GET /teams/{id} instead |
-|Deletion|beta|Removed PATCH /groups/{id}/team, use PATCH /teams/{id} instead |
+|Deletion|beta|Removed DELETE /groups/{id}/team/channels/{id}, use DELETE /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed GET /groups/{id}/team/channels/{id}, use GET /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed PATCH /groups/{id}/team/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed POST /groups/{id}/team/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead. |
+|Deletion|beta|Removed GET /groups/{id}/team/channels, use GET /teams/{id}/channels instead. |
+|Deletion|beta|Removed DELETE /groups/{id}/channels/{id} , use DELETE /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed GET /groups/{id}/channels/{id}, use GET /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed PATCH /groups/{id}/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead. |
+|Deletion|beta|Removed POST /groups/{id}/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead. |
+|Deletion|beta|Removed GET /groups/{id}/channels, use GET /teams/{id}/channels instead. |
+|Deletion|beta|Removed POST /groups/{id}/team/channels, use POST /teams/{id}/channels instead. |
+|Deletion|beta|Removed GET /groups/{id}/team, use GET /teams/{id} instead. |
+|Deletion|beta|Removed PATCH /groups/{id}/team, use PATCH /teams/{id} instead. |
 
 
 ## June 2018

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -12,6 +12,24 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 | :-------------- | :---------- | :--------------------------------------- |
 | Change          | Beta        | The [application](https://graph.microsoft.io/en-us/docs/api-reference/beta/resources/application) and [servicePrincipal](https://graph.microsoft.io/en-us/docs/api-reference/beta/resources/serviceprincipal) APIs will be updated in preview (beta). The first set of changes will be applied on July 16, 2018. The changes include property renaming and restructuring. Most of the existing properties will not be available until the changes are completed. There will be new properties added. The changes will be released in preview (beta) prior to releasing to v1.0. |
 
+### Microsoft Teams APIs
+| **Change type** | **Version**   | **Description**                          |
+| :-------------- | :------------ | :--------------------------------------- |
+|Deletion|beta|Removed DELETE /groups/{id}/team/channels/{id}, use DELETE /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed GET /groups/{id}/team/channels/{id}, use GET /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed PATCH /groups/{id}/team/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed POST /groups/{id}/team/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead |
+|Deletion|beta|Removed GET /groups/{id}/team/channels, use GET /teams/{id}/channels instead |
+|Deletion|beta|Removed DELETE /groups/{id}/channels/{id} , use DELETE /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed GET /groups/{id}/channels/{id}, use GET /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed PATCH /groups/{id}/channels/{id}, use  PATCH /teams/{id}/channels/{id} instead |
+|Deletion|beta|Removed POST /groups/{id}/channels/{id}/chatthreads, use POST /teams/{id}/channels/{id}/chatthreads instead |
+|Deletion|beta|Removed GET /groups/{id}/channels, use GET /teams/{id}/channels instead |
+|Deletion|beta|Removed POST /groups/{id}/team/channels, use POST /teams/{id}/channels instead |
+|Deletion|beta|Removed GET /groups/{id}/team, use GET /teams/{id} instead |
+|Deletion|beta|Removed PATCH /groups/{id}/team, use PATCH /teams/{id} instead |
+
+
 ## June 2018
 
 ### Directory APIs


### PR DESCRIPTION
Announcing the deprecation of some APIs that we stopped documenting earlier. (Or perhaps more accurately, announcing their renaming -- the same functionality is available in different APIs)