### PR TITLE
Images only accept data-url or binary part

### DIFF
--- a/concepts/onenote-update-page.md
+++ b/concepts/onenote-update-page.md
@@ -59,7 +59,7 @@ The following array defines two changes. The first inserts an image above a para
     'target':'#para-id',
     'action':'insert',
     'position':'before',
-    'content':'<img src="image-url-or-part-name" alt="Image above the target paragraph" />'
+    'content':'<img src="image-data-url-or-part-name" alt="Image above the target paragraph" />'
   }, 
   {
     'target':'#list-id',
@@ -276,7 +276,7 @@ The following example adds two sibling nodes to the page. It adds an image above
      'target':'#para1',
      'action':'insert',
      'position':'before',
-     'content':'<img src="image-url-or-part-name" alt="Image inserted above the target" />'
+     'content':'<img src="image-data-url-or-part-name" alt="Image inserted above the target" />'
   },
   {
     'target':'#para2',
@@ -380,7 +380,7 @@ Authorization: Bearer {token}
     'target':'#para-id',
     'action':'insert',
     'position':'before',
-    'content':'<img src="image-url" alt="New image from a URL" />'
+    'content':'<img src="image-data-url" alt="New image from a URL" />'
   }, 
   {
     'target':'#list-id',

--- a/concepts/onenote-update-page.md
+++ b/concepts/onenote-update-page.md
@@ -53,6 +53,9 @@ Your changes are sent in the message body as an array of JSON change objects. Ea
 
 The following array defines two changes. The first inserts an image above a paragraph as a sibling, and the second appends an item to a list as a last child.
 
+> [!NOTE]
+> When updating an image on a OneNote page, you can't use www links. The service won't try to download random resources. Instead, the image must be part of the request, either by an image-data-url or a part-name of a multipart request.
+
 ```json
 [
    {


### PR DESCRIPTION
When updating an image on a OneNote page through the API you are unable to use www links since the service won't try and download random resources from www. Instead the image needs to be part of the request itself, either by an image-data-url or a part-name of a multipart request.