### PR TITLE
Fix typo in beta teamwork create group reference

### DIFF
--- a/api-reference/beta/api/group-post-groups.md
+++ b/api-reference/beta/api/group-post-groups.md
@@ -10,7 +10,7 @@ ms.prod: "groups"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Ceate a new [group](../resources/group.md) as specified in the request body. You can create one of the following groups:
+Create a new [group](../resources/group.md) as specified in the request body. You can create one of the following groups:
 
 * Office 365 Group (unified group)
 * Security group


### PR DESCRIPTION
Change `Ceate` to `Create`