### PR TITLE
Fix inverted boolean behavior for saveToSentItems

### DIFF
--- a/concepts/outlook-send-mail-from-other-user.md
+++ b/concepts/outlook-send-mail-from-other-user.md
@@ -102,7 +102,7 @@ After the message is sent, it can be saved to the sending user's Sent Items fold
 The default behavior can be changed by other outside factors:
 
 - Administrators can update the from user's mailbox to [always save a copy of messages sent from a delegate](/exchange/recipients-in-exchange-online/manage-user-mailboxes/automatically-save-sent-items-in-delegator-s-mailbox) to their Sent Items.
-- By setting the `saveToSentItems` property to `true` in a [send mail](/graph/api/user-sendmail?view=graph-rest-1.0) request, you can prevent the item from being saved to the Sent Items folder. However, if an administrator has configured the "always save a copy" setting, the message will still be saved to the from user's Sent Items.
+- By setting the `saveToSentItems` property to `false` in a [send mail](/graph/api/user-sendmail?view=graph-rest-1.0) request, you can prevent the item from being saved to the Sent Items folder. However, if an administrator has configured the "always save a copy" setting, the message will still be saved to the from user's Sent Items.
 
 ## Examples
 


### PR DESCRIPTION
"By setting the `saveToSentItems` property to `true`" is wrong and the value must be FALSE as TRUE is the documented default and it makes no sense based on the property wording. If set to false it will not store a copy in the send items folder execpt an admin configured an exchange policy.