### PR TITLE
Update team-post.md

### DIFF
--- a/api-reference/beta/api/team-post.md
+++ b/api-reference/beta/api/team-post.md
@@ -114,7 +114,7 @@ The following is a request with a full payload. The client can override values i
 POST https://graph.microsoft.com/beta/teams
 Content-Type: application/json
 {
-    "template@odata.bind": "https://graph.microsoft.com/beta/teamsTemplates('standard')",
+    "template@odata.bind": "https://graph.microsoft.com/beta/teamsTemplates/standard",
     "visibility": "Private",
     "displayName": "Sample Engineering Team",
     "description": "This is a sample engineering team, used to showcase the range of properties supported by this API",


### PR DESCRIPTION
link in the wronge format, leaving it liek it was will give a error. Changed to correct link.