### PR TITLE
Fixed typo in getbyids

### DIFF
--- a/api-reference/v1.0/api/directoryobject_getbyids.md
+++ b/api-reference/v1.0/api/directoryobject_getbyids.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /directoryObjects/getById
+POST /directoryObjects/getByIds
 ```
 
 ## Request headers


### PR DESCRIPTION
Url shows /getById but this should be /getByIds