### PR TITLE
Fix invalid invitation example

### DIFF
--- a/api-reference/v1.0/api/driveitem-invite.md
+++ b/api-reference/v1.0/api/driveitem-invite.md
@@ -43,7 +43,7 @@ In the request body, provide a JSON object with the following parameters.
 {
   "requireSignIn": false,
   "sendInvitation": false,
-  "roles": [ "read | write"],
+  "roles": [ "read"],
   "recipients": [
     { "@odata.type": "microsoft.graph.driveRecipient" },
     { "@odata.type": "microsoft.graph.driveRecipient" }


### PR DESCRIPTION
"read | write" is not a valid role