### PR TITLE
Fix incorrect statement about groups created via the azure portal

### DIFF
--- a/api-reference/beta/api/group-post-groups.md
+++ b/api-reference/beta/api/group-post-groups.md
@@ -56,7 +56,7 @@ The following table shows the properties of the [group](../resources/group.md) r
 | owners | [directoryObject](../resources/directoryobject.md) collection | This property represents the owners for the group at creation time. Optional. |
 | members | [directoryObject](../resources/directoryobject.md) collection | This property represents the members for the group at creation time. Optional. |
 
-> Note: Groups created using the Microsoft Azure portal always have **securityEnabled** and **mailEnabled** initially set to `true`.
+> Note: Groups created using the Microsoft Azure portal always have **securityEnabled** initially set to `true`.
 
 Since the **group** resource supports [extensions](/graph/extensibility-overview), you can use the `POST` operation and add custom properties with your own data to the group while creating it.
 

--- a/api-reference/v1.0/api/group-post-groups.md
+++ b/api-reference/v1.0/api/group-post-groups.md
@@ -51,7 +51,7 @@ The following table shows the properties of the [group](../resources/group.md) r
 | owners | string collection | This property represents the owners for the group at creation time. Optional. |
 | members | string collection | This property represents the members for the group at creation time. Optional. |
 
-> Note: Groups created using the Microsoft Azure portal always have **securityEnabled** and **mailEnabled** initially set to `true`.
+> Note: Groups created using the Microsoft Azure portal always have **securityEnabled** initially set to `true`.
 
 Specify other writable properties as necessary for your group. For more information, see the properties of the [group](../resources/group.md) resource.
 


### PR DESCRIPTION
Only security groups and unified groups can be created via the azure portal. In order to have mailEnabled be true for both, the group types would have to be "mail-enabled security" and "unified". (I own the code in the azure portal for group creation and know for a fact that I set mailEnabled to false when creating security groups).