### PR TITLE
Update application_post_applications.md

### DIFF
--- a/api-reference/beta/api/application_post_applications.md
+++ b/api-reference/beta/api/application_post_applications.md
@@ -45,7 +45,6 @@ Content-type: application/json
 Content-length: 67
 
 {
-  "allowPublicClient": true,
   "displayName": "Display name"
 }
 ```


### PR DESCRIPTION
Error message when "allowPublicClient": true," is in the JSON" -> One or more properties contains invalid values. 
When allowPublicClient is not in the JSON the application is made in Azure AD.