### PR TITLE
Replace {ver} token with beta.

### DIFF
--- a/api-reference/beta/api/connector-get.md
+++ b/api-reference/beta/api/connector-get.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_connector"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectors/{id}
+GET https://graph.microsoft.com/beta/connectors/{id}
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connector-list-memberof.md
+++ b/api-reference/beta/api/connector-list-memberof.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_memberof"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectors/{id}/memberOf
+GET https://graph.microsoft.com/beta/connectors/{id}/memberOf
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connector-list.md
+++ b/api-reference/beta/api/connector-list.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_connectors"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectors
+GET https://graph.microsoft.com/beta/connectors
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connector-post-memberof.md
+++ b/api-reference/beta/api/connector-post-memberof.md
@@ -44,12 +44,12 @@ Here is an example of the request.
   "name": "create_connectorgroup_from_connector"
 }-->
 ```http
-POST https://graph.microsoft.com/{ver}/connectors/{id}/memberOf
+POST https://graph.microsoft.com/beta/connectors/{id}/memberOf
 Content-type: application/json
 Content-length: 99
 
 {
-  "@odata.id": "https://graph.microsoft.com/{ver}/connectorGroups/{id}"
+  "@odata.id": "https://graph.microsoft.com/beta/connectorGroups/{id}"
 }
 ```
 In the request body, supply a JSON representation of [connectorGroup](../resources/connectorgroup.md) object.

--- a/api-reference/beta/api/connectorgroup-delete.md
+++ b/api-reference/beta/api/connectorgroup-delete.md
@@ -46,7 +46,7 @@ Here is an example of the request.
   "name": "delete_connectorgroup"
 }-->
 ```http
-DELETE https://graph.microsoft.com/{ver}/connectorGroups/{id}
+DELETE https://graph.microsoft.com/beta/connectorGroups/{id}
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connectorgroup-get.md
+++ b/api-reference/beta/api/connectorgroup-get.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_connectorgroup"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectorGroups/{id}
+GET https://graph.microsoft.com/beta/connectorGroups/{id}
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connectorgroup-list-applications.md
+++ b/api-reference/beta/api/connectorgroup-list-applications.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_applications"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectorGroups/{id}/applications
+GET https://graph.microsoft.com/beta/connectorGroups/{id}/applications
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connectorgroup-list-members.md
+++ b/api-reference/beta/api/connectorgroup-list-members.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_members"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectorGroups/{id}/members
+GET https://graph.microsoft.com/beta/connectorGroups/{id}/members
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connectorgroup-list.md
+++ b/api-reference/beta/api/connectorgroup-list.md
@@ -45,7 +45,7 @@ Here is an example of the request.
   "name": "get_connectorgroups"
 }-->
 ```http
-GET https://graph.microsoft.com/{ver}/connectorGroups
+GET https://graph.microsoft.com/beta/connectorGroups
 ```
 ##### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.

--- a/api-reference/beta/api/connectorgroup-post-applications.md
+++ b/api-reference/beta/api/connectorgroup-post-applications.md
@@ -44,12 +44,12 @@ Here is an example of the request.
   "name": "create_application_from_connectorgroup"
 }-->
 ```http
-POST https://graph.microsoft.com/{ver}/connectorGroups/{id}/applications
+POST https://graph.microsoft.com/beta/connectorGroups/{id}/applications
 Content-type: application/json
 Content-length: 329
 
 {
-  "@odata.id": "https://graph.microsoft.com/{ver}/applications/{id}"
+  "@odata.id": "https://graph.microsoft.com/beta/applications/{id}"
 }
 ```
 In the request body, supply a JSON representation of [application](../resources/application.md) object.

--- a/api-reference/beta/api/connectorgroup-post-connectorgroups.md
+++ b/api-reference/beta/api/connectorgroup-post-connectorgroups.md
@@ -44,7 +44,7 @@ Here is an example of the request.
   "name": "create_connectorgroup_from_connectorgroups"
 }-->
 ```http
-POST https://graph.microsoft.com/{ver}/connectorGroups
+POST https://graph.microsoft.com/beta/connectorGroups
 Content-type: application/json
 Content-length: 99
 

--- a/api-reference/beta/api/connectorgroup-post-members.md
+++ b/api-reference/beta/api/connectorgroup-post-members.md
@@ -43,7 +43,7 @@ Here is an example of the request.
   "name": "create_connector_from_connectorgroup"
 }-->
 ```http
-POST https://graph.microsoft.com/{ver}/connectorGroups/{id}/members/$ref
+POST https://graph.microsoft.com/beta/connectorGroups/{id}/members/$ref
 Content-type: application/json
 Content-length: 104
 

--- a/api-reference/beta/api/connectorgroup-update.md
+++ b/api-reference/beta/api/connectorgroup-update.md
@@ -47,7 +47,7 @@ Here is an example of the request.
   "name": "update_connectorgroup"
 }-->
 ```http
-PATCH https://graph.microsoft.com/{ver}/connectorGroups/{id}
+PATCH https://graph.microsoft.com/beta/connectorGroups/{id}
 Content-type: application/json
 Content-length: 99
 


### PR DESCRIPTION
We came across these set of docs where the version (beta|v1.0) is tokenized as {ver}. 

We need the full url, including the version, this PR is meant to have this issue elaborated, whether the full version will be indicated as the docs get elaborated or its going to permanently be {ver} and we have to read the version from elsewhere and replace it here. 

Also the resources in this changeset don't exist in the metadata. Are they going to be added soon?
