### PR TITLE
Removing extra header and formatting.

### DIFF
--- a/api-reference/v1.0/resources/organization.md
+++ b/api-reference/v1.0/resources/organization.md
@@ -11,10 +11,10 @@ This resource lets you add your own data to custom properties using [extensions]
 |:---------------|:--------|:----------|
 |[Get organization](../api/organization_get.md) | [organization](organization.md) |Read properties and relationships of organization object.|
 |[Update](../api/organization_update.md) | [organization](organization.md)  |Update organization object. The only properties that can be updated are: **marketingNotificationMails**, **technicalNotificationMails**, **securityComplianceNotificationMails**, **securityComplianceNotificationPhones** and **privacyProfile**. |
-|**Open extensions**| | ||**Open extensions**| | |
+|**Open extensions**| 
 |[Create open extension](../api/opentypeextension_post_opentypeextension.md) |[openTypeExtension](opentypeextension.md)| Create an open extension and add custom properties to a new or existing resource.|
 |[Get open extension](../api/opentypeextension_get.md) |[openTypeExtension](opentypeextension.md) collection| Get an open extension identified by the extension name.|
-|**Schema extensions**| | |
+|**Schema extensions**| 
 |[Add schema extension values](../../../concepts/extensibility_schema_groups.md) || Create a schema extension definition and then use it to add custom typed data to a resource.|
 
 ## Properties


### PR DESCRIPTION
When adding section headers to tables, use care to add just one. 

For best results, do _not_ specify the empty column pipes. 

Example:
- Do this: `|**Section label**| `  
- Not this: `|**Section label**| | |`
- Absolutely not: `|**Section label**| | ||**Section label**| | |` 


