### PR TITLE
Per issue 1975, copying size request examples from beta.

### DIFF
--- a/api-reference/v1.0/api/profilephoto_get.md
+++ b/api-reference/v1.0/api/profilephoto_get.md
@@ -47,6 +47,18 @@ GET /me/contactfolders/{contactFolderId}/contacts/{id}/photo
 GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photo
 ```
 
+## HTTP request to get the metadata for a specific photo size
+<!-- { "blockType": "ignored" } -->
+```http
+GET /me/photos/{size}
+GET /users/{id | userPrincipalName}/photos/{size}
+GET /groups/{id}/photos/{size}
+GET /me/contacts/{id}/photos/{size}
+GET /users/{id | userPrincipalName}/contacts/{id}/photos/{size}
+GET /me/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
+GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
+```
+
 ## Parameters
 
 |**Parameter**|**Type**|**Description**|

--- a/api-reference/v1.0/api/profilephoto_get.md
+++ b/api-reference/v1.0/api/profilephoto_get.md
@@ -10,8 +10,6 @@ The supported sizes of HD photos on Office 365 are as follows: '48x48', '64x64',
 You can get the metadata of the largest available photo, or specify a size to get the metadata for that photo size.
 If the size you request is not available, you can still get a smaller size that the user has uploaded and made available.
 For example, if the user uploads a photo that is 504x504 pixels, then all but the 648x648 size of photo will be available for download.
-If the specified size is not available in the user's mailbox or in Azure Active Directory, the size of '1x1' is returned with the rest of 
-metadata.
 
 ## Permissions
 
@@ -39,6 +37,7 @@ GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{i
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/photo
+GET /me/photos
 GET /users/{id | userPrincipalName}/photo
 GET /groups/{id}/photo
 GET /me/contacts/{id}/photo


### PR DESCRIPTION
Per Issue #1975, this copies in the HTTP request examples for `/size`.

@dkershaw10 - PTAL 