### PR TITLE
Updates in Planner overview and planner task

### DIFF
--- a/api-reference/beta/resources/planner_overview.md
+++ b/api-reference/beta/resources/planner_overview.md
@@ -55,7 +55,7 @@ The custom columns in the bucket task board are represented by [bucket](plannerb
 
 All the ordering is controlled by the principles identified in [Planner order hints](planner_order_hint_format.md).
 
-## <a name="delta">Track changes using delta query</a>
+## Track changes using delta query
 
 Planner's delta query supports querying objects that the user is subscribed to.
 
@@ -67,7 +67,7 @@ Users are subscribed to the following objects.
 | Plans                 | <ul><li>Shared with the user through the plan's **SharedWith** collection</li></ul>                                                                                                                     |
 | Buckets               | <ul><li>Contained in a plan shared with the user through the plan's **SharedWith** collection</li></ul>                                                                                                 |  |
 
-### <a name="objectcache">Populate the object cache for delta queries</a>
+### Populate the object cache for delta queries
 
 If you want to use the Planner delta query API, maintain a local cache of objects that the user is interested in observing in order to apply the changes from the delta response feed.
 

--- a/api-reference/beta/resources/plannertask.md
+++ b/api-reference/beta/resources/plannertask.md
@@ -16,7 +16,7 @@ The **plannerTask** resource represents a Planner task in Office 365. A Planner 
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|activeChecklistItemCount|Int32|Number of checklist items with value set to 'false', representing incomplete items.|
+|activeChecklistItemCount|Int32|Number of checklist items with value set to `false`, representing incomplete items.|
 |appliedCategories|[plannerAppliedCategories](plannerappliedcategories.md)|The categories to which the task has been applied. See [applied Categories](plannerappliedcategories.md) for possible values.|
 |assigneePriority|String|Hint used to order items of this type in a list view. The format is defined as outlined [here](planner_order_hint_format.md).|
 |assignments|[plannerAssignments](plannerassignments.md)|The set of assignees the task is assigned to.|
@@ -33,7 +33,7 @@ The **plannerTask** resource represents a Planner task in Office 365. A Planner 
 |orderHint|String|Hint used to order items of this type in a list view. The format is defined as outlined [here](planner_order_hint_format.md).|
 |percentComplete|Int32|Percentage of task completion. When set to `100`, the task is considered completed. |
 |planId|String|Plan ID to which the task belongs.|
-|previewType|string|This sets the type of preview that shows up on the task. Possible values are: `automatic`, `noPreview`, `checklist`, `description`, `reference`.|
+|previewType|String|This sets the type of preview that shows up on the task. Possible values are: `automatic`, `noPreview`, `checklist`, `description`, `reference`.|
 |referenceCount|Int32|Number of external references that exist on the task.|
 |startDateTime|DateTimeOffset|Date and time at which the task starts. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |title|String|Title of the task.|
@@ -76,7 +76,7 @@ Here is a JSON representation of the resource.
   "orderHint": "String",
   "percentComplete": 1024,
   "planId": "String",
-  "previewType": "string",
+  "previewType": "String",
   "referenceCount": 1024,
   "startDateTime": "String (timestamp)",
   "title": "String"


### PR DESCRIPTION
The reason I have removed the anchor tags around the titles in Planner overview is because it looks like these extra tags break the shortcuts displayed in the sidebar for that particular document (that's my theory at least). Like in this screenshot:

![image](https://user-images.githubusercontent.com/1096332/47573599-04692700-d93e-11e8-9eda-60c589914712.png)

As you can see the `Track changes using delta query` and `Populate the object cache for delta queries` titles are missing from the sidebar and they are the only ones that are wrapped in an `a` tag. 