### PR TITLE
Create get-drive-by-site-Cs-snippets.md

### DIFF
--- a/api-reference/v1.0/includes/get-drive-by-site-Cs-snippets.md
+++ b/api-reference/v1.0/includes/get-drive-by-site-Cs-snippets.md
@@ -1,0 +1,10 @@
+
+```Cs
+
+GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+
+var drive = await graphClient.Sites["{siteId}"].Drive
+	.Request()
+	.GetAsync();
+
+```


### PR DESCRIPTION
Currently theres no code snippet example for CS to reference on https://github.com/microsoftgraph/microsoft-graph-docs/blob/master/api-reference/v1.0/api/drive-get.md, currently the snippet there is referring to the Get Drive by Group CS snippet