### PR TITLE
Add documentation for expiratinDateTime and password

### DIFF
--- a/api-reference/beta/api/driveitem-createlink.md
+++ b/api-reference/beta/api/driveitem-createlink.md
@@ -44,10 +44,12 @@ POST /users/{userId}/drive/items/{itemId}/createLink
 The body of the request defines properties of the sharing link your application is requesting.
 The request should be a JSON object with the following properties.
 
-|   Name    |  Type  |                                 Description                                  |
-| :-------- | :----- | :--------------------------------------------------------------------------- |
-| **type**  | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.       |
-| **scope** | string | Optional. The scope of link to create. Either `anonymous` or `organization`. |
+|   Name                 |  Type  |                                 Description                                                               |
+| :----------------------| :----- | :---------------------------------------------------------------------------------------------------------|
+| **type**               | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.                                    |
+| **password**           | string | The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.         |
+| **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
+| **scope**              | string | Optional. The scope of link to create. Either `anonymous` or `organization`.                              |
 
 
 ### Link types
@@ -65,10 +67,11 @@ The following values are allowed for the **type** parameter.
 The following values are allowed for the **scope** parameter.
 If the **scope** parameter is not specified, the default link type for the organization is created.
 
-| Type value     | Description                                                                                                                   |
-|:---------------|:------------------------------------------------------------------------------------------------------------------------------|
-| `anonymous`    | Creates a link to the DriveItem accessible to anyone with the link. Anonymous links may be disabled by an administrator.                 |
-| `organization` | Creates a link to the DriveItem accessible to anyone within the user's organization. Organization link scope is not available for OneDrive personal. |
+| Value          | Description
+|:---------------|:------------------------------------------------------------
+| `anonymous`    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
+| `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
+
 
 ## Response
 
@@ -96,6 +99,7 @@ Content-type: application/json
 
 {
   "type": "view",
+  "password": "ThisIsMyPrivatePassword",
   "scope": "anonymous"
 }
 ```
@@ -133,7 +137,8 @@ Content-Type: application/json
       "id": "1234",
       "displayName": "Sample Application"
     },
-  }
+  },
+  "hasPassword": true
 }
 ```
 

--- a/api-reference/beta/api/driveitem-createlink.md
+++ b/api-reference/beta/api/driveitem-createlink.md
@@ -44,12 +44,12 @@ POST /users/{userId}/drive/items/{itemId}/createLink
 The body of the request defines properties of the sharing link your application is requesting.
 The request should be a JSON object with the following properties.
 
-|   Name                 |  Type  |                                 Description                                                               |
+|   Property                 |  Type  |                                 Description                                                               |
 | :----------------------| :----- | :---------------------------------------------------------------------------------------------------------|
-| **type**               | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.                                    |
-| **password**           | string | The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.         |
-| **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
-| **scope**              | string | Optional. The scope of link to create. Either `anonymous` or `organization`.                              |
+|type               | string | The type of sharing link to create. Either view, edit, or embed.                                    |
+|password           | string | The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.         |
+|expirationDateTime | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
+|scope              | string | Optional. The scope of link to create. Either anonymous or organization.                              |
 
 
 ### Link types
@@ -58,9 +58,9 @@ The following values are allowed for the **type** parameter.
 
 | Type value | Description                                                                                  |
 |:-----------|:---------------------------------------------------------------------------------------------|
-| `view`     | Creates a read-only link to the DriveItem.                                                        |
-| `edit`     | Creates a read-write link to the DriveItem.                                                       |
-| `embed`    | Creates an embeddable link to the DriveItem. This option is only available for files in OneDrive personal. |
+| view     | Creates a read-only link to the DriveItem.                                                        |
+| edit     | Creates a read-write link to the DriveItem.                                                       |
+| embed    | Creates an embeddable link to the DriveItem. This option is only available for files in OneDrive personal. |
 
 ### Scope types
 
@@ -69,8 +69,8 @@ If the **scope** parameter is not specified, the default link type for the organ
 
 | Value          | Description
 |:---------------|:------------------------------------------------------------
-| `anonymous`    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
-| `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
+| anonymous    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
+| organization | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
 
 
 ## Response

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -27,6 +27,12 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 |Addition|beta|Added the **revision** property to the [groupPolicyDefinitionFile](/graph/api/resources/intune-grouppolicy-grouppolicydefinitionfile?view=graph-rest-beta) entity|
 |Addition|beta|Added the **valuePrefix** property to the [groupPolicyPresentationListBox](/graph/api/resources/intune-grouppolicy-grouppolicypresentationlistbox?view=graph-rest-beta) entity|
 
+### OneDrive and Sharepoint APIs
+|Change type|Version|Description|
+|:---|:---|:---|
+|Addition|beta|Added the **expirationDatetime** property to the [createLink](/graph/api/driveitem-createlink?view=graph-rest-beta) action. |
+|Addition|beta|Added the **password** property to the [createLink](/graph/api/driveitem-createlink?view=graph-rest-beta) action. |
+
 ## June 2019
 
 ### Devices and apps (Microsoft Intune)


### PR DESCRIPTION
`permission.md` documentation makes reference to `password` and `expirationDateTime` but the `createLink` documentation does not. The schema is published, so you can call the API as expected, the documentation just doesn't align. This PR fixes that.