### PR TITLE
Create get-drive-by-site-Javascript-snippets.md

### DIFF
--- a/api-reference/v1.0/includes/get-drive-by-site-Javascript-snippets.md
+++ b/api-reference/v1.0/includes/get-drive-by-site-Javascript-snippets.md
@@ -1,0 +1,13 @@
+
+```Javascript
+
+const options = {
+	authProvider,
+};
+
+const client = Client.init(options);
+
+let res = await client.api('/sites/{site-id}/drive')
+	.get();
+
+```


### PR DESCRIPTION
Currently theres no code snippet example for JS to reference on https://github.com/microsoftgraph/microsoft-graph-docs/blob/master/api-reference/v1.0/api/drive-get.md, currently the snippet there is referring to the Get Drive by Group snippet