### PR TITLE
Update Application Permissions

### DIFF
--- a/api-reference/v1.0/api/conversationthread-reply.md
+++ b/api-reference/v1.0/api/conversationthread-reply.md
@@ -15,7 +15,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | Group.ReadWrite.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Group.ReadWrite.All |
+|Application | Not supported. |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
This article currently states that Application permissions are supported (Groups.ReadWrite.All). This isn't accurate as calling this API returns the same error that we expect when calling the other Conversation/ConversationThread APIs return when attempting to leverage Application permissions:

    'code': 'ErrorAccessDenied',
    'message': 'Access is denied. Check credentials and try again.',

I'm able to reproduce this on demand in my test tenant, and at least one customer can confirm this behavior as well. I'm confident that PG doesn't support Application permissions for this API, rather it is an error with the documentation.