### PR TITLE
Capability to Run ApiDoctor locally.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ nuget.exe
 apidoc.exe
 *.dll
 .vs/
+
+#Test-Docs-Local.ps1 related files
+ApiDoctor.log
+apidoctor/

--- a/Test-Docs-Local.ps1
+++ b/Test-Docs-Local.ps1
@@ -1,0 +1,114 @@
+﻿Param(
+    [switch]$cleanUp,
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateSet('v1.0', 'beta', 'all')]
+    [string]$docsVersion,
+    [switch]$log
+)
+$apiDoctorVersion = "https://github.com/OneDrive/apidoctor.git"
+$apiDoctorBranch = "master"
+$repoPath = (Get-Location).Path
+$docSubPath = "/api-reference/"
+$docSubPath += $docsVersion
+$downloadedApiDoctor = $false
+$downloadedNuGet = $false
+Write-Host "Repository location: ", $repoPath
+
+# Check if ApiDoctor version has been set
+if ([string]::IsNullOrWhiteSpace($apiDoctorVersion)) {
+    Write-Host "API Doctor version has not been set. Aborting..."
+    exit 1
+}
+
+# Check if ApiDoctor subpath has been set
+if ([string]::IsNullOrWhiteSpace($docSubPath)) {
+    Write-Host "API Doctor subpath has not been set. Aborting..."
+    exit 1
+}
+# Get NuGet
+$nugetPath = $null
+if (Get-Command "nuget.exe" -ErrorAction SilentlyContinue) {
+    # Use the existing nuget.exe from the path
+    $nugetPath = (Get-Command "nuget.exe").Source
+}
+else {
+    # Download nuget.exe from the nuget server if required
+    $nugetPath = Join-Path $repoPath -ChildPath "nuget.exe"
+    $nugetExists = Test-Path $nugetPath
+    if ($nugetExists -eq $false) {
+        Write-Host "nuget.exe not found. Downloading from dist.nuget.org"
+        Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nugetPath
+    }
+    $downloadedNuGet = $true
+}
+# Check for ApiDoctor in path
+$apidoc = $null
+if (Get-Command "apidoc.exe" -ErrorAction SilentlyContinue) {
+    $apidoc = (Get-Command "apidoc.exe").Source
+}
+else {
+    $apidocPath = Join-Path $repoPath -ChildPath "apidoctor"
+    #check for a previous version of ApiDoctor
+    $prexistingPackageFolder = Get-ChildItem -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" }
+    $prexistingApiDoctor = [System.IO.Path]::Combine($apidocPath, $prexistingPackageFolder.Name, "tools\apidoc.exe")
+    $childItems = Get-ChildItem $prexistingApiDoctor -ErrorAction SilentlyContinue
+    if ($childItems.Exists -eq $false) {
+        New-Item -ItemType Directory -Force -Path $apidocPath
+
+        # Download ApiDoctor from GitHub	
+        Write-Host "Cloning API Doctor repository from GitHub"
+        Write-Host "`tRemote URL: $apiDoctorVersion"
+        Write-Host "`tBranch: $apiDoctorBranch"
+        & git clone -b $apiDoctorBranch $apiDoctorVersion --recurse-submodules "$apidocPath\SourceCode" 2>&1 | Write-Host
+        $downloadedApiDoctor = $true
+		
+        $nugetParams = "restore", "$apidocPath\SourceCode"
+        & $nugetPath $nugetParams
+			
+        # Build ApiDoctor
+        Install-Module -Name Invoke-MsBuild -Scope CurrentUser -Force 
+        Write-Host "`r`nBuilding API Doctor..."
+        Invoke-MsBuild -Path "$apidocPath\SourceCode\ApiDoctor.sln" -MsBuildParameters "/t:Rebuild /p:Configuration=Release /p:OutputPath=$apidocPath\ApiDoctor\tools"
+
+        # Delete existing ApiDoctor source code     
+        Remove-Item $apidocPath\SourceCode -Force  -Recurse -ErrorAction SilentlyContinue
+    }
+    #apiDoctor exists from a previous run
+    # Get the path to the ApiDoctor exe
+    $pkgfolder = Get-ChildItem -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" }
+    $apidoc = [System.IO.Path]::Combine($apidocPath, $pkgfolder.Name, "tools\apidoc.exe")
+    $downloadedApiDoctor = $true
+}   
+
+$lastResultCode = 0
+
+# Run validation at the root of the repository
+
+$fullPath = Join-Path $repoPath -ChildPath $docSubPath
+$params = "check-all", "--path", $fullPath, "--ignore-warnings"
+
+if ($log -eq $true) {
+    $params = $params += "--log", "ApiDoctor.log"
+}
+& $apidoc $params
+
+
+if ($LastExitCode -ne 0) { 
+    $lastResultCode = $LastExitCode
+}
+
+# Clean up the stuff we downloaded
+if ($cleanUp -eq $true) {
+    if ($downloadedApiDoctor -eq $true) {
+        Remove-Item $apidocPath -Recurse -Force
+    }
+    if ($downloadedNuGet -eq $true) {
+        Remove-Item $nugetPath 
+    }   
+}
+
+if ($lastResultCode -ne 0) {
+    Write-Host "Errors were detected. This build failed."
+    exit $lastResultCode
+}

