### PR TITLE
Update teamstab-update.md

### DIFF
--- a/api-reference/v1.0/api/teamstab-update.md
+++ b/api-reference/v1.0/api/teamstab-update.md
@@ -53,7 +53,7 @@ Content-type: application/json
 Content-length: 211
 
 {
-  "name": "My Contoso Tab - updated"
+  "displayName": "My Contoso Tab - updated"
 }
 ```
 #### Response
@@ -63,7 +63,7 @@ Content-type: application/json
 
 {
   "id": "tabId",
-  "name": "My Contoso Tab - updated",
+  "displayName": "My Contoso Tab - updated",
   "teamsAppId": "06805b9e-77e3-4b93-ac81-525eb87513b8",
   "configuration": {
     "entityId": "2DCA2E6C7A10415CAF6B8AB6661B3154",


### PR DESCRIPTION
Fixed property "name" to "displayName" for v1.0 endpoint update Teams tab operation. The property is called "name" only in the beta endpoint.