### PR TITLE
eduassignments: allowLateSubmissions default is true

### DIFF
--- a/api-reference/beta/resources/educationassignment.md
+++ b/api-reference/beta/resources/educationassignment.md
@@ -25,7 +25,7 @@ The assignment APIs are exposed in the class namespace.
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |id|String| Read-only.|
-|allowLateSubmissions|Boolean| Identifies whether students can submit after the due date. |
+|allowLateSubmissions|Boolean| Identifies whether students can submit after the due date. If this property is not specified during create, it defaults to true. |
 |allowStudentsToAddResourcesToSubmission|Boolean| Identifies whether students can add their own resources to a submission or if they can only modify resources added by the teacher. |
 |assignDateTime|DateTimeOffset|The date when the assignment should become active.  If in the future, the assignment is not shown to the student until this date.  The **Timestamp** type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |assignTo|[educationAssignmentRecipient](educationassignmentrecipient.md)| Which users, or whole class should receive a submission object once the assignment is published. |


### PR DESCRIPTION
allowLateSubmissions default is true (as of 08/10/18) when the caller does not specify any value during a create (POST) assignment request.