### PR TITLE
Add missing scopes to a whole bunch of education ref docs.

### DIFF
--- a/api-reference/v1.0/api/educationclass_get.md
+++ b/api-reference/v1.0/api/educationclass_get.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationroot_list_classes.md
+++ b/api-reference/v1.0/api/educationroot_list_classes.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | EduRoster.ReadBasic |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationroot_list_schools.md
+++ b/api-reference/v1.0/api/educationroot_list_schools.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationschool_get.md
+++ b/api-reference/v1.0/api/educationschool_get.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationschool_list_classes.md
+++ b/api-reference/v1.0/api/educationschool_list_classes.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationuser_get.md
+++ b/api-reference/v1.0/api/educationuser_get.md
@@ -9,7 +9,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/educationuser_get_user.md
+++ b/api-reference/v1.0/api/educationuser_get_user.md
@@ -11,7 +11,7 @@ A combination of permissions is required to call this API. To learn more, includ
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  One from EduRoster.ReadBasic, EduRoster.Read, EduRoster.Write plus either Directory.Read.All or User.Read|
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All plus Directory.Read.All| 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All plus Directory.Read.All| 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationuser_list_classes.md
+++ b/api-reference/v1.0/api/educationuser_list_classes.md
@@ -11,7 +11,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/educationuser_list_schools.md
+++ b/api-reference/v1.0/api/educationuser_list_schools.md
@@ -11,7 +11,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduRoster.ReadBasic  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | EduRoster.Read.All, EduRoster.ReadWrite.All | 
+|Application | EduRoster.ReadBasic.All, EduRoster.Read.All, EduRoster.ReadWrite.All | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
Just simple changes to add the scopes to the permissions header block. Same scope in every file.