### PR TITLE
[Ready-to-merge] Added auth-overview redirect to go to new auth landing page

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -26592,7 +26592,7 @@
         },
         {
             "source_path": "concepts\\auth_overview.md",
-            "redirect_url": "/graph/auth",
+            "redirect_url": "/graph/auth/",
             "redirect_document_id": true
         },
         {

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -26592,6 +26592,11 @@
         },
         {
             "source_path": "concepts\\auth_overview.md",
+            "redirect_url": "/graph/auth-overview",
+            "redirect_document_id": true
+        },
+        {
+            "source_path": "concepts\\auth-overview.md",
             "redirect_url": "/graph/auth/",
             "redirect_document_id": true
         },

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -26592,7 +26592,7 @@
         },
         {
             "source_path": "concepts\\auth_overview.md",
-            "redirect_url": "/graph/auth-overview",
+            "redirect_url": "/graph/auth",
             "redirect_document_id": true
         },
         {

--- a/concepts/auth/auth-concepts.md
+++ b/concepts/auth/auth-concepts.md
@@ -6,7 +6,7 @@ localization_priority: Priority
 ms.prod: "microsoft-identity-platform"
 ---
 
-# Authentication and Authorization basics for Microsoft Graph
+# Authentication and authorization basics for Microsoft Graph
 
 To call Microsoft Graph, your app must acquire an access token from the Microsoft identity platform. The access token contains information about your app and the permissions it has for the resources and APIs available through Microsoft Graph. To get an access token, your app must be registered with the Microsoft identity platform and be authorized by either a user or an administrator for access to the Microsoft Graph resources it needs. 
 


### PR DESCRIPTION
- Added new redirect to point auth-overview to the landing page (currently, auth-overview links result in 404 on search sites, etc)
- Also used sentence case for topic title in auth-concepts.md file (minor change)