### PR TITLE
Graph notifications docs

### DIFF
--- a/api-reference/beta/api/projectrome_post_notification.md
+++ b/api-reference/beta/api/projectrome_post_notification.md
@@ -1,0 +1,78 @@
+# Create and publish a user-centric notification to Microsoft Graph
+> **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
+Create and publish a user-centric notification to Microsoft Graph. The notification gets stored inside notification feed store in the Graph, and then gets fanned-out to all app clients on different device endpoints the user is logged in on.  
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Notifications.ReadWrite.CreatedByApp    |
+|Delegated (personal Microsoft account) | Notifications.ReadWrite.CreatedByApp    |
+
+## HTTP request
+```http
+POST /me/notifications/}
+```
+## Request headers
+|Name | Type | Description|
+|:----|:-----|:-----------|
+|Authorization | string |The authorization header is used to pass the credentials of the calling party. OAuth: Authorization: bearer <access_token> |
+## Request body
+In the request body, supply a JSON representation of an [notification](../resources/projectrome_notification.md) object.
+
+## Response
+If successful, this method returns the `201 Created` response code if the notification was successfully created and stored. 
+## Example
+#### Request
+The following is an example of the request.
+
+```http
+POST https://graph.microsoft.com/beta/me/activities/
+Content-type: application/json
+
+{
+    "targetHostName": "undemo.activity.windows.com",
+    "appNotificationId": "testDirectToastNotification",
+    "expirationDateTime": "2018-08-29T23:51:33.000Z",
+    "payload": {
+        "visualContent": {
+            "title": "Hello Ignite!",
+            "body": "Notifications are Great!"
+        }
+    },
+    "targetPolicy": {
+        "platformTypes": [
+        "windows"
+        ]
+    },
+    "priority": "High",
+    "groupName": "TestGroup",
+    "displayTimeToLive": "23"
+}
+```
+
+#### Response
+The following is an example of the response.
+
+```http
+HTTP/1.1 201
+Content-Type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/test872018/$metadata#users('rayxu1988%40gmail.com')/notifications/$entity",
+    "appNotificationId": "testDirectToastNotification",
+    "displayTimeToLive": 22,
+    "expirationDateTime": "2018-08-24T12:31:53.858Z",
+    "groupName": "TestGroup",
+    "id": "cd5c5e6a-99ce-470a-9982-c47635e73620",
+    "priority": "1",
+    "payload": {
+        "visualContent": {
+            "title": "Hello Ignite!",
+            "body": "Notifications are Great!"
+        }
+    }
+}
+```
+
+

--- a/api-reference/beta/resources/project_rome_overview.md
+++ b/api-reference/beta/resources/project_rome_overview.md
@@ -2,9 +2,9 @@
 
 > **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
 
