### PR TITLE
Removing unsupported functional example

### DIFF
--- a/api-reference/beta/api/profilephoto-get.md
+++ b/api-reference/beta/api/profilephoto-get.md
@@ -10,21 +10,20 @@ localization_priority: Priority
 
 Get the specified [profilePhoto](../resources/profilephoto.md) or its metadata (**profilePhoto** properties).
 
-A GET photo operation first attempt to retrieve the specified photo from Office 365. If the photo is not available in Office 365, the API attempts to retrieve the photo from Azure Active Directory.
+A GET photo method first attempts to retrieve the specified photo from Office 365. If the photo is not available in Office 365, the API attempts to retrieve the photo from Azure Active Directory.
 
-The supported sizes of HD photos on Office 365 are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', 
-'360x360','432x432', '504x504', and '648x648'. Photos can be any dimension if they are stored in Azure Active Directory.
+The supported sizes of HD photos in Office 365 are as follows: 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. Photos can be any dimension if they are stored in Azure Active Directory.
 
 You can get the metadata of the largest available photo, or specify a size to get the metadata for that photo size.
 If the size you request is not available, you can still get a smaller size that the user has uploaded and made available.
-For example, if the user uploads a photo that is 504x504 pixels, then all but the 648x648 size of photo will be available for download.
-If the specified size is not available in the user's mailbox or in Azure Active Directory, the size of '1x1' is returned with the rest of 
+For example, if the user uploads a photo that is 504x504 pixels, all but the 648x648 size photo will be available for download.
+If the specified size is not available in the user's mailbox or in Azure Active Directory, the size 1x1 is returned with the rest of 
 metadata.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-> **Note:** The GET photo operation in beta supports a user's work, school, or personal accounts. The GET photo metadata operation, however, supports only the user's work or school accounts and not personal accounts.
+> **Note:** The GET photo method in beta supports a user's work, school, or personal accounts. The GET photo metadata operation, however, supports only the user's work or school accounts and not personal accounts.
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -69,10 +68,10 @@ GET /groups/{id}/photos/{size}
 
 |**Parameter**|**Type**|**Description**|
 |:-----|:-----|:-----|
-|size  |String  | A photo size. The supported sizes of HD photos on Office 365 are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'. Photos can be any dimension if they are stored in Azure Active Directory. |
+|size  |String  | A photo size. The supported sizes of HD photos on Office 365 are as follows: 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. Photos can be any dimension if they are stored in Azure Active Directory. |
 
 ## Optional query parameters
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
 ## Request headers
 | Name       | Type | Description|
@@ -86,12 +85,13 @@ Do not supply a request body for this method.
 ### Response for getting the photo
 If successful, this method returns a `200 OK` response code and binary data of the requested photo.  If no photo exists, the operation returns `404 Not Found`.
 ### Response for getting the metadata of the photo
-If successful, this method returns a `200 OK` response code and [profilePhoto](../resources/profilephoto.md) object in the response body.
+If successful, this method returns a `200 OK` response code and a [profilePhoto](../resources/profilephoto.md) object in the response body.
 
-## Example
-##### Request 1
-This request gets the photo for the signed-in user, in the largest available size.
+## Examples
 
+### Example 1: Get the photo for the signed-in user in the largest available size.
+
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -100,12 +100,12 @@ GET https://graph.microsoft.com/beta/me/photo/$value
 Content-Type: image/jpg
 ```
 
-##### Response 1
+##### Response
 Contains the binary data of the requested photo. The HTTP response code is 200.
 
-##### Request 2
-This request gets the 48x48 photo for the signed-in user.
+### Example 2: Get the 48x48 photo for the signed-in use
 
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -114,12 +114,12 @@ GET https://graph.microsoft.com/beta/me/photos/48x48/$value
 Content-Type: image/jpg
 ```
 
-##### Response 2
+##### Response
 Contains the binary data of the requested 48x48 photo. The HTTP response code is 200.
 
-##### Request 3
-This request gets the metadata of the user photo of the signed-in user.
+### Example 3: Get the metadata of the user photo of the signed-in user
 
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -127,8 +127,10 @@ This request gets the metadata of the user photo of the signed-in user.
 GET https://graph.microsoft.com/beta/me/photo
 ```
 
-##### Response 3
-The following response data shows the photo metadata. Note: The response object shown here may be truncated for brevity.
+##### Response
+The following response data shows the photo metadata. 
+
+>**Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "ignored"
@@ -148,7 +150,9 @@ Content-type: application/json
 }
 ```
 
-The following response data shows the contents of a response when a photo hasn't already been uploaded for the user. Note: The response object shown here may be truncated for brevity.
+The following response data shows the contents of a response when a photo hasn't already been uploaded for the user. 
+
+>**Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "ignored"
@@ -169,7 +173,7 @@ Content-type: application/json
 ```
 ## Using the binary data of the requested photo
 
-When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. Here is an example in JavaScript of how to create an array that you can pass as the value of the `Attachments` parameter of an [Outlook Message](user-post-messages.md).
+When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. The following JavaScript example shows how to create an array that you can pass as the value of the `attachments` parameter of an [Outlook message](user-post-messages.md).
 
       const attachments = [{
         '@odata.type': '#microsoft.graph.fileAttachment',

--- a/api-reference/beta/api/profilephoto-get.md
+++ b/api-reference/beta/api/profilephoto-get.md
@@ -63,10 +63,6 @@ GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{i
 GET /me/photos/{size}
 GET /users/{id | userPrincipalName}/photos/{size}
 GET /groups/{id}/photos/{size}
-GET /me/contacts/{id}/photos/{size}
-GET /users/{id | userPrincipalName}/contacts/{id}/photos/{size}
-GET /me/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
-GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
 ```
 
 ## Path parameters


### PR DESCRIPTION
The get contact image by size functionality has never been supported. Removing the example to avoid confusion.