### PR TITLE
Moving master to live

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -36,6 +36,7 @@
   "skip_source_output_uploading": false,
   "need_preview_pull_request": false,
   "contribution_branch_mappings": {},
+  "git_repository_branch_open_to_public_contributors": "master",  
   "dependent_repositories": [
     {
       "path_to_root": "_themes",

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -2,7 +2,7 @@
     "redirections": [
         {
             "source_path": "concepts\\v1-overview.md",
-            "redirect_url": "graph/api/overview?view=graph-rest-1.0",
+            "redirect_url": "api/overview?view=graph-rest-1.0",
             "redirect_document_id": true
         },
         {


### PR DESCRIPTION
-  Changing the edit button on pages to point to master branch, not live.