-[Project Rome](https://developer.microsoft.com/en-us/windows/project-rome) is a Microsoft initiative to build a cross-device experiences platform. Project Rome enables an app on a local client or service to interact with apps and services on a remote host when the user signs in with the same Microsoft account that they use to sign in on the client device. This allows you to program cross-device and cross-platform experiences that are centered around user tasks rather than devices. 
+[Project Rome](https://developer.microsoft.com/en-us/windows/project-rome) is a Microsoft initiative to build a platform that enables app developers to build great cross-device experiences. Project Rome enables different capabilities that connects different services and client endpoints when the user signs in with the same Microsoft account (MSA account or AAD school/work account). This allows you to implement cross-device and cross-platform experiences that are centered around user tasks rather than devices. 
 
-Two key components are exposed via Microsoft Graph to enable these experiences: devices and activities. 
+Three key capabilities are exposed via Microsoft Graph from Project Rome to help you enable great cross-device experiences – activities, devices, and notifications. 
 
 ## Activities
 
@@ -42,3 +42,12 @@ You can use the following Microsoft Graph APIs to communicate with other Windows
 - [List the user's devices](../api/user_list_devices.md)
 - [Send a command to a device](../api/send_device_command.md)
 - [Get command status](../api/get_device_command_status.md)
+
+## Notifications
+
+MS Graph notifications let you deliver and manage notifications across multiple endpoints owned by the same logged in user, in a human-centric, rather than a device-centric way. 
+
+You can use the notifications API in Microsoft Graph to publish a raw data notification or a direct visual notification. When a raw data notification is delivered to a device endpoint, you can then use the client-side SDK (Graph notifications SDK for Windows, Project Rome SDK for iOS and Android) to receive and manage notifications. When a direct visual notification is delivered to a device endpoint, it directly shows the platform-specific native notification to the user. 
+
+- [Create and publish a user-centric notification](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/projectrome_post_notification)
+

--- a/api-reference/beta/resources/projectrome-graph-notifications-api-overview.md
+++ b/api-reference/beta/resources/projectrome-graph-notifications-api-overview.md
@@ -1,0 +1,7 @@
+# Use the MS Graph notifications REST API
+You can use the Graph notifications API in Microsoft Graph to send push notifications to a user. Simply target a user account to publish a notification, and the platform will help you to fan-out and deliver this notification to all device endpoints. Graph notifications API requests are performed on behalf of a user via [delegated permissions](../../../concepts/permissions_reference.md#delegated-permissions-application-permissions-and-effective-permissions) and the [notification permission]( ../../../concepts/permissions_reference.md), which can be used with either personal or work and school accounts.
+This type of user-centric notification is represented by the [notification](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/projectrome_notification) resource and are stored in Microsoft Graph, which can then be accessed and managed by the publishing app through the client-side Rome SDK APIs. 
+
+## Next steps
+- See the [notification resource](https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/projectrome_notification) and create notifications to engage with your users. 
+- (Coming soon) Try the API in the [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).

--- a/api-reference/beta/resources/projectrome_notification.md
+++ b/api-reference/beta/resources/projectrome_notification.md
@@ -1,0 +1,60 @@
+# notification resource type
+> **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
+Represents a user-targeting notification that is published by app server. The notification is stored in Microsoft Graph and may be fanned-out to different device endpoints owned by this user. A notification can be a visual notification payload that can be directly interpreted by different OS platforms including Windows, Android, and iOS. It can also be a data payload which is delivered to and handled by app clients, which then determine the corresponding user experience on each device – usually, a visual notification UI is generated locally, that’s corresponding to the content in the original data payload. 
+When a user engages and acts on a visual notification, the app client can then use client-side Rome SDK to update the state of the corresponding notification feed in Microsoft Graph, such as, marking a notification as dismissed. The update will then be fanned-out to all other app client endpoints, so these clients can handle this change accordingly, such as, dismiss the same notification universally to prevent the user from seeing any redundant information. The same notification resource can also be accessed at a later time before it expires (even after being marked as dismissed), as notification history, by app clients through the Project Rome SDK. 
+
+## Methods
+|Method | Return Type | Description|
+|:------|:------------|:-----------|
+|[Create notification](../api/projectrome_post_notification.md) | [notification](projectrome_notification.md) |Creates and publish a notification. |
+
+## Properties
+|Name | Type | Description|
+|:----|:-----|:-----------|
+
+| targetHostName | String | Represents the host name of the app to which the calling service wants to post the notification, for the given user. |
+| appNotificationId | String | This is the unique id set by the app server of a notification that is used to identify and target an individual notification. |
+| expirationDateTime | DateTimeOffset | This sets a UTC expiration time on a user notification - when time is up, the notification is removed from the Microsoft Graph notification feed store completely and is no longer part of notification history. Max value is 30 days. |
+| payload | Edm.ComplexType, JSON object | This is the data content of a raw or visual user notification that will be delivered to and consumed by the app client receiving this notification. |
+| payload.rawContent | String | This is the notification content of a raw user notification that will be delivered to and consumed by the app client receiving this notification. *At least one of Payload.RawContent and Payload.VisualContent needs to be valid for a POST Notification request. |
+| payload.visual | Edm.ComplexType, JSON object | This is the visual content of a visual user notification, which will be directly consumed by notification platform on each mobile platform and rendered for the users. *At least one of Content and VisualContent needs to be valid for a POST Notification request. |
+| payload.visual.title | String | This is the title of a visual user notification. *Must have either title or body. |
+| payload.visual.body | String | This is the body of a visual user notification. *Must have either title or body. |
+| displayTimeToLive | Int | This sets how long (in seconds) this notification content will stay in each platform’s notification viewer. For example, when the notification is delivered to a Windows device, the value of this property is passed on to ToastNotification.ExpirationTime, which determines how long the toast notification will stay in user’s Windows Action Center. |
+| priority | EnumType | This indicates the priority of a raw user notification. Visual notifications are sent with high priority by default. Valid values are High and Low. |
+| groupName | String | This is the name of the group that this notification belongs to. It is set by the developer for the purpose of grouping notifications together. |
+| targetPolicy | Edm.ComplexType, JSON object | Target policy object handles notification delivery policy at 2 different levels - endpoint types (Windows, iOS and Android) that should be targeted, and specific endpoints (identified by subscription ids) that should be targeted. |
+| targetPolicy.platformTypes | Edm.ComplexType, Collection (EnumType) | App developer can use this property if they want to filter the notification fanout to a specific platform(s). By default, all push endpoint types (iOS, Windows and Android) are enabled. |
+
+## Relationships
+None.
+
+## JSON representation
+Here is a JSON representation of the resource.
+```json
+{
+    "targetHostName": "String",
+    "appNotificationId": "String",
+"expirationDateTime": "DateTimeOffset",
+"payload":  [
+	{
+		"rawContent": "String",
+		"visual": [
+			{
+				"title": "String",
+				"body": "String"
+}
+],
+}
+],
+    "displayTimeToLive": "Int",
+    "priority": "Enum",
+"groupName": "String",
+"targetPolicy":  [
+	{
+		"platformTypes": [{ "@odata.type": "Enum" }]
+}
+],
+}
+```
+

--- a/api-reference/v1.0/resources/project_rome_overview.md
+++ b/api-reference/v1.0/resources/project_rome_overview.md
@@ -2,9 +2,9 @@
 
 [Project Rome](https://developer.microsoft.com/en-us/windows/project-rome) is a Microsoft initiative to build a cross-device experiences platform. Project Rome enables an app on a local client or service to interact with apps and services on a remote host when the user signs in with the same Microsoft account that they use to sign in on the client device. This allows you to program cross-device and cross-platform experiences that are centered around user tasks rather than devices.
 
-A key component is exposed via Microsoft Graph to enable these experiences: activities.
-
 ## Activities
+
+A key component is exposed via Microsoft Graph to enable these experiences: activities.
 
 Activities in Microsoft Graph enable you to drive user engagement with your apps across devices and platforms. An activity is the unit of user engagement, and consists of three components:
 
@@ -24,3 +24,7 @@ You can use the following Microsoft Graph APIs to create and retrieve user activ
 - [Delete an activity](../api/projectrome_delete_activity.md)
 - [Create or replace a history item](../api/projectrome_put_historyitem.md)
 - [Delete a history item](../api/projectrome_delete_historyitem.md)
+
+## Graph notifications 
+
+Graph notifications aim to enable your app to build a human-centric notification story improve your exisitng notification story allow you to target users. Graph notifications will take care of the heavy lifting, including mapping between users and endpoints, syncing notification state across users' different endpoints, and more. 

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -4,6 +4,15 @@ This changelog covers what's changed in Microsoft Graph, including the v1.0 and 
 
 For details about known issues with Microsoft Graph APIs, see [Known issues](known_issues.md).
 
+## August 2018
+### Microsoft Graph Notifications API
+
+| **Change type** | **Version** | **Description**                          |
+| :-------------- | :---------- | :--------------------------------------- |
+| Addition          | Beta        | Add [notification](https://graph.microsoft.io/en-us/docs/api-reference/beta/resources/projectrome_notification) resource type |
+| Addition          | Beta        | Enabled creating and publishing a user-centric notifications using [Post notification API] (https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/projectrome_post_notification) |
+
+
 ## July 2018
 
 ### Application and servicePrincipal API changes

--- a/concepts/cross-device-concept-overview.md
+++ b/concepts/cross-device-concept-overview.md
@@ -14,8 +14,14 @@ With activities, you have a way to capture the unique tasks for users of your ap
 ### Build rich cross-device experiences by using the device relay API 
 In addition to Microsoft devices (PCs, Windows Phones, Xbox, IoT, HoloLens, and more), the device relay API also exposes Android and iOS devices. This enables you to truly break down boundaries between your users' devices. You can build apps that utilize the user’s environment and create rich experiences that transcend a single device in real-time. 
 
+## Reach out to and engage with your users anywhere by building a coherent and human-centric notification story using the Graph notifications API
+Notification is one of the most effective and direct path of communication for you to engage with your users. 
+
+With Microsoft Graph notifications APIs, notification delivery can be done in a human-centric, instead of a device-centric way - you can target a user to send notifications, and rely on the Graph notifications framework to deliver the notifications to each endpoint the user has logged in on. Cross-device notification management is made easy with Graph notifications APIs as well, so you can sync notifications across user's devices, and reduce the amount of redundancy and interruption for your users. 
+
 ## Next steps
 
 - [Use the Microsoft Graph API to enable cross-device experiences](../api-reference/v1.0/resources/cross-device-reference-overview.md)
 - [Learn more about the activity feed API in Microsoft Graph](activity-feed-concept-overview.md)
 - [Learn more about the device replay API in Microsoft Graph](device-relay-concept-overview.md)
+- [Learn more about the Microsoft Graph notifications API in Microsoft Graph](graph-notifications-concept-overview.md)

--- a/concepts/graph-notifications-concept-overview.md
+++ b/concepts/graph-notifications-concept-overview.md
@@ -1,0 +1,28 @@
+# Using the notifications API in Microsoft Graph to enable human-centric notification experiences 
+
+Notifications are the most effective way to re-engage your users, due to their ability to catch your user’s attention and bring the user back to your app. In a multi-device world, your users could be accessing your apps and services from anywhere, across different platforms and devices where your apps have a presence. 
+
+Therefore, notification scenarios should be considered and designed in a "human-centric" way, in which the primary goal is to notify the user, wherever he or she is. The existing notification solutions provided by major platforms are excellent at targeting devices. Graph notifications, on the other hand, aim to improve that and allow you to target users. Graph notifications will take care of the heavy lifting, including mapping between users and endpoints, syncing notification state across users' different endpoints, and more. 
+
+## Why integrate with Graph notifications?
+### Deliver notifications to a user across different endpoints
+As part of Microsoft Graph, notification APIs allow you to target a Microsoft account (MSA) or a school/work account (AAD) to deliver a notification. The platform fans out this notification to all their endpoints, including Windows UWP, Android, iOS. More platform and endpoint type support to come in near future. 
+
+### Manage notifications across endpoints
+Graph notifications APIs allow you to update the state of a notification and sync that state across all endpoints. For example, when a user acts on a notification on one device, we allow you to update the state of this notification (such as marking it as read or dismissed), and the same state change will be fanned-out to all other endpoints. With Graph notifications tracking the state of your users' notifications in a centralized way, it is easy to make sure your notifications are "handled once, dismissed everywhere".
+
+### Retrieve notification history
+Graph notifications APIs allow you to retrieve notification history based on an expiration time you define (up to 30 days). Notifications that are marked as read or dismissed are still retrievable from the history in order to power in-app views of notification history and other desired scenarios. 
+
+## How to integrate with Graph notifications?
+
+You can integrate your apps with Graph notifications with a few simple steps - onboarding your app via Windows Dev Center, using MS Graph POST API to publish notifications, and using Project Rome SDK to receive and manage notifications on your app clients.  
+
+To learn more about how to publish a user notification via MS Graph POST API, check out [the API reference](https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/projectrome_get_recent_activities).
+ 
+To learn more about receiving and managing notifications by integration with the Project Rome SDK, check out [the documentations on Project Rome SDK](https://docs.microsoft.com/en-us/windows/project-rome/) 
+
+## See also
+
+- [Cross-device experiences in Microsoft Graph](cross-device-concept-overview.md)
+- [Learn more about Project Rome](http://aka.ms/projectrome)

--- a/concepts/permissions_reference.md
+++ b/concepts/permissions_reference.md
@@ -1002,4 +1002,17 @@ The *CreatedByApp* constraint associated with this permission indicates the serv
 *	_UserActivity.ReadWrite.CreatedByApp_: Delete a user activity in response to user initiated request or to remove invalid data. (DELETE /me/activities/{id}).
 *	_UserActivity.ReadWrite.CreatedByApp_: Delete a history item in response to user initiated request or to remove invalid data. (DELETE /me/activities/{id}/historyItems/{id}).
 
+## Microsoft Graph notifications permissions
+#### Delegated permissions
+|Permission    |Display String   |Description |Admin Consent Required |
+|:-----------------------------|:-----------------------------------------|:-----------------|:-----------------|
+| _Notifications.ReadWrite.CreatedByApp_ | Deliver and manage notifications for this app | Allow the app to deliver its notifications on behalf of signed-in users. Also allows the app to read, update, and delete the user’s notification items for this app |No |
+### Remarks
+*Notifications.ReadWrite.CreatedByApp* is valid for both Microsoft accounts and work or school accounts. 
+The *CreatedByApp* constraint associated with this permission indicates the service will apply implicit filtering to results based on the identity of the calling app, either the MSA app id or a set of app ids configured for a cross-platform application identity. 
+### Example usage
+#### Delegated
+* _Notifications.ReadWrite.CreatedByApp_: Publish a user-centric notification which may then be delivered to user’s multiple application clients running on different endpoints. (POST /me/notifications/).
+
+
 <br/>


### PR DESCRIPTION
Adding Graph notifications concept and beta API docs.

Made some changes to existing Rome overview (both conceptual overview and the API overview under resource), as well as the permission model page and the change log page. 

The new files should be in this hierarchy inside the ToC but Laura please chime in if you have suggestions:

Conceptual doc:
concepts/graph-notifications-concept-overview.md should be a new node under https://developer.microsoft.com/en-us/graph/docs/concepts/cross-device-concept-overview, in parallel to the Activity Feed and Device Relay overviews;


API doc: 
api-reference/beta/resources/projectrome-graph-notifications-api-overview.md should be a new node under https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/project_rome_overview; 

api-reference/beta/resources/projectrome_notification.md should be under api-reference/beta/resources/projectrome-graph-notifications-api-overview.md

api-reference/beta/api/projectrome_post_notification.md should be under api-reference/beta/resources/projectrome_notification.md

In summary, just like how we list under Beta reference today:
Cross-device experience
- Activity Feed
--- Activity
----- Create or replace an activity

We should also have:
- Microsoft Graph Notifications
--- Notification
----- Create and publish a notification


Thanks,
Lei