--- a/Test-Docs-Local.ps1
+++ b/Test-Docs-Local.ps1
@@ -6,109 +6,131 @@
     [string]$docsVersion,
     [switch]$log
 )
+
+
+Function Invoke-ApiDoctor([bool]$cleanUp,
+    [string]$apiDoctorVersion,
+    [string]$apiDoctorBranch,
+    [string]$repoPath,
+    [string]$apiDoctorPath,
+    [switch]$log,
+    [string]$docSubPath) {
+
+    $downloadedApiDoctor = $false
+    $downloadedNuGet = $false
+    Write-Host "Repository location: ", $repoPath
+
+    # Check if ApiDoctor version has been set
+    if ([string]::IsNullOrWhiteSpace($apiDoctorVersion)) {
+        Write-Host "API Doctor version has not been set. Aborting..."
+        exit 1
+    }
+
+    # Check if ApiDoctor subpath has been set
+    if ([string]::IsNullOrWhiteSpace($docSubPath)) {
+        Write-Host "API Doctor subpath has not been set. Aborting..."
+        exit 1
+    }
+    # Get NuGet
+    $nugetPath = $null
+    if (Get-Command "nuget.exe" -ErrorAction SilentlyContinue) {
+        # Use the existing nuget.exe from the path
+        $nugetPath = (Get-Command "nuget.exe").Source
+    }
+    else {
+        # Download nuget.exe from the nuget server if required
+        $nugetPath = Join-Path $repoPath -ChildPath "nuget.exe"
+        $nugetExists = Test-Path $nugetPath
+        if ($nugetExists -eq $false) {
+            Write-Host "nuget.exe not found. Downloading from dist.nuget.org"
+            Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nugetPath
+        }
+        $downloadedNuGet = $true
+    }
+    # Check for ApiDoctor in path
+    $apidoc = $null
+    if (Get-Command "apidoc.exe" -ErrorAction SilentlyContinue) {
+        $apidoc = (Get-Command "apidoc.exe").Source
+    }
+    else {
+        $apidocPath = Join-Path $repoPath -ChildPath "apidoctor"
+        #check for a previous version of ApiDoctor
+        $prexistingPackageFolder = Get-ChildItem -ErrorAction SilentlyContinue -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" } 
+        $prexistingApiDoctor = [System.IO.Path]::Combine($apidocPath, $prexistingPackageFolder.Name, "tools\apidoc.exe")
+        $apiDoctorExists = Test-Path $prexistingApiDoctor
+        if ($apiDoctorExists -eq $false) {
+            New-Item -ItemType Directory -Force -Path $apidocPath
+
+            # Download ApiDoctor from GitHub	
+            Write-Host "Cloning API Doctor repository from GitHub"
+            Write-Host "`tRemote URL: $apiDoctorVersion"
+            Write-Host "`tBranch: $apiDoctorBranch"
+            & git clone -b $apiDoctorBranch $apiDoctorVersion --recurse-submodules "$apidocPath\SourceCode" 2>&1 | Write-Host
+            $downloadedApiDoctor = $true
+		
+            $nugetParams = "restore", "$apidocPath\SourceCode"
+            & $nugetPath $nugetParams
+			
+            # Build ApiDoctor
+            Install-Module -Name Invoke-MsBuild -Scope CurrentUser -Force 
+            Write-Host "`r`nBuilding API Doctor..."
+            Invoke-MsBuild -Path "$apidocPath\SourceCode\ApiDoctor.sln" -MsBuildParameters "/t:Rebuild /p:Configuration=Release /p:OutputPath=$apidocPath\ApiDoctor\tools"
+
+            # Delete existing ApiDoctor source code     
+            Remove-Item $apidocPath\SourceCode -Force  -Recurse -ErrorAction SilentlyContinue
+        }
+        #apiDoctor exists from a previous run
+        # Get the path to the ApiDoctor exe
+        $pkgfolder = Get-ChildItem -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" }
+        $apidoc = [System.IO.Path]::Combine($apidocPath, $pkgfolder.Name, "tools\apidoc.exe")
+        $downloadedApiDoctor = $true
+    }   
+
+    $lastResultCode = 0
+
+    # Run validation at the root of the repository
+
+    $fullPath = Join-Path $repoPath -ChildPath $docSubPath
+    $params = "check-all", "--path", $fullPath, "--ignore-warnings"
+
+    if ($log -eq $true) {
+        $params = $params += "--log", "ApiDoctor.log"
+    }
+    & $apidoc $params
+
+    if ($LastExitCode -ne 0) { 
+        $lastResultCode = $LastExitCode
+    }
+
+    # Clean up the stuff we downloaded
+    if ($cleanUp -eq $true) {
+        if ($downloadedApiDoctor -eq $true) {
+            Remove-Item $apidocPath -Recurse -Force
+        }
+        if ($downloadedNuGet -eq $true) {
+            Remove-Item $nugetPath 
+        }   
+    }
+
+    if ($lastResultCode -ne 0) {
+        Write-Host "Errors were detected. This build failed."
+        exit $lastResultCode
+    }
+}
+
+
 $apiDoctorVersion = "https://github.com/OneDrive/apidoctor.git"
 $apiDoctorBranch = "master"
 $repoPath = (Get-Location).Path
 $docSubPath = "/api-reference/"
