### PR TITLE
subscribe a resource on behalf of a user

### DIFF
--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -95,6 +95,8 @@ Content-Type: application/json
 
 The `changeType`, `notificationUrl`, `resource`, and `expirationDateTime` properties are required. See [subscription resource type](../api-reference/v1.0/resources/subscription.md) for property definitions and values.
 
+The `resource` property specifies the resource that will be monitored for changes for instance, you can create a subscription to a specific mail folder: `me/mailFolders('inbox')/messages` or on behalf of a user given by an administrator  consent: `users/john.doe@onmicrosoft.com/mailFolders('inbox')/messages`.
+
 Although `clientState` is not required, you must include it to comply with our recommended notification handling process. Setting this property will allow you to confirm that notifications you receive originate from the Microsoft Graph service. For this reason, the value of the property should remain secret and known only to your application and the Microsoft Graph service.
 
 If successful, Microsoft Graph returns a `201 Created` code and a [subscription](../api-reference/v1.0/resources/subscription.md) object in the body.


### PR DESCRIPTION
Its not clear by the documentation how to subscribe to a given resource on behalf of a user in case of permissions given by administrator consent. Documentation provide examples that mention specific resource id or me/ resources. But in case of an administrator consent, you will be able to subscribe for notifications on a specific mailbox user, such as: john.doe@onmicrosoft.com.
In case that the resource isnt available you get an unclear error.