### PR TITLE
Update formating in Planner docs

### DIFF
--- a/api-reference/beta/api/plannerplan_get.md
+++ b/api-reference/beta/api/plannerplan_get.md
@@ -2,7 +2,7 @@
 
 > **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
 
-Retrieve the properties and relationships of **plannerplan** object.
+Retrieve the properties and relationships of **plannerPlan** object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -15,7 +15,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/<id>
+GET /planner/plans/{plan-id}
 ```
 ## Request headers
 | Name      |Description|

--- a/api-reference/beta/api/plannerplan_list_buckets.md
+++ b/api-reference/beta/api/plannerplan_list_buckets.md
@@ -2,7 +2,7 @@
 
 > **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
 
-Retrieve a list of **plannerbucket** objects contained by a [plannerPlan](../resources/plannerplan.md) object.
+Retrieve a list of **plannerBucket** objects contained by a [plannerPlan](../resources/plannerplan.md) object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -15,7 +15,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/<id>/buckets
+GET /planner/plans/{plan-id}/buckets
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerplan_list_tasks.md
+++ b/api-reference/beta/api/plannerplan_list_tasks.md
@@ -2,7 +2,7 @@
 
 > **Important:** APIs under the /beta version in Microsoft Graph are in preview and are subject to change. Use of these APIs in production applications is not supported.
 
-Retrieve a list of **plannertask** objects associated to a [plannerPlan](../resources/plannerplan.md) object.
+Retrieve a list of **plannerTask** objects associated to a [plannerPlan](../resources/plannerplan.md) object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -15,7 +15,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/<id>/tasks
+GET /planner/plans/{plan-id}/tasks
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerplan_update.md
+++ b/api-reference/beta/api/plannerplan_update.md
@@ -16,7 +16,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/plans/<id>
+PATCH /planner/plans/{plan-id}
 ```
 
 ## Request headers

--- a/api-reference/beta/resources/planner_overview.md
+++ b/api-reference/beta/resources/planner_overview.md
@@ -12,7 +12,7 @@ Office 365 groups are the owners of the plans in the Planner API.
 To [get the plans owned by a group](../api/plannergroup_list_plans.md), make the following HTTP request.
 
 ``` http
-GET /groups/{id}/planner/plans
+GET /groups/{group-id}/planner/plans
 ```
 
 When [creating a new plan](../api/planner_post_plans.md), give the plan a group owner by setting the `owner` property on a plan object. A plan must be owned by a group. A group can own multiple plans.
@@ -27,7 +27,7 @@ Tasks currently cannot be created without plans.
 To [retrieve the tasks in a plan](../api/plannerplan_list_tasks.md), make the following HTTP request.
 
 ``` http
-GET /planner/plans/{id}/tasks
+GET /planner/plans/{plan-id}/tasks
 ```
 
 ## Tasks

--- a/api-reference/v1.0/api/plannerplan_get.md
+++ b/api-reference/v1.0/api/plannerplan_get.md
@@ -1,6 +1,6 @@
 # Get plannerPlan
 
-Retrieve the properties and relationships of **plannerplan** object.
+Retrieve the properties and relationships of **plannerPlan** object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -13,7 +13,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/{id}
+GET /planner/plans/{plan-id}
 ```
 ## Request headers
 | Name      |Description|

--- a/api-reference/v1.0/api/plannerplan_list_buckets.md
+++ b/api-reference/v1.0/api/plannerplan_list_buckets.md
@@ -1,6 +1,6 @@
 # List buckets
 
-Retrieve a list of **plannerbucket** objects contained by a [plannerPlan](../resources/plannerplan.md) object.
+Retrieve a list of **plannerBucket** objects contained by a [plannerPlan](../resources/plannerplan.md) object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -13,7 +13,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/{id}/buckets
+GET /planner/plans/{plan-id}/buckets
 ```
 
 ## Request headers

--- a/api-reference/v1.0/api/plannerplan_list_tasks.md
+++ b/api-reference/v1.0/api/plannerplan_list_tasks.md
@@ -1,6 +1,6 @@
 # List tasks
 
-Retrieve a list of **plannertask** objects associated to a [plannerPlan](../resources/plannerplan.md) object.
+Retrieve a list of **plannerTask** objects associated to a [plannerPlan](../resources/plannerplan.md) object.
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](../../../concepts/permissions_reference.md).
 
@@ -13,7 +13,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/{id}/tasks
+GET /planner/plans/{plan-id}/tasks
 ```
 
 ## Request headers

--- a/api-reference/v1.0/api/plannerplan_update.md
+++ b/api-reference/v1.0/api/plannerplan_update.md
@@ -14,7 +14,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/plans/{id}
+PATCH /planner/plans/{plan-id}
 ```
 
 ## Request headers

--- a/api-reference/v1.0/resources/planner_overview.md
+++ b/api-reference/v1.0/resources/planner_overview.md
@@ -10,7 +10,7 @@ Office 365 groups are the owners of the plans in the Planner API.
 To [get the plans owned by a group](../api/plannergroup_list_plans.md), make the following HTTP request.
 
 ``` http
-GET /groups/{id}/planner/plans
+GET /groups/{group-id}/planner/plans
 ```
 
 When [creating a new plan](../api/planner_post_plans.md), make a group its owner by setting the `owner` property on a plan object. Plans must be owned by groups.
@@ -25,7 +25,7 @@ Tasks currently cannot be created without plans.
 To [retrieve the tasks in a plan](../api/plannerplan_list_tasks.md), make the following HTTP request.
 
 ``` http
-GET /planner/plans/{id}/tasks
+GET /planner/plans/{plan-id}/tasks
 ```
 
 ## Tasks


### PR DESCRIPTION
I'm wondering, are these type of PRs welcome? 

I mean, changing **`plannerplan`** to **`plannerPlan`** seems ok, but what about **`{id}`** to **`{plan-id}`** in order to make it more explicit (and also sometimes to look similar to the example given in the example section)?