### PR TITLE
Fix Education docs to pass apidoctor tests. 

### DIFF
--- a/api-reference/beta/api/educationsynchronizationerrors-get.md
+++ b/api-reference/beta/api/educationsynchronizationerrors-get.md
@@ -55,7 +55,7 @@ The following is an example of the response.
 
 <!-- {
   "blockType": "response",
-  "@odata.type": "#microsoft.graph.educationSynchronizationError",
+  "@odata.type": "microsoft.graph.educationSynchronizationError",
   "isCollection": true
 } -->
 ```http

--- a/api-reference/beta/api/educationsynchronizationprofile-get.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-get.md
@@ -56,7 +56,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "ignored",
   "truncated": true,
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfile",
+  "@odata.type": "microsoft.graph.educationSynchronizationProfile",
 } -->
 ```http
 HTTP/1.1 200 OK
@@ -69,7 +69,7 @@ Content-length: 2487
     "state": "provisioned",
     "id": "86904b1e-c7d0-4ead-b13a-98f11fc400ee",
     "dataProvider": {
-        "@odata.type": "#microsoft.graph.educationCsvDataProvider",
+        "@odata.type": "microsoft.graph.educationCsvDataProvider",
         "customizations": {
             "student": {
                 "optionalPropertiesToSync": [
@@ -109,7 +109,7 @@ Content-length: 2487
         }
     },
     "identitySynchronizationConfiguration": {
-        "@odata.type": "#microsoft.graph.educationIdentityCreationConfiguration",
+        "@odata.type": "microsoft.graph.educationIdentityCreationConfiguration",
         "userDomains": [
             {
                 "appliesTo": "student",
@@ -124,14 +124,14 @@ Content-length: 2487
     "licensesToAssign": 
          [
             {
-                "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",
+                "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",
                 "appliesTo": "teacher",
                 "skuIds": [
                     "6fd2c87f-b296-42f0-b197-1e91e994b900"
                 ]
             },
             {
-                "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",
+                "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",
                 "appliesTo": "student",
                 "skuIds": [
                     "6fd2c87f-b296-42f0-b197-1e91e994b900"

--- a/api-reference/beta/api/educationsynchronizationprofile-list.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-list.md
@@ -59,7 +59,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "ignored",
   "truncated": true,
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfile",
+  "@odata.type": "microsoft.graph.educationSynchronizationProfile",
   "isCollection": true
 } -->
 ```http
@@ -74,7 +74,7 @@ Content-length: 3296
         "state": "provisioned",
         "id": "15e9b9fa-de85-492e-aa44-550c40de626e",
         "dataProvider": {
-            "@odata.type": "#microsoft.graph.educationCsvDataProvider",
+            "@odata.type": "microsoft.graph.educationCsvDataProvider",
             "customizations": {
                 "school": {
                     "optionalPropertiesToSync": [
@@ -128,7 +128,7 @@ Content-length: 3296
             }
         },
         "identitySynchronizationConfiguration": {
-            "@odata.type": "#microsoft.graph.educationIdentityCreationConfiguration",
+            "@odata.type": "microsoft.graph.educationIdentityCreationConfiguration",
             "userDomains": [
                 {
                     "appliesTo": "student",
@@ -142,14 +142,14 @@ Content-length: 3296
         },
         "licensesToAssign": [
             {
-                "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",                
+                "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",                
                 "appliesTo": "teacher",
                 "skuIds": [
                     "6fd2c87f-b296-42f0-b197-1e91e994b900"
                 ]
             },
             {
-                "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",
+                "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",
                 "appliesTo": "student",
                 "skuIds": [
                     "6fd2c87f-b296-42f0-b197-1e91e994b900"

--- a/api-reference/beta/api/educationsynchronizationprofile-post.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-post.md
@@ -53,7 +53,7 @@ Content-type: application/json
 {
     "displayName": "Test Profile",
     "dataProvider": {
-        "@odata.type": "#microsoft.graph.educationcsvdataprovider",
+        "@odata.type": "microsoft.graph.educationCsvDataProvider",
         "customizations": {
             "student": {
                 "optionalPropertiesToSync": [
@@ -64,7 +64,7 @@ Content-type: application/json
         }
     },
     "identitySynchronizationConfiguration": {
-        "@odata.type": "#microsoft.graph.educationidentitycreationconfiguration",
+        "@odata.type": "microsoft.graph.educationIdentitySynchronizationConfiguration",
         "userDomains": [
             {
                 "appliesTo": "student",
@@ -101,7 +101,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "ignored",
   "truncated": true,
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfile",
+  "@odata.type": "microsoft.graph.educationSynchronizationProfile",
 } -->
 ```http
 HTTP/1.1 201 Created
@@ -112,7 +112,7 @@ Content-type: application/json
     "state": "provisioning",
     "id": "86904b1e-c7d0-4ead-b13a-98f11fc400ee",
     "dataProvider": {
-        "@odata.type": "#microsoft.graph.educationCsvDataProvider",
+        "@odata.type": "microsoft.graph.educationCsvDataProvider",
         "customizations": {
             "student": {
                 "optionalPropertiesToSync": [
@@ -152,7 +152,7 @@ Content-type: application/json
         }
     },
     "identitySynchronizationConfiguration": {
-        "@odata.type": "#microsoft.graph.educationIdentityCreationConfiguration",
+        "@odata.type": "microsoft.graph.educationIdentityCreationConfiguration",
         "userDomains": [
             {
                 "appliesTo": "student",
@@ -166,14 +166,14 @@ Content-type: application/json
     },
     "licensesToAssign": [
         {
-            "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",
+            "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",
             "appliesTo": "teacher",
             "skuIds": [
                 "6fd2c87f-b296-42f0-b197-1e91e994b900"
             ]
         },
         {
-            "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",
+            "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",
             "appliesTo": "student",
             "skuIds": [
                 "6fd2c87f-b296-42f0-b197-1e91e994b900"

--- a/api-reference/beta/api/educationsynchronizationprofile-put.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-put.md
@@ -53,7 +53,7 @@ Content-type: application/json
 {
     "displayName": "Test Profile",
     "dataProvider": {
-        "@odata.type": "#microsoft.graph.educationcsvdataprovider",
+        "@odata.type": "microsoft.graph.educationcsvdataprovider",
         "customizations": {
             "student": {
                 "optionalPropertiesToSync": [
@@ -64,7 +64,7 @@ Content-type: application/json
         }
     },
     "identitySynchronizationConfiguration": {
-        "@odata.type": "#microsoft.graph.educationidentitycreationconfiguration",
+        "@odata.type": "microsoft.graph.educationidentitycreationconfiguration",
         "userDomains": [
             {
                 "appliesTo": "student",
@@ -101,7 +101,7 @@ Here is an example of the response.
 <!-- {
   "blockType": "ignored",
   "truncated": true,
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfile",
+  "@odata.type": "microsoft.graph.educationSynchronizationProfile",
 } -->
 ```http
 HTTP/1.1 202 Accepted
@@ -112,7 +112,7 @@ Content-type: application/json
     "state": "provisioning",
     "id": "86904b1e-c7d0-4ead-b13a-98f11fc400ee",
     "dataProvider": {
-        "@odata.type": "#microsoft.graph.educationCsvDataProvider",
+        "@odata.type": "microsoft.graph.educationCsvDataProvider",
         "customizations": {
             "student": {
                 "optionalPropertiesToSync": [
@@ -152,7 +152,7 @@ Content-type: application/json
         }
     },
     "identitySynchronizationConfiguration": {
-        "@odata.type": "#microsoft.graph.educationIdentityCreationConfiguration",
+        "@odata.type": "microsoft.graph.educationIdentityCreationConfiguration",
         "userDomains": [
             {
                 "appliesTo": "student",
@@ -166,14 +166,14 @@ Content-type: application/json
     },
     "licensesToAssign": [
         {
-            "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",                
+            "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",                
             "appliesTo": "teacher",
             "skuIds": [
                 "6fd2c87f-b296-42f0-b197-1e91e994b900"
             ]
         },
         {
-            "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment",                
+            "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment",                
             "appliesTo": "student",
             "skuIds": [
                 "6fd2c87f-b296-42f0-b197-1e91e994b900"

--- a/api-reference/beta/api/educationsynchronizationprofilestatus-get.md
+++ b/api-reference/beta/api/educationsynchronizationprofilestatus-get.md
@@ -55,7 +55,7 @@ The following is an example of the response.
 
 <!-- {
   "blockType": "response",
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfileStatus",
+  "@odata.type": "microsoft.graph.educationSynchronizationProfileStatus",
 } -->
 ```http
 HTTP/1.1 200 OK

--- a/api-reference/beta/resources/educationassignmentclassrecipient.md
+++ b/api-reference/beta/resources/educationassignmentclassrecipient.md
@@ -19,6 +19,21 @@ This resource is a subclass of [educationAssignmentRecipient](educationassignmen
 
 None.
 
+
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationAssignmentClassRecipient"
+}-->
+
+```json
+{
+
+}
+
+```
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->
 <!-- {

--- a/api-reference/beta/resources/educationassignmentgradetype.md
+++ b/api-reference/beta/resources/educationassignmentgradetype.md
@@ -19,6 +19,21 @@ This superclass can not be used directly in the assignment property. It exists t
 
 None.
 
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationAssignmentGradeType"
+}-->
+
+```json
+{
+
+}
+
+```
+
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->
 <!-- {

--- a/api-reference/beta/resources/educationassignmentrecipient.md
+++ b/api-reference/beta/resources/educationassignmentrecipient.md
@@ -20,6 +20,22 @@ The [educationAssignmentClassRecipient](educationassignmentclassrecipient.md) re
 ## Properties
 None.
 
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationAssignmentRecipient"
+}-->
+
+```json
+{
+
+}
+
+```
+
+
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->
 <!-- {

--- a/api-reference/beta/resources/educationclass.md
+++ b/api-reference/beta/resources/educationclass.md
@@ -77,7 +77,7 @@ The following is a JSON representation of the resource.
   "externalName": "String",
   "externalSource": "string",
   "mailNickname": "String",
-  "term": {"@odata.type": "microsoft.graph.education.term"}
+  "term": {"@odata.type": "microsoft.graph.educationTerm"}
 }
 
 ```

--- a/api-reference/beta/resources/educationcsvdataprovider.md
+++ b/api-reference/beta/resources/educationcsvdataprovider.md
@@ -27,12 +27,12 @@ Derived from [educationSynchronizationDataProvider](educationsynchronizationdata
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationCsvDataProvider"
+  "@odata.type": "microsoft.graph.educationCsvDataProvider"
 }-->
 
 ```json
 {
-    "@odata.type": "#microsoft.graph.educationCsvDataProvider",
+    "@odata.type": "microsoft.graph.educationCsvDataProvider",
     "customizations": { "@odata.type": "microsoft.graph.educationSynchronizationCustomizations" }
 }
 ```

--- a/api-reference/beta/resources/educationidentitycreationconfiguration.md
+++ b/api-reference/beta/resources/educationidentitycreationconfiguration.md
@@ -34,10 +34,10 @@ Derived from [educationIdentitySynchronizationConfiguration](educationidentitysy
 
 ```json
 {
-    "@odata.type": "#microsoft.graph.educationIdentityCreationConfiguration",
+    "@odata.type": "microsoft.graph.educationIdentityCreationConfiguration",
     "userDomains": [
         {
-            "@odata.type": "#microsoft.graph.educationIdentityDomain",
+            "@odata.type": "microsoft.graph.educationIdentityDomain",
         }
     ]
 }

--- a/api-reference/beta/resources/educationidentitydomain.md
+++ b/api-reference/beta/resources/educationidentitydomain.md
@@ -25,12 +25,12 @@ Represents the mapping between an education user type and the domain the user's 
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationIdentityDomain"
+  "@odata.type": "microsoft.graph.educationIdentityDomain"
 }-->
 
 ```json
 {
-    "appliesTo": {"@odata.type": "#microsoft.graph.educationUserRole"},
+    "appliesTo": {"@odata.type": "microsoft.graph.educationUserRole"},
     "name": "String"
 }
 ```

--- a/api-reference/beta/resources/educationidentitymatchingconfiguration.md
+++ b/api-reference/beta/resources/educationidentitymatchingconfiguration.md
@@ -18,7 +18,7 @@ Defines the settings for matching school data profile identities. These identiti
 
 | Property | Type | Description |
 |:-|:-|:-|
-| **matchingOptions** | [educationIdentityMatchingOptions](educationidentitymatchingoptions.md) collection | Mapping between the user account and the options to use to uniquely identify the user to update. |
+| **matchingOptions** | [microsoft.graph.educationIdentityMatchingOptions](educationidentitymatchingoptions.md) collection | Mapping between the user account and the options to use to uniquely identify the user to update. |
 
 ## JSON representation
 <!-- {
@@ -26,15 +26,15 @@ Defines the settings for matching school data profile identities. These identiti
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationIdentityMatchingConfiguration"
+  "@odata.type": "microsoft.graph.educationIdentityMatchingConfiguration"
 }-->
 
 ```json
 {
-    "@odata.type": "#microsoft.graph.educationIdentityMatchingConfiguration",
+    "@odata.type": "microsoft.graph.educationIdentityMatchingConfiguration",
     "matchingOptions": [
         {
-            "appliesTo": {"@odata.type": "#microsoft.graph.educationUserRole"},
+            "appliesTo": {"@odata.type": "microsoft.graph.educationUserRole"},
             "sourcePropertyName": "String",
             "targetPropertyName": "String",
             "targetDomain": "String"

--- a/api-reference/beta/resources/educationidentitymatchingoptions.md
+++ b/api-reference/beta/resources/educationidentitymatchingoptions.md
@@ -27,12 +27,12 @@ Provides a mapping between a source property and a target property for matching 
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationIdentityMatchingOptions"
+  "@odata.type": "microsoft.graph.educationIdentityMatchingOptions"
 }-->
 
 ```json
 {
-    "appliesTo": {"@odata.type": "#microsoft.graph.educationUserRole"},
+    "appliesTo": {"@odata.type": "microsoft.graph.educationUserRole"},
     "sourcePropertyName": "String",
     "targetPropertyName": "String",
     "targetDomain": "String"

--- a/api-reference/beta/resources/educationidentitysynchronizationconfiguration.md
+++ b/api-reference/beta/resources/educationidentitysynchronizationconfiguration.md
@@ -17,3 +17,16 @@ Abstract base class for all school data profile identity synchronization configu
 |:-|:-|
 | [**educationIdentityMatchingConfiguration**](educationidentitymatchingconfiguration.md) | Use this type to match existing user accounts in Azure Active Directory (Azure AD). |
 | [**educationIdentityCreationConfiguration**](educationidentitycreationconfiguration.md) | Use this type to create new user accounts in Azure AD. |
+
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationIdentitySynchronizationConfiguration"
+}-->
+
+```json
+{
+}
+```

--- a/api-reference/beta/resources/educationonerosterapidataprovider.md
+++ b/api-reference/beta/resources/educationonerosterapidataprovider.md
@@ -21,8 +21,8 @@ Derived from [educationSynchronizationDataProvider](educationsynchronizationdata
 | **connectionUrl** | String | The connection URL to the OneRoster instance. |
 | **schoolsIds** | String collection |  The list of school sourcedIds to sync. |
 | **providerName** | String | The OneRoster Service Provider name as defined by the [OneRoster specification](https://www.imsglobal.org/oneroster-v11-final-best-practice-and-implementation-guide#AppA). |
-| **connectionSettings** | [educationSynchronizationConnectionSettings](educationsynchronizationconnectionsettings.md) | Connection settings for the OneRoster instance. Should be of type [educationSynchronizationOAuth1ConnectionSettings](educationsynchronizationoauth1connectionsettings.md) or [educationSynchronizationOAuth2ClientCredentialsConnectionSettings](educationsynchronizationoauth2clientcredentialsconnectionsettings.md). |
-| **customizations** | [educationSynchronizationCustomizations](educationsynchronizationcustomizations.md) | Optional customization to be applied to the synchronization profile.|
+| **connectionSettings** | [microsoft.graph.educationSynchronizationConnectionSettings](educationsynchronizationconnectionsettings.md) | Connection settings for the OneRoster instance. Should be of type [microsoft.graph.educationSynchronizationOAuth1ConnectionSettings](educationsynchronizationoauth1connectionsettings.md) or [microsoft.graph.educationSynchronizationOAuth2ClientCredentialsConnectionSettings](educationsynchronizationoauth2clientcredentialsconnectionsettings.md). |
+| **customizations** | [microsoft.graph.educationSynchronizationCustomizations](educationsynchronizationcustomizations.md) | Optional customization to be applied to the synchronization profile.|
 
 ## JSON representation
 <!-- {
@@ -30,19 +30,19 @@ Derived from [educationSynchronizationDataProvider](educationsynchronizationdata
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationoneRosterApiDataProvider"
+  "@odata.type": "microsoft.graph.educationoneRosterApiDataProvider"
 }-->
 
 ```json
 {
-    "@odata.type": "#microsoft.graph.educationoneRosterApiDataProvider",
+    "@odata.type": "microsoft.graph.educationoneRosterApiDataProvider",
     "connectionUrl": "String",
     "providerName": "String",
     "schoolsIds": [
         "String"
     ],
     "connectionSettings": {
-        "@odata.type": "#microsoft.graph.educationSynchronizationOAuth1ConnectionSettings",
+        "@odata.type": "microsoft.graph.educationSynchronizationOAuth1ConnectionSettings",
         "clientId": "String",
         "clientSecret": "String",
     },

--- a/api-reference/beta/resources/educationpowerschooldataprovider.md
+++ b/api-reference/beta/resources/educationpowerschooldataprovider.md
@@ -32,12 +32,12 @@ Derived from [educationSynchronizationDataProvider](educationsynchronizationdata
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationPowerSchoolDataProvider"
+  "@odata.type": "microsoft.graph.educationPowerSchoolDataProvider"
 }-->
 
 ```json
 {
-    "@odata.type": "#microsoft.graph.educationPowerSchoolDataProvider",
+    "@odata.type": "microsoft.graph.educationPowerSchoolDataProvider",
     "connectionUrl": "String",
     "clientId": "String",
     "clientSecret": "String",

--- a/api-reference/beta/resources/educationstudent.md
+++ b/api-reference/beta/resources/educationstudent.md
@@ -17,7 +17,7 @@ Additional information added to an [educationUser](educationuser.md) that is pre
 |:---------------|:--------|:----------|
 |birthDate|Date| Birth date of the student.|
 |externalId|String| ID of the student in the source system.|
-|gender|`educationGender enumeration`| Possible values are: `female`, `male`, `other`, `unkownFutureValue`.|
+|gender|educationGender| Possible values are: `female`, `male`, `other`, `unkownFutureValue`.|
 |grade|String|Current grade level of the student.|
 |graduationYear|String| Year the student is graduating from the school.|
 |studentNumber|String| Student Number.|

--- a/api-reference/beta/resources/educationsubmissionrecipient.md
+++ b/api-reference/beta/resources/educationsubmissionrecipient.md
@@ -16,6 +16,19 @@ Abstract class that represents the different sets of users to whom a submission 
 ## Properties
 None.
 
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationSubmissionRecipient"
+}-->
+
+```json
+{
+}
+```
+
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->
 <!-- {

--- a/api-reference/beta/resources/educationsynchronizationcustomization.md
+++ b/api-reference/beta/resources/educationsynchronizationcustomization.md
@@ -30,7 +30,7 @@ Provides settings for customizing the school data profile synchronization of the
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationCustomization"
+  "@odata.type": "microsoft.graph.educationSynchronizationCustomization"
 }-->
 
 ```json

--- a/api-reference/beta/resources/educationsynchronizationcustomizations.md
+++ b/api-reference/beta/resources/educationsynchronizationcustomizations.md
@@ -36,7 +36,7 @@ This resource is member of the following data providers:
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationCustomizations"
+  "@odata.type": "microsoft.graph.educationSynchronizationCustomizations"
 }-->
 
 ```json

--- a/api-reference/beta/resources/educationsynchronizationdataprovider.md
+++ b/api-reference/beta/resources/educationsynchronizationdataprovider.md
@@ -24,3 +24,18 @@ Represents the source SIS schema. This allows the system to know how to map the 
 ## Properties
 
 No properties are exposed by this type.
+
+
+
+<!-- {
+  "blockType": "resource",
+  "optionalProperties": [
+
+  ],
+  "@odata.type": "microsoft.graph.educationSynchronizationDataProvider "
+}-->
+
+```json
+{
+}
+```

--- a/api-reference/beta/resources/educationsynchronizationerror.md
+++ b/api-reference/beta/resources/educationsynchronizationerror.md
@@ -35,7 +35,7 @@ Represents an error during school data profile validation and/or sync. A unique 
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationError"
+  "@odata.type": "microsoft.graph.educationSynchronizationError"
 }-->
 
 ```json

--- a/api-reference/beta/resources/educationsynchronizationlicenseassignment.md
+++ b/api-reference/beta/resources/educationsynchronizationlicenseassignment.md
@@ -25,12 +25,12 @@ Represents the license information to assign to user accounts. The resource will
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationLicenseAssignment"
+  "@odata.type": "microsoft.graph.educationSynchronizationLicenseAssignment"
 }-->
 
 ```json
 {
-    "appliesTo": {"@odata.type": "#microsoft.graph.educationUserRole"},
+    "appliesTo": {"@odata.type": "microsoft.graph.educationUserRole"},
     "skuIds": ["String"]
 }
 ```

--- a/api-reference/beta/resources/educationsynchronizationoauth1connectionsettings.md
+++ b/api-reference/beta/resources/educationsynchronizationoauth1connectionsettings.md
@@ -12,7 +12,7 @@ ms.prod: "education"
 
 When OAuth1 is to be used to connect to the data provider, this connection settings type should be used to set up the profile.
 
-Derived from [educationSynchronizationConnectionSettings](educationsynchronizationconnectionsettings.md).
+Derived from [microsoft.graph.educationSynchronizationConnectionSettings](educationsynchronizationconnectionsettings.md).
 
 ## Properties
 
@@ -21,12 +21,12 @@ No additional properties are exposed by this type.
 ## JSON representation
 <!-- {
   "blockType": "resource",
-  "@odata.type": "#microsoft.graph.educationSynchronizationOAuth1ConnectionSettings"
+  "@odata.type": "microsoft.graph.educationSynchronizationOAuth1ConnectionSettings"
 }-->
 
 ```json
-"connectionSettings": {
-    "@odata.type": "#microsoft.graph.educationSynchronizationOAuth1ConnectionSettings",
+{
+    "@odata.type": "microsoft.graph.educationSynchronizationOAuth1ConnectionSettings",
     "clientId": "String",
     "clientSecret": "String"
 }

--- a/api-reference/beta/resources/educationsynchronizationoauth2clientcredentialsconnectionsettings.md
+++ b/api-reference/beta/resources/educationsynchronizationoauth2clientcredentialsconnectionsettings.md
@@ -28,7 +28,7 @@ Derived from [educationSynchronizationConnectionSettings](educationsynchronizati
 }-->
 
 ```json
-"connectionSettings": {
+{
     "@odata.type": "#microsoft.graph.educationSynchronizationOAuth2ClientCredentialsConnectionSettings",
     "clientId": "String",
     "clientSecret": "String",

--- a/api-reference/beta/resources/educationsynchronizationprofile.md
+++ b/api-reference/beta/resources/educationsynchronizationprofile.md
@@ -34,9 +34,9 @@ Represents a set of configurations used to synchronize education entities and ro
 |:-|:-|:-|
 | **displayName** | string |  Name of the configuration profile for syncing identities.         |
 | **dataProvider** | [educationSynchronizationDataProvider](educationsynchronizationdataprovider.md) |  The data provider used for the profile.         |
-| **identitysynchronizationconfiguration** | [educationIdentitySynchronizationConfiguration](educationidentitysynchronizationconfiguration.md) | Identity [creation](educationidentitycreationconfiguration.md) or [matching](educationidentitymatchingconfiguration.md) configuration .        |
+| **identitySynchronizationConfiguration** | [educationIdentitySynchronizationConfiguration](educationidentitysynchronizationconfiguration.md) | Identity [creation](educationidentitycreationconfiguration.md) or [matching](educationidentitymatchingconfiguration.md) configuration .        |
 | **licensesToAssign** | [educationSynchronizationLicenseAssignment](educationsynchronizationlicenseassignment.md) collection|  License setup configuration.        |
-| **state** | string |  The state of the profile. Possible values are: `provisioning`, `provisioned`, `provisioningFailed`, `deleting`, `deletionFailed`.          |
+| **state** | educationSynchronizationProfileState |  The state of the profile. Possible values are: `provisioning`, `provisioned`, `provisioningFailed`, `deleting`, `deletionFailed`.          |
 
 ## Relationships
 
@@ -53,7 +53,7 @@ The following is a JSON representation of the **educationSynchronizationProfile*
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfile"
+  "@odata.type": "microsoft.graph.educationSynchronizationProfile"
 }-->
 
 ```json
@@ -62,8 +62,8 @@ The following is a JSON representation of the **educationSynchronizationProfile*
     "state": { "@odata.type": "microsoft.graph.educationSynchronizationProfileState" },
     "profileStatus": {"@odata.type": "microsoft.graph.educationSynchronizationProfileStatus"},
     "errors": [{"@odata.type": "microsoft.graph.educationSynchronizationProfileStatus" }],
-    "dataProvider": { "@odata.type": "#microsoft.graph.educationcsvdataprovider" },
-    "identitySynchronizationConfiguration": { "@odata.type": "#microsoft.graph.educationIdentitySynchronizationConfiguration" },
+    "dataProvider": { "@odata.type": "microsoft.graph.educationCsvDataProvider" },
+    "identitySynchronizationConfiguration": { "@odata.type": "microsoft.graph.educationIdentitySynchronizationConfiguration" },
     "licensesToAssign": [{"@odata.type":"microsoft.graph.educationSynchronizationLicenseAssignment"}],
     "handleSpecialCharacterConstraint": "Boolean"
 }

--- a/api-reference/beta/resources/educationsynchronizationprofilestatus.md
+++ b/api-reference/beta/resources/educationsynchronizationprofilestatus.md
@@ -24,7 +24,7 @@ Represents the synchronization status of a school data [synchronization profile]
 
 | Property | Type | Description |
 |:-|:-|:-|
-| **status** | string | The status of a sync. Possible values are: `paused`, `inProgress`, `success`, `error`, `quarantined`, `validationError`. |
+| **status** | educationSynchronizationStatus | The status of a sync. Possible values are: `paused`, `inProgress`, `success`, `error`, `quarantined`, `validationError`. |
 | **lastSynchronizationDateTime** | DateTimeOffset | Represents the time when most recent changes have been observed in the directory.  |
 
 ## JSON representation
@@ -33,7 +33,7 @@ Represents the synchronization status of a school data [synchronization profile]
   "optionalProperties": [
 
   ],
-  "@odata.type": "#microsoft.graph.educationSynchronizationProfileStatus"
+  "@odata.type": "microsoft.graph.educationSynchronizationProfileStatus"
 }-->
 
 ```json

--- a/api-reference/beta/resources/educationuser.md
+++ b/api-reference/beta/resources/educationuser.md
@@ -44,10 +44,10 @@ This object provides a targeted subset of properties from the core [user](user.m
 |middleName| String | The middle name of user.|
 |mobilePhone|String|The primary cellular telephone number for the user.|
 |passwordPolicies|String|Specifies password policies for the user. This value is an enumeration with one possible value being “DisableStrongPassword”, which allows weaker passwords than the default policy to be specified. “DisablePasswordExpiration” can also be specified. The two can be specified together; for example: "DisablePasswordExpiration, DisableStrongPassword".|
-|passwordProfile|[PasswordProfile](passwordprofile.md)|Specifies the password profile for the user. The profile contains the user’s password. This property is required when a user is created. The password in the profile must satisfy minimum requirements as specified by the **passwordPolicies** property. By default, a strong password is required.|
+|passwordProfile|[passwordProfile](passwordprofile.md)|Specifies the password profile for the user. The profile contains the user’s password. This property is required when a user is created. The password in the profile must satisfy minimum requirements as specified by the **passwordPolicies** property. By default, a strong password is required.|
 |preferredLanguage|String|The preferred language for the user. Should follow ISO 639-1 Code; for example, "en-US".|
 |primaryRole|string| Default role for a user. The user's role might be different in an individual class. Possible values are: `student`, `teacher`, `enum_sentinel`. Supports $filter.|
-|provisionedPlans|[ProvisionedPlan](provisionedplan.md) collection|The plans that are provisioned for the user. Read-only. Not nullable. |
+|provisionedPlans|[provisionedPlan](provisionedplan.md) collection|The plans that are provisioned for the user. Read-only. Not nullable. |
 |residenceAddress|[physicalAddress](physicaladdress.md)| Address where user lives.|
 |student|[educationStudent](educationstudent.md)| If the primary role is student, this block will contain student specific data.|
 |surname|String|The user's surname (family name or last name). Supports $filter.|

--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -1,0 +1,639 @@
+---
+title: "timeZoneStandard values"
+description: " Value"
+---
+
+
+### timeZoneStandard values
+
+| Value
+|:-----------------
+| windows
+| iana
+
+
+### freeBusyStatus values
+
+| Member            |Value
+|:------------------|:-------
+| free              | 0
+| tentative         | 1
+| busy              | 2
+| oof               | 3
+| workingElsewhere  | 4
+| unknown           | -1
+
+
+### attendeeType values
+
+| Value
+|:-------------------------
+| required
+| optional
+| resource
+
+
+### externalAudienceScope values
+
+| Value
+|:-------------------------
+| none
+| contactsOnly
+| all
+
+
+### automaticRepliesStatus values
+
+| Value
+|:-------------------------
+| disabled
+| alwaysEnabled
+| scheduled
+
+
+### calendarColor values
+
+| Member     | Value
+|:-----------|:----------
+| auto       | -1
+| lightBlue  | 0
+| lightGreen | 1
+| lightOrange| 2
+| lightGray  | 3
+| lightYellow| 4
+| lightTeal  | 5
+| lightPink  | 6
+| lightBrown | 7
+| lightRed   | 8
+| maxColor   | 9
+
+
+### educationSynchronizationProfileState values
+
+| Member     | Value
+|:-----------|:----------
+| deleting          | 2
+| deletionFailed    | 3
+| provisioningFailed | 5
+| provisioned        | 6
+| provisioning       | 7
+| unknownFutureValue | 8
+
+
+### educationSynchronizationStatus values
+
+| Member     | Value
+|:-----------|:----------
+| paused          | 0
+| inProgress    | 1
+| success | 2
+| error        | 3
+| validationError | 4
+| quarantined       | 5
+| unknownFutureValue | 6
+
+### educationExternalSource values
+
+| Value
+|:-------------------------
+| sis
+| manual
+| unknownFutureValue
+
+
+### educationGender values
+
+| Value
+|:-------------------------
+| female
+| male
+| other
+| unknownFutureValue
+
+
+### eventType values
+
+| Value
+|:-------------------------
+| singleInstance
+| occurrence
+| exception
+| seriesMaster
+
+
+### sensitivity values
+
+| Value
+|:-------------------------
+| normal
+| personal
+| private
+| confidential
+
+
+### importance values
+
+| Value
+|:-------------------------
+| low
+| normal
+| high
+
+
+### educationUserRole values
+| Value
+|:---------------------
+| student
+| teacher
+| none
+| unknownFutureValue
+
+
+### meetingMessageType values
+
+| Value
+|:-----------------
+| none
+| meetingRequest
+| meetingCancelled
+| meetingAccepted
+| meetingTentativelyAccepted
+| meetingDeclined
+
+
+### followupFlagStatus values
+
+| Value
+|:-------------------------
+| notFlagged
+| complete
+| flagged
+
+
+### inferenceClassificationType values
+
+| Value
+|:-----------------
+| focused
+| other
+
+
+### iosNotificationAlertType values
+
+| Value
+|:-------------------------
+| deviceDefault
+| banner
+| modal
+| none
+
+### deviceEnrollmentFailureReason values
+
+| Value
+|:-------------
+| unknown
+| authentication
+| authorization
+| accountValidation
+| userValidation
+| deviceNotSupported
+| inMaintenance
+| badRequest
+| featureNotSupported
+| enrollmentRestrictionsEnforced
+| clientDisconnected
+
+
+### bodyType values
+| Value
+|:---------
+| text
+| html
+
+
+### locationType values
+
+| Value
+|:-------------------------
+| default
+| conferenceRoom
+| homeAddress
+| businessAddress
+| geoCoordinates
+| streetAddress
+| hotel
+| restaurant
+| localBusiness
+| postalAddress
+
+### locationUniqueIdType values
+
+| Value
+|:-------------------------
+| unknown
+| locationStore
+| directory
+| private
+| bing
+
+
+### messageActionFlag values
+
+| Value
+|:-------------------------
+| any
+| call
+| doNotForward
+| followUp
+| fyi
+| forward
+| noResponseNecessary
+| read
+| reply
+| replyToAll
+| review
+
+
+### onenoteUserRole values
+
+| Member      | Value
+|:------------|:------------
+| Owner       | 0
+| Contributor | 1
+| Reader      | 2
+| None        | -1
+
+
+### operationStatus values
+
+| Value
+|:-----------------
+| NotStarted
+| Running
+| Completed
+| Failed
+
+
+### onenotePatchActionType values
+
+| Value
+|:-------------------------
+| Replace
+| Append
+| Delete
+| Insert
+| Prepend
+
+### onenotePatchInsertPosition values
+
+| Value
+|:-------------------------
+| After
+| Before
+
+
+### phoneType values
+
+| Value
+|:-------------------------
+| home
+| business
+| mobile
+| other
+| assistant
+| homeFax
+| businessFax
+| otherFax
+| pager
+| radio
+
+
+### plannerPreviewType values
+
+| Value
+|:-------------------------
+| automatic
+| noPreview
+| checklist
+| description
+| reference
+
+
+### status values
+
+| Value
+|:-----------------
+| active
+| updated
+| deleted
+| ignored
+| unknownFutureValue
+
+
+### weekIndex values
+
+| Value
+|:-------------------------
+| first
+| second
+| third
+| fourth
+| last
+
+
+### dayOfWeek values
+
+| Value
+|:-------------------------
+| sunday
+| monday
+| tuesday
+| wednesday
+| thursday
+| friday
+| saturday
+
+### recurrencePatternType values
+
+| Value
+|:-------------------------
+| daily
+| weekly
+| absoluteMonthly
+| relativeMonthly
+| absoluteYearly
+| relativeYearly
+
+
+### recurrenceRangeType values
+
+| Value
+|:-------------------------
+| endDate
+| noEnd
+| numbered
+
+
+### onenoteSourceService values
+| Value
+|:---------------------
+| Unknown
+| OneDrive
+| OneDriveForBusiness
+| OnPremOneDriveForBusiness
+
+
+### responseType values
+
+| Value
+|:-------------------------
+| none
+| organizer
+| tentativelyAccepted
+| accepted
+| declined
+| notResponded
+
+
+### activityDomain values
+
+| Value
+|:-------------------------
+| unknown
+| work
+| personal
+| unrestricted
+
+
+### websiteType values
+
+| Value
+|:-------------------------
+| other
+| home
+| work
+| blog
+| profile
+
+
+### categoryColor values
+
+| Member   |Value    
+|:---------|:--------
+| none     | -1      
+| preset0  | 0       
+| preset1  | 1       
+| preset2  | 2       
+| preset3  | 3       
+| preset4  | 4       
+| preset5  | 5       
+| preset6  | 6       
+| preset7  | 7       
+| preset8  | 8       
+| preset9  | 9       
+| preset10 | 10      
+| preset11 | 11      
+| preset12 | 12      
+| preset13 | 13      
+| preset14 | 14      
+| preset15 | 15      
+| preset16 | 16      
+| preset17 | 17      
+| preset18 | 18      
+| preset19 | 19      
+| preset20 | 20      
+| preset21 | 21      
+| preset22 | 22      
+| preset23 | 23      
+| preset24 | 24      
+
+# Security API enums
+
+# alertFeedback enum type
+
+Possible feedback values on the alert provided by an analyst.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown.|
+|truePositive|1|Alert is true-positive.|
+|falsePositive|2| Alert is false-positive.|
+|benignPositive|3| Alert is benign-positive.|
+
+# fileHashType enum type
+
+Enum for file hash types.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown type.|
+|sha1|1|SHA1 hash type.|
+|sha256|2| SHA256 hash type.|
+|md5|3| MD5 hash type.|
+|authenticodeHash256|4| AuthenticodeHash256 hash type.|
+|lsHash|5| LsHash hash type.|
+|ctph|6| CTPH hash type.|
+|peSha1|7| PESHA1 hash type.|
+|peSha256|8| PESHA256 hash type.|
+
+# connectionDirection enum type
+
+Enum for the direction of the network connection (inbound/outbound).
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown connection.|
+|inbound|1|Inbound connection.|
+|outbound|2| Outbound connection.|
+
+# connectionStatus enum type
+
+Enum for the status of connections.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown connection status.|
+|attempted|1|Connection attempted.|
+|succeeded|2| Connection succeeded.|
+|blocked|3| Connection blocked.|
+|failed|4| Connection failed.|
+
+# processIntegrityLevel enum type
+
+Possible integrity level values of the process.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown.|
+|untrusted|10|Integrity level is Untrusted.|
+|low|20| Integrity level is Low.|
+|medium|30| Integrity level is Medium.|
+|high|40| Integrity level is High.|
+|system|50| Integrity level is System.|
+
+# registryHive enum type
+
+Enum for registry hives as defined by [https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-hives](https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-hives).
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown hive.|
+|currentConfig|1|HKEY_CURRENT_CONFIG hive.|
+|currentUser|2| HKEY_CURRENT_USER hive.|
+|localMachineSam|3| HKEY_LOCAL_MACHINE\SAM hive.|
+|localMachineSamSoftware|4| HKEY_LOCAL_MACHINE\Software hive.|
+|localMachineSystem|5| HKEY_LOCAL_MACHINE\System hive.|
+|usersDefault|6| HKEY_USERS\\.DEFAULT hive.|
+
+# registryOperation enum type
+
+Operation that changed the registry key name and/or value.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown registry value type.|
+|create|1|Create registry.|
+|modify|2|Modify registry.|
+|delete|3|Delete registry.|
+
+# registryValueType enum type
+
+Enum for registry value types as defined by [https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-value-types](https://docs.microsoft.com/en-us/windows/desktop/sysinfo/registry-value-types).
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown registry value type.|
+|binary|1|REG_BINARY registry value type.|
+|dword|2| REG_DWORD registry value type.|
+|dwordLittleEndian|3| REG_DWORD_LITTLE_ENDIAN registry value type.|
+|dwordBigEndian|4| REG_DWORD_BIG_ENDIAN registry value type.|
+|expandSz|5| REG_EXPAND_SZ registry value type.|
+|link|6| REG_LINK registry value type.|
+|multiSz|7| REG_MULTI_SZ registry value type.|
+|none|8| REG_NONE registry value type.|
+|qword|9| REG_QWORD registry value type.|
+|qwordlittleEndian|10| REG_QWORD_LITTLE_ENDIAN registry value type.|
+|sz|11| REG_SZ registry value type.|
+
+# alertSeverity enum type
+
+Enum for severity of alerts.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Severity is unknown.|
+|informational|1|Severity is only for information.|
+|low|2| Severity is low.|
+|medium|3| Severity is medium.|
+|high|4| Severity is high.|
+
+# alertStatus enum type
+
+Possible values of an Alert lifecycle status (stage).
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown status.|
+|newAlert|10| Alert is new.|
+|inProgress|20|Alert is in progress.|
+|resolved|30|Alert is resolved.|
+
+# emailRole enum type
+
+Possible values for email roles.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|0|Unknown Role.|
+|sender|1|Sender of the email.|
+|recipient|2|Recipient of the email.|
+
+# logonType enum type
+
+Possible values for the method of user signin.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|-1|Unknown.|
+|interactive|0|Logon is interactive.|
+|remoteInteractive|1| Logon is remote interactive.|
+|network|2| Logon is network.|
+|batch|3| Logon is batch.|
+|service|4| Logon is service.|
+
+# userAccountSecurityType enum type
+
+Possible values for user account types (group membership), per Windows definition.
+
+## Members
+
+|Member|Value|Description|
+|:---|:---|:---|
+|unknown|-1|Unknown.|
+|standard|0|Member of Standard Users group.|
+|power|1| Member of Power Users group.|
+|administrator|2| Member of Administrators group.|


### PR DESCRIPTION
Remove inconsistent resource naming in education docs, especially regarding the use of '#' in resource names.
Copy enums file from v1.0
Introduce missing education resources.
Correct json errors.