+$v1Docs = $docSubPath + "v1.0"
+$betaDocs = $docSubPath + "beta"
 $docSubPath += $docsVersion
-$downloadedApiDoctor = $false
-$downloadedNuGet = $false
-Write-Host "Repository location: ", $repoPath
 
-# Check if ApiDoctor version has been set
-if ([string]::IsNullOrWhiteSpace($apiDoctorVersion)) {
-    Write-Host "API Doctor version has not been set. Aborting..."
-    exit 1
+if($docsVersion.Equals("all") -eq $true){
+    Invoke-ApiDoctor -docSubPath $v1Docs -cleanUp $cleanUp.IsPresent -apiDoctorVersion $apiDoctorVersion -apiDoctorBranch $apiDoctorBranch -repoPath $repoPath  -log $log
+    Invoke-ApiDoctor -docSubPath $betaDocs -cleanUp $cleanUp.IsPresent -apiDoctorVersion $apiDoctorVersion -apiDoctorBranch $apiDoctorBranch -repoPath $repoPath  -log $log
 }
-
-# Check if ApiDoctor subpath has been set
-if ([string]::IsNullOrWhiteSpace($docSubPath)) {
-    Write-Host "API Doctor subpath has not been set. Aborting..."
-    exit 1
-}
-# Get NuGet
-$nugetPath = $null
-if (Get-Command "nuget.exe" -ErrorAction SilentlyContinue) {
-    # Use the existing nuget.exe from the path
-    $nugetPath = (Get-Command "nuget.exe").Source
-}
-else {
-    # Download nuget.exe from the nuget server if required
-    $nugetPath = Join-Path $repoPath -ChildPath "nuget.exe"
-    $nugetExists = Test-Path $nugetPath
-    if ($nugetExists -eq $false) {
-        Write-Host "nuget.exe not found. Downloading from dist.nuget.org"
-        Invoke-WebRequest -Uri "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe" -OutFile $nugetPath
-    }
-    $downloadedNuGet = $true
-}
-# Check for ApiDoctor in path
-$apidoc = $null
-if (Get-Command "apidoc.exe" -ErrorAction SilentlyContinue) {
-    $apidoc = (Get-Command "apidoc.exe").Source
-}
-else {
-    $apidocPath = Join-Path $repoPath -ChildPath "apidoctor"
-    #check for a previous version of ApiDoctor
-    $prexistingPackageFolder = Get-ChildItem -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" }
-    $prexistingApiDoctor = [System.IO.Path]::Combine($apidocPath, $prexistingPackageFolder.Name, "tools\apidoc.exe")
-    $childItems = Get-ChildItem $prexistingApiDoctor -ErrorAction SilentlyContinue
-    if ($childItems.Exists -eq $false) {
-        New-Item -ItemType Directory -Force -Path $apidocPath
-
-        # Download ApiDoctor from GitHub	
-        Write-Host "Cloning API Doctor repository from GitHub"
-        Write-Host "`tRemote URL: $apiDoctorVersion"
-        Write-Host "`tBranch: $apiDoctorBranch"
-        & git clone -b $apiDoctorBranch $apiDoctorVersion --recurse-submodules "$apidocPath\SourceCode" 2>&1 | Write-Host
-        $downloadedApiDoctor = $true
-		
-        $nugetParams = "restore", "$apidocPath\SourceCode"
-        & $nugetPath $nugetParams
-			
-        # Build ApiDoctor
-        Install-Module -Name Invoke-MsBuild -Scope CurrentUser -Force 
-        Write-Host "`r`nBuilding API Doctor..."
-        Invoke-MsBuild -Path "$apidocPath\SourceCode\ApiDoctor.sln" -MsBuildParameters "/t:Rebuild /p:Configuration=Release /p:OutputPath=$apidocPath\ApiDoctor\tools"
-
-        # Delete existing ApiDoctor source code     
-        Remove-Item $apidocPath\SourceCode -Force  -Recurse -ErrorAction SilentlyContinue
-    }
-    #apiDoctor exists from a previous run
-    # Get the path to the ApiDoctor exe
-    $pkgfolder = Get-ChildItem -LiteralPath $apidocPath -Directory | Where-Object { $_.name -match "ApiDoctor" }
-    $apidoc = [System.IO.Path]::Combine($apidocPath, $pkgfolder.Name, "tools\apidoc.exe")
-    $downloadedApiDoctor = $true
-}   
-
-$lastResultCode = 0
-
-# Run validation at the root of the repository
-
-$fullPath = Join-Path $repoPath -ChildPath $docSubPath
-$params = "check-all", "--path", $fullPath, "--ignore-warnings"
-
-if ($log -eq $true) {
-    $params = $params += "--log", "ApiDoctor.log"
-}
-& $apidoc $params
-
-
-if ($LastExitCode -ne 0) { 
-    $lastResultCode = $LastExitCode
-}
-
-# Clean up the stuff we downloaded
-if ($cleanUp -eq $true) {
-    if ($downloadedApiDoctor -eq $true) {
-        Remove-Item $apidocPath -Recurse -Force
-    }
-    if ($downloadedNuGet -eq $true) {
-        Remove-Item $nugetPath 
-    }   
-}
-
-if ($lastResultCode -ne 0) {
-    Write-Host "Errors were detected. This build failed."
-    exit $lastResultCode
+else{
+    Invoke-ApiDoctor -docSubPath $docSubPath -cleanUp $cleanUp.IsPresent -apiDoctorVersion $apiDoctorVersion -apiDoctorBranch $apiDoctorBranch -repoPath $repoPath  -log $log
 }


### PR DESCRIPTION
A new Powershell script named Test-Docs-Local.ps1 will be introduced into the microsoft-graph-docs repository. The script shall have sensible defaults to enable writers to execute apidoctor against the docs. 

To use the script, start a new powershell instance inside the folder where the docs were cloned, execute the following:-

```
.\Test-Docs-Local.ps1 -docsVersion v1.0 -log  
.\Test-Docs-Local.ps1 -docsVersion beta -log
.\Test-Docs-Local.ps1 -docsVersion all -log

.\Test-Docs-Local.ps1 -docsVersion v1.0 -log  -cleanUp
.\Test-Docs-Local.ps1 -docsVersion beta -log  -cleanUp
.\Test-Docs-Local.ps1 -docsVersion all -log  -cleanUp

.\Test-Docs-Local.ps1 -docsVersion v1.0 
.\Test-Docs-Local.ps1 -docsVersion beta 
.\Test-Docs-Local.ps1 -docsVersion all 
```


Params:
`-docsVersion` : can be "v1.0", "beta", "all" -> Which version of docs you want to check. 
`-log` : A switch that makes apiDoctor produce a text log to the local directory. 
`-cleanUp`: A switch that makes the script delete (clean up) all downloads resources and logs. 

Performance:
Cloning, Building and Running apidoctor for each time the user wants to check the docs is time-consuming and inefficient, as such apiDoctor builds will be re-used up and until the `-cleanUp` switch is used. 

This will 
1. Install nuget package manager if its doesn't exist. 
2. Clone ApiDoctor from GitHub if it doesn't exist locally, such as when this is the first run or a previous run used the -cleanUp flag.
3. Install the Invoke-MsBuild from PsGallery, and execute it against the cloned source code. 
4. Execute the just built ApiDoctor against the docs in the parent folder. 

Linked to [AB#4618](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/4618)
