### PR TITLE
"get" URL is missing an "s" at the end

### DIFF
--- a/api-reference/beta/api/educationsynchronizationerrors_get.md
+++ b/api-reference/beta/api/educationsynchronizationerrors_get.md
@@ -37,7 +37,7 @@ The following is an example of the request.
   "name": "get_educationSynchronizationProfile_error"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/education/synchronizationProfiles/{id}/error
+GET https://graph.microsoft.com/beta/education/synchronizationProfiles/{id}/errors
 ```
 
 ##### Response


### PR DESCRIPTION
Added an "s" to ```http
GET https://graph.microsoft.com/beta/education/synchronizationProfiles/{id}/error to make it ```http
GET https://graph.microsoft.com/beta/education/synchronizationProfiles/{id}/errors