### PR TITLE
Fix HTTP status table in errors.md

### DIFF
--- a/concepts/errors.md
+++ b/concepts/errors.md
@@ -31,9 +31,7 @@ The following table lists and describes the HTTP status codes that can be return
 | 415         | Unsupported Media Type          | The content type of the request is a format that is not supported by the service.                                                      |
 | 416         | Requested Range Not Satisfiable | The specified byte range is invalid or unavailable.                                                                                    |
 | 422         | Unprocessable Entity            | Cannot process the request because it is semantically incorrect.
-
 | 423         | Locked                          | The resource that is being accessed is locked.
-
 | 429         | Too Many Requests               | Client application has been throttled and should not attempt to repeat the request until an amount of time has elapsed.                |
 | 500         | Internal Server Error           | There was an internal server error while processing the request.                                                                       |
 | 501         | Not Implemented                 | The requested feature isn’t implemented.                                                                                               |


### PR DESCRIPTION
Remove newlines that were preventing the HTTP status table from being displayed correctly in errors.md