### PR TITLE
Removing unsupported functional examples

### DIFF
--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -10,12 +10,12 @@ Get the specified [profilePhoto](../resources/profilephoto.md) or its metadata (
 
 > **Note** This operation in version 1.0 supports only a user's work or school mailboxes and not personal mailboxes.
 
-The supported sizes of HD photos on Office 365 are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', 
-'360x360','432x432', '504x504', and '648x648'. Photos can be any dimension if they are stored in Azure Active Directory.
+The supported sizes of HD photos on Office 365 are as follows: 48x48, 64x64, 96x96, 120x120, 240x240, 
+360x360, 432x432, 504x504, and 648x648. Photos can be any dimension if they are stored in Azure Active Directory.
 
 You can get the metadata of the largest available photo, or specify a size to get the metadata for that photo size.
 If the size you request is not available, you can still get a smaller size that the user has uploaded and made available.
-For example, if the user uploads a photo that is 504x504 pixels, then all but the 648x648 size of photo will be available for download.
+For example, if the user uploads a photo that is 504x504 pixels, all but the 648x648 size of photo will be available for download.
 
 ## Permissions
 
@@ -66,10 +66,10 @@ GET /groups/{id}/photos/{size}
 
 |Parameter|Type|Description|
 |:-----|:-----|:-----|
-|size  |String  | A photo size. The supported sizes of HD photos on Office 365 are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'. Photos can be any dimension if they are stored in Azure Active Directory. |
+|size  |String  | A photo size. The supported sizes of HD photos on Office 365 are as follows: 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. Photos can be any dimension if they are stored in Azure Active Directory. |
 
 ## Optional query parameters
-This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
+This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
 ## Request headers
 | Name       | Type | Description|
@@ -84,9 +84,10 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and binary data of the requested photo.  If no photo exists, the operation returns `404 Not Found`.
 ### Response for getting the metadata of the photo
 If successful, this method returns a `200 OK` response code and [profilePhoto](../resources/profilephoto.md) object in the response body.
-## Example
-##### Request 1
-This request gets the photo for the signed-in user, in the largest available size.
+## Examples
+
+### Example 1: Get the photo for the signed-in user in the largest available size
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -94,12 +95,11 @@ This request gets the photo for the signed-in user, in the largest available siz
 GET https://graph.microsoft.com/v1.0/me/photo/$value
 ```
 
-##### Response 1
+##### Response 
 Contains the binary data of the requested photo. The HTTP response code is 200.
 
-##### Request 2
-This request gets the 48x48 photo for the signed-in user.
-
+### Example 2: Get the 48x48 photo for the signed-in use
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -108,11 +108,11 @@ GET https://graph.microsoft.com/v1.0/me/photos/48x48/$value
 Content-Type: image/jpg
 ```
 
-##### Response 2
+##### Response
 Contains the binary data of the requested 48x48 photo. The HTTP response code is 200.
 
-##### Request 3
-This request gets the metadata of the user photo of the signed-in user.
+### Example 3: Get the metadata of the user photo of the signed-in user
+##### Request
 <!-- {
   "blockType": "ignored"
 }-->
@@ -120,9 +120,11 @@ This request gets the metadata of the user photo of the signed-in user.
 GET https://graph.microsoft.com/v1.0/me/photo
 ```
 
-##### Response 3
+##### Response
 
-The following response data shows the photo metadata. Note: The response object shown here may be truncated for brevity.
+The following response data shows the photo metadata. 
+
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "ignored"
 }-->
@@ -141,7 +143,9 @@ Content-type: application/json
 }
 ```
 
-The following response data shows the contents of a response when a photo hasn't already been uploaded for the user. Note: The response object shown here may be truncated for brevity.
+The following response data shows the contents of a response when a photo hasn't already been uploaded for the user.
+
+>**Note:** The response object shown here might be shortened for readability.
 
 <!-- {
   "blockType": "ignored"

--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -60,10 +60,6 @@ GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{i
 GET /me/photos/{size}
 GET /users/{id | userPrincipalName}/photos/{size}
 GET /groups/{id}/photos/{size}
-GET /me/contacts/{id}/photos/{size}
-GET /users/{id | userPrincipalName}/contacts/{id}/photos/{size}
-GET /me/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
-GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photos/{size}
 ```
 
 ## Path parameters


### PR DESCRIPTION
These appear to have been inadvertently added to the documentation. There has never been support for multiple image sizes for Contact photos.