### PR TITLE
Add metadata to precede metadata blocks.

### DIFF
--- a/api-reference/beta/api/directoryaudit-get.md
+++ b/api-reference/beta/api/directoryaudit-get.md
@@ -76,8 +76,7 @@ Here is an example of the response.
 HTTP/1.1 200 OK
 Content-type: application/json
 Content-length: 218
-```
-```json
+
 {
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#auditLogs/directoryAudits",
   "value": [{

--- a/api-reference/beta/api/directoryaudit-list.md
+++ b/api-reference/beta/api/directoryaudit-list.md
@@ -100,8 +100,7 @@ Here is an example of the response.
 HTTP/1.1 200 OK
 Content-type: application/json
 Content-length: 271
-```
-```json
+
 {
   "@odata.context": "https://graph.microsoft.com/beta/$metadata#auditLogs/directoryAudits",
   "value": [{

--- a/api-reference/beta/api/driveitem-preview.md
+++ b/api-reference/beta/api/driveitem-preview.md
@@ -55,7 +55,7 @@ The request should be a JSON object with the following properties.
 | zoom        | number        | Optional. Zoom level to start at, if applicable.
 
 ## Response
-
+<!-- { "blockType": "response" } -->
 ```json
 {
     "getUrl": "https://www.onedrive.com/embed?foo=bar&bar=baz",

--- a/api-reference/beta/resources/synchronization-configure-with-directory-extension-attributes.md
+++ b/api-reference/beta/resources/synchronization-configure-with-directory-extension-attributes.md
@@ -15,12 +15,16 @@ This article assumes that you have already added an application that supports sy
 ## Find the service principal object by display name
 
 The following example shows how to find a service principal object with the display name "Salesforce Sandbox".
-
+<!-- { 
+    "blockType": "request"
+} -->
 ```http
 GET https://graph.microsoft.com/beta/servicePrincipals?$select=id,appId,displayName&$filter=startswith(displayName, 'salesforce')
 Authorization: Bearer {Token}
 ```
-
+<!-- { 
+    "blockType": "response"
+} -->
 ```json
 {
     "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals(id,appId,displayName)",
@@ -50,11 +54,16 @@ The `{servicePrincipalId}` is `60443998-8cf7-4e61-b05c-a53b658cb5e1`.
 
 The following example shows you how to get the `jobId` that you need to work with. Generally, the response returns only one job.
 
+<!-- { 
+    "blockType": "request"
+} -->
 ```http
 GET https://graph.microsoft.com/beta/servicePrincipals/60443998-8cf7-4e61-b05c-a53b658cb5e1/synchronization/jobs
 Authorization: Bearer {Token}
 ```
-
+<!-- { 
+    "blockType": "response"
+} -->
 ```json
 {
     "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals('60443998-8cf7-4e61-b05c-a53b658cb5e1')/synchronization/jobs",

--- a/api-reference/beta/resources/synchronization-configure-with-directory-extension-attributes.md
+++ b/api-reference/beta/resources/synchronization-configure-with-directory-extension-attributes.md
@@ -25,7 +25,10 @@ Authorization: Bearer {Token}
 <!-- { 
     "blockType": "response"
 } -->
-```json
+```http
+HTTP/1.1 200 OK
+content-type: application/json
+
 {
     "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals(id,appId,displayName)",
     "value": [
@@ -64,7 +67,10 @@ Authorization: Bearer {Token}
 <!-- { 
     "blockType": "response"
 } -->
-```json
+```http
+HTTP/1.1 200 OK
+content-type: application/json
+
 {
     "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals('60443998-8cf7-4e61-b05c-a53b658cb5e1')/synchronization/jobs",
     "value": [

--- a/api-reference/beta/resources/workbook.md
+++ b/api-reference/beta/resources/workbook.md
@@ -55,11 +55,14 @@ Inside a cell, the `vlookup` function looks like this:
 (See the documentation for the [VLOOKUP Excel function](https://support.office.com/en-us/article/VLOOKUP-function-0bbc8083-26fe-4963-8ab8-93a18ad188a1).)
 
 The example below shows how to call the `vlookup` function and pass these parameters with the Excel REST API.
-Request: 
-<!-- { "blockType": "request" } -->
+Request:
+
+<!-- { 
+    "blockType": "request"
+} -->
 ```http 
 POST https://graph.microsoft.com/beta/me/drive/root:/book1.xlsx:/workbook/functions/vlookup
-content-type: Application/Json 
+content-type: application/json 
 authorization: Bearer {access-token} 
 workbook-session-id: {session-id}
 
@@ -72,9 +75,13 @@ workbook-session-id: {session-id}
 ```
 
 Response:
-<!-- { "blockType": "response" } -->
+
+<!-- { 
+    "blockType": "response",
+    "@odata.type": "microsoft.graph.workbookFunctionResult"
+} -->
 ```http
-HTTP code: 200 OK
+HTTP/1.1 200 OK
 content-type: application/json;odata.metadata 
 
 {
@@ -98,11 +105,14 @@ Inside a cell, the `median` function looks like this example:
 
 The example below shows how to call the `median` function and one or more input ranges with the Excel REST API. 
 
-Request: 
-<!-- { "blockType": "request" } -->
+Request:
+
+<!-- { 
+    "blockType": "request"
+} -->
 ```http 
 POST https://graph.microsoft.com/beta/me/drive/root:/book1.xlsx:/workbook/functions/median
-content-type: Application/Json 
+content-type: application/json 
 authorization: Bearer {access-token} 
 workbook-session-id: {session-id}
 
@@ -115,9 +125,13 @@ workbook-session-id: {session-id}
 ```
 
 Response:
-<!-- { "blockType": "response" } -->
+
+<!-- { 
+    "blockType": "response", 
+    "@odata.type": "microsoft.graph.workbookFunctionResult"
+} -->
 ```http
-HTTP code: 200 OK
+HTTP/1.1 200 OK
 content-type: application/json;odata.metadata 
 
 {

--- a/api-reference/beta/resources/workbook.md
+++ b/api-reference/beta/resources/workbook.md
@@ -56,7 +56,7 @@ Inside a cell, the `vlookup` function looks like this:
 
 The example below shows how to call the `vlookup` function and pass these parameters with the Excel REST API.
 Request: 
-
+<!-- { "blockType": "request" } -->
 ```http 
 POST https://graph.microsoft.com/beta/me/drive/root:/book1.xlsx:/workbook/functions/vlookup
 content-type: Application/Json 
@@ -72,7 +72,7 @@ workbook-session-id: {session-id}
 ```
 
 Response:
-
+<!-- { "blockType": "response" } -->
 ```http
 HTTP code: 200 OK
 content-type: application/json;odata.metadata 
@@ -99,7 +99,7 @@ Inside a cell, the `median` function looks like this example:
 The example below shows how to call the `median` function and one or more input ranges with the Excel REST API. 
 
 Request: 
-
+<!-- { "blockType": "request" } -->
 ```http 
 POST https://graph.microsoft.com/beta/me/drive/root:/book1.xlsx:/workbook/functions/median
 content-type: Application/Json 
@@ -115,7 +115,7 @@ workbook-session-id: {session-id}
 ```
 
 Response:
-
+<!-- { "blockType": "response" } -->
 ```http
 HTTP code: 200 OK
 content-type: application/json;odata.metadata 

--- a/api-reference/beta/resources/workbookfunctionresult.md
+++ b/api-reference/beta/resources/workbookfunctionresult.md
@@ -1,0 +1,29 @@
+---
+title: "workbookFunctionResult type"
+description: ""
+localization_priority: Normal
+---
+
+# workbookFunctionResult resource type
+
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|error|string| |
+|value|Json|   |
+
+## Relationships
+None
+## JSON Representation
+Here is a JSON representation of the resource.
+<!--{
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.workbookFunctionResult"
+}-->
+```json
+{
+    "error": "string",
+    "value": {"@odata.type": "microsoft.graph.Json"}
+}
+```


### PR DESCRIPTION
We are implementing a new validation rule requiring all json and http blocks to be preceeded by a metadata block indicating what the json/http block is about (request, response, resource). 
This PR is a sample of the changes. 
Correct content-types.