### PR TITLE
Add directory permissions to list groups endpoint

### DIFF
--- a/api-reference/v1.0/api/group_list.md
+++ b/api-reference/v1.0/api/group_list.md
@@ -18,9 +18,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Group.Read.All, Group.ReadWrite.All    |
+|Delegated (work or school account) | Group.Read.All, Group.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Group.Read.All, Group.ReadWrite.All |
+|Application | Group.Read.All, Group.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
You can also use the permissions `Directory.Read.All` and `Directory.ReadWrite.All` to access the `GET /groups` endpoint.