### PR TITLE
Fixed subscription expiration times

### DIFF
--- a/api-reference/beta/resources/subscription.md
+++ b/api-reference/beta/resources/subscription.md
@@ -51,11 +51,11 @@ Here is a JSON representation of the resource.
 
 | Resource            | Maximum Expiration Time  |
 |:--------------------|:-------------------------|
-| Mail                | 4320 minutes (3 days)    |
-| Calendar            | 4320 minutes (3 days)    |
-| Contacts            | 4320 minutes (3 days)    |
-| Group conversations | 4320 minutes (3 days)    |
-| Drive root items    | 4320 minutes (3 days) |
+| Mail                | 4230 minutes (under 3 days)    |
+| Calendar            | 4230 minutes (under 3 days)    |
+| Contacts            | 4230 minutes (under 3 days)    |
+| Group conversations | 4230 minutes (under 3 days)    |
+| Drive root items    | 4230 minutes (under 3 days)    |
 
 > **Note:** Existing applications and new applications should not exceed the supported value. In the future, any requests to create or renew a subscription beyond the maximum value will fail.
 

--- a/api-reference/v1.0/resources/subscription.md
+++ b/api-reference/v1.0/resources/subscription.md
@@ -62,11 +62,11 @@ Here is a JSON representation of the resource.
 
 | Resource            | Maximum Expiration Time  |
 |:--------------------|:-------------------------|
-| Mail                | 4320 minutes (3 days)    |
-| Calendar            | 4320 minutes (3 days)    |
-| Contacts            | 4320 minutes (3 days)    |
-| Group conversations | 4320 minutes (3 days)    |
-| Drive root items    | 4320 minutes (3 days) |
+| Mail                | 4230 minutes (under 3 days)    |
+| Calendar            | 4230 minutes (under 3 days)    |
+| Contacts            | 4230 minutes (under 3 days)    |
+| Group conversations | 4230 minutes (under 3 days)    |
+| Drive root items    | 4230 minutes (under 3 days)    |
 
 > **Note:** Existing applications and new applications should not exceed the supported value. In the future, any requests to create or renew a subscription beyond the maximum value will fail.
 


### PR DESCRIPTION
Customers reported we advertise the incorrect internal subscription times. the hard enforced limits are the new numbers (slightly under 3 days)