### PR TITLE
Fixed http request format in various docs

### DIFF
--- a/api-reference/beta/api/accessreview-addreviewer.md
+++ b/api-reference/beta/api/accessreview-addreviewer.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /accessReviews('{reviewId}')/reviewers
+POST /accessReviews/{reviewId}/reviewers
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-apply.md
+++ b/api-reference/beta/api/accessreview-apply.md
@@ -33,7 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /accessReviews('<id>')/applyDecisions()
+POST /accessReviews/{reviewId}/applyDecisions
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-delete.md
+++ b/api-reference/beta/api/accessreview-delete.md
@@ -26,7 +26,7 @@ The caller should also have ProgramControl.ReadWrite.All permission, so that it 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /accessReviews('<id>')
+DELETE /accessReviews/{reviewId}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-get.md
+++ b/api-reference/beta/api/accessreview-get.md
@@ -31,7 +31,7 @@ In order to call this API, the signed in user must also be in a directory role t
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /accessReviews('{reviewId}')
+GET /accessReviews/{reviewId}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-listdecisions.md
+++ b/api-reference/beta/api/accessreview-listdecisions.md
@@ -29,7 +29,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /accessReviews('{reviewId}')/decisions
+GET /accessReviews/{reviewId}/decisions
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-listmydecisions.md
+++ b/api-reference/beta/api/accessreview-listmydecisions.md
@@ -26,7 +26,7 @@ The signed in user must also be permitted to read this particular access review.
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /accessReviews('{reviewId}')/myDecisions
+GET /accessReviews/{reviewId}/myDecisions
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-listreviewers.md
+++ b/api-reference/beta/api/accessreview-listreviewers.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /accessReviews('{reviewId}')/reviewers
+GET /accessReviews/{reviewId}/reviewers
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-removereviewer.md
+++ b/api-reference/beta/api/accessreview-removereviewer.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /accessReviews('{reviewId}')/reviewers('{userId'})
+DELETE /accessReviews/{reviewId}/reviewers/{userId}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-reset.md
+++ b/api-reference/beta/api/accessreview-reset.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /accessReviews('<id>')/resetDecisions()
+POST /accessReviews/{reviewId}/resetDecisions
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-sendreminder.md
+++ b/api-reference/beta/api/accessreview-sendreminder.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /accessReviews('<id>')/sendReminder()
+POST /accessReviews/{reviewId}/sendReminder
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-stop.md
+++ b/api-reference/beta/api/accessreview-stop.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /accessReviews('<id>')/stop()
+POST /accessReviews/{reviewId}/stop
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/accessreview-update.md
+++ b/api-reference/beta/api/accessreview-update.md
@@ -28,7 +28,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /accessReviews('{reviewId}')
+PATCH /accessReviews/{reviewId}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/agreement-delete.md
+++ b/api-reference/beta/api/agreement-delete.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /agreements/<id>
+DELETE /agreements/{id}
 ```
 ## Request headers
 | Name         | Type        | Description |
@@ -47,7 +47,7 @@ If successful, this method returns a `204, No Content` response code. It does no
   "name": "delete_agreement"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/agreements/<id>
+DELETE https://graph.microsoft.com/beta/agreements/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-agreement-csharp-snippets.md)]

--- a/api-reference/beta/api/agreement-get.md
+++ b/api-reference/beta/api/agreement-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /agreements/<id>
+GET /agreements/{id}
 ```
 <!--
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and [agreement](../r
   "name": "get_agreement"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/agreements/<id>?$expand=files
+GET https://graph.microsoft.com/beta/agreements/{id}?$expand=files
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-agreement-csharp-snippets.md)]

--- a/api-reference/beta/api/agreement-update.md
+++ b/api-reference/beta/api/agreement-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /agreements/<id>
+PATCH /agreements/{id}
 ```
 ## Request headers
 | Name         | Type        | Description |
@@ -50,7 +50,7 @@ If successful, this method returns a `200 OK` response code and an updated [agre
   "name": "update_agreement"
 }-->
 ```http
-PATCH https://graph.microsoft.com/beta/agreements/<id>
+PATCH https://graph.microsoft.com/beta/agreements/{id}
 Content-type: application/json
 Content-length: 85
 

--- a/api-reference/beta/api/applicationsignindetailedsummary-get.md
+++ b/api-reference/beta/api/applicationsignindetailedsummary-get.md
@@ -55,7 +55,7 @@ The following is an example of the request.
   "name": "get_applicationsignindetailedsummary"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/reports/applicationSignInDetailedSummary/<id>
+GET https://graph.microsoft.com/beta/reports/applicationSignInDetailedSummary/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-applicationsignindetailedsummary-csharp-snippets.md)]

--- a/api-reference/beta/api/attachment-delete.md
+++ b/api-reference/beta/api/attachment-delete.md
@@ -70,8 +70,8 @@ Attachments for an [Outlook task](../resources/outlooktask.md).
 <!-- { "blockType": "ignored" } -->
 
 ```http
-DELETE /me/outlook/tasks/<id>/attachments/{id}
-DELETE /users/<id>/outlook/tasks/<id>/attachments/{id}
+DELETE /me/outlook/tasks/{id}/attachments/{id}
+DELETE /users/{id}/outlook/tasks/{id}/attachments/{id}
 ```
 
 Attachments for a [post](../resources/post.md) in a [thread](../resources/conversationthread.md) belonging to a [conversation](../resources/conversation.md) of a group.

--- a/api-reference/beta/api/bookingbusiness-delete.md
+++ b/api-reference/beta/api/bookingbusiness-delete.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /bookingBusinesses/<id>
+DELETE /bookingBusinesses/{id}
 
 ```
 ## Request headers

--- a/api-reference/beta/api/bookingbusiness-get.md
+++ b/api-reference/beta/api/bookingbusiness-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /bookingBusinesses/<id>
+GET /bookingBusinesses/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.

--- a/api-reference/beta/api/bookingbusiness-update.md
+++ b/api-reference/beta/api/bookingbusiness-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /bookingBusinesses/<id>
+PATCH /bookingBusinesses/{id}
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/bookingcurrency-get.md
+++ b/api-reference/beta/api/bookingcurrency-get.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /bookingCurrencies/<id>
+GET /bookingCurrencies/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.

--- a/api-reference/beta/api/contact-delta.md
+++ b/api-reference/beta/api/contact-delta.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/contactFolders/{id}/contacts/delta
-GET /users/<id>/contactFolders/{id}/contacts/delta
+GET /users/{id}/contactFolders/{id}/contacts/delta
 ```
 
 ## Query parameters

--- a/api-reference/beta/api/contactfolder-delta.md
+++ b/api-reference/beta/api/contactfolder-delta.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/contactFolders/delta
-GET /users/<id>/contactFolders/delta
+GET /users/{id}/contactFolders/delta
 ```
 
 ## Query parameters

--- a/api-reference/beta/api/event-delta.md
+++ b/api-reference/beta/api/event-delta.md
@@ -35,7 +35,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/calendarView/delta?startDateTime={start_datetime}&endDateTime={end_datetime}
-GET /users/<id>/calendarView/delta?startDateTime={start_datetime}&endDateTime={end_datetime}
+GET /users/{id}/calendarView/delta?startDateTime={start_datetime}&endDateTime={end_datetime}
 
 ```
 

--- a/api-reference/beta/api/group-validateproperties.md
+++ b/api-reference/beta/api/group-validateproperties.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ``` http
-POST /groups/<id>/validateProperties
+POST /groups/{id}/validateProperties
 ```
 
 ## Request headers

--- a/api-reference/beta/api/mailfolder-delta.md
+++ b/api-reference/beta/api/mailfolder-delta.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/mailFolders/delta
-GET /users/<id>/mailFolders/delta
+GET /users/{id}/mailFolders/delta
 ```
 
 ## Query parameters

--- a/api-reference/beta/api/message-delta.md
+++ b/api-reference/beta/api/message-delta.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/mailFolders/{id}/messages/delta
-GET /users/<id>/mailFolders/{id}/messages/delta
+GET /users/{id}/mailFolders/{id}/messages/delta
 ```
 
 ## Query parameters

--- a/api-reference/beta/api/plannerassignedtotaskboardtaskformat-get.md
+++ b/api-reference/beta/api/plannerassignedtotaskboardtaskformat-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/tasks/<id>/assignedToTaskBoardFormat
+GET /planner/tasks/{id}/assignedToTaskBoardFormat
 ```
 ## Request headers
 | Name      |Description|

--- a/api-reference/beta/api/plannerassignedtotaskboardtaskformat-update.md
+++ b/api-reference/beta/api/plannerassignedtotaskboardtaskformat-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/tasks/<id>/assignedToTaskBoardFormat
+PATCH /planner/tasks/{id}/assignedToTaskBoardFormat
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/plannerbucket-delete.md
+++ b/api-reference/beta/api/plannerbucket-delete.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /planner/buckets/<id>
+DELETE /planner/buckets/{id}
 ```
 ## Request headers
 | Name       | Description|
@@ -51,7 +51,7 @@ Here is an example of the request.
   "name": "delete_plannerbucket"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/planner/buckets/<id>
+DELETE https://graph.microsoft.com/beta/planner/buckets/{id}
 If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/plannerbucket-get.md
+++ b/api-reference/beta/api/plannerbucket-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/buckets/<id>
+GET /planner/buckets/{id}
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerbucket-list-tasks.md
+++ b/api-reference/beta/api/plannerbucket-list-tasks.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/buckets/<id>/tasks
+GET /planner/buckets/{id}/tasks
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerbucket-update.md
+++ b/api-reference/beta/api/plannerbucket-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/buckets/<id>
+PATCH /planner/buckets/{id}
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/plannerbuckettaskboardtaskformat-get.md
+++ b/api-reference/beta/api/plannerbuckettaskboardtaskformat-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/tasks/<id>/bucketTaskBoardFormat
+GET /planner/tasks/{id}/bucketTaskBoardFormat
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerbuckettaskboardtaskformat-update.md
+++ b/api-reference/beta/api/plannerbuckettaskboardtaskformat-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/tasks/<id>/bucketTaskBoardFormat
+PATCH /planner/tasks/{id}/bucketTaskBoardFormat
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/plannerplan-delete.md
+++ b/api-reference/beta/api/plannerplan-delete.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /planner/plans/<id>
+DELETE /planner/plans/{id}
 
 ```
 ## Request headers
@@ -52,7 +52,7 @@ Here is an example of the request.
   "name": "delete_plannerplan"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/planner/plans/<id>
+DELETE https://graph.microsoft.com/beta/planner/plans/{id}
 If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/plannerplan-get.md
+++ b/api-reference/beta/api/plannerplan-get.md
@@ -50,7 +50,7 @@ Here is an example of the request.
   "name": "get_plannerplan"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/planner/plans/<id>
+GET https://graph.microsoft.com/beta/planner/plans/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-plannerplan-csharp-snippets.md)]

--- a/api-reference/beta/api/plannerplan-update.md
+++ b/api-reference/beta/api/plannerplan-update.md
@@ -59,7 +59,7 @@ Here is an example of the request.
   "name": "update_plannerplan"
 }-->
 ```http
-PATCH https://graph.microsoft.com/beta/planner/plans/<id>
+PATCH https://graph.microsoft.com/beta/planner/plans/{id}
 Content-type: application/json
 Content-length: 29
 If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="

--- a/api-reference/beta/api/plannerplandetails-get.md
+++ b/api-reference/beta/api/plannerplandetails-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/plans/<id>/details
+GET /planner/plans/{id}/details
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannerplandetails-update.md
+++ b/api-reference/beta/api/plannerplandetails-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/plans/<id>/details
+PATCH /planner/plans/{id}/details
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/plannerprogresstaskboardtaskformat-get.md
+++ b/api-reference/beta/api/plannerprogresstaskboardtaskformat-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/tasks/<id>/progressTaskBoardFormat
+GET /planner/tasks/{id}/progressTaskBoardFormat
 ```
 
 ## Request headers
@@ -51,7 +51,7 @@ Here is an example of the request.
   "name": "get_plannerprogresstaskboardtaskformat"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/planner/tasks/<id>/progressTaskBoardFormat
+GET https://graph.microsoft.com/beta/planner/tasks/{id}/progressTaskBoardFormat
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-plannerprogresstaskboardtaskformat-csharp-snippets.md)]

--- a/api-reference/beta/api/plannerprogresstaskboardtaskformat-update.md
+++ b/api-reference/beta/api/plannerprogresstaskboardtaskformat-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/tasks/<id>/progressTaskBoardFormat
+PATCH /planner/tasks/{id}/progressTaskBoardFormat
 ```
 ## Optional request headers
 | Name       | Description|
@@ -55,7 +55,7 @@ Here is an example of the request.
   "name": "update_plannerprogresstaskboardtaskformat"
 }-->
 ```http
-PATCH https://graph.microsoft.com/beta/planner/tasks/<id>/progressTaskBoardFormat
+PATCH https://graph.microsoft.com/beta/planner/tasks/{id}/progressTaskBoardFormat
 Content-type: application/json
 Content-length: 34
 If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="

--- a/api-reference/beta/api/plannertask-delete.md
+++ b/api-reference/beta/api/plannertask-delete.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /planner/tasks/<id>
+DELETE /planner/tasks/{id}
 ```
 ## Request headers
 | Name       | Description|
@@ -51,7 +51,7 @@ Here is an example of the request.
   "name": "delete_plannertask"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/planner/tasks/<id>
+DELETE https://graph.microsoft.com/beta/planner/tasks/{id}
 If-Match: W/"JzEtVGFzayAgQEBAQEBAQEBAQEBAQEBAWCc="
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/plannertask-get.md
+++ b/api-reference/beta/api/plannertask-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/tasks/<id>
+GET /planner/tasks/{id}
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannertask-update.md
+++ b/api-reference/beta/api/plannertask-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/tasks/<id>
+PATCH /planner/tasks/{id}
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/plannertaskdetails-get.md
+++ b/api-reference/beta/api/plannertaskdetails-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /planner/tasks/<id>/details
+GET /planner/tasks/{id}/details
 ```
 
 ## Request headers

--- a/api-reference/beta/api/plannertaskdetails-update.md
+++ b/api-reference/beta/api/plannertaskdetails-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /planner/tasks/<id>/details
+PATCH /planner/tasks/{id}/details
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/planneruser-get.md
+++ b/api-reference/beta/api/planneruser-get.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/planner
-GET /users/<id>/planner
+GET /users/{id}/planner
 ```
 
 ## Request headers

--- a/api-reference/beta/api/planneruser-list-delta.md
+++ b/api-reference/beta/api/planneruser-list-delta.md
@@ -35,7 +35,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ```http
 GET /me/planner/all/delta
-GET /users/<id>/planner/all/delta
+GET /users/{id}/planner/all/delta
 ```
 
 No additional query parameters (such as `$select`, `$expand`, or `$filter`) are currently supported on Planner's implementation of delta queries.

--- a/api-reference/beta/api/planneruser-list-favoriteplans.md
+++ b/api-reference/beta/api/planneruser-list-favoriteplans.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/planner/favoritePlans
-GET /users/<id>/planner/favoritePlans
+GET /users/{id}/planner/favoritePlans
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.

--- a/api-reference/beta/api/planneruser-list-plans.md
+++ b/api-reference/beta/api/planneruser-list-plans.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/planner/plans
-GET /users/<id>/planner/plans
+GET /users/{id}/planner/plans
 GET /drive/root/createdByUser/planner/plans
 ```
 

--- a/api-reference/beta/api/planneruser-list-recentplans.md
+++ b/api-reference/beta/api/planneruser-list-recentplans.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/planner/recentPlans
-GET /users/<id>/planner/recentPlans
+GET /users/{id}/planner/recentPlans
 ```
 
 ## Request headers

--- a/api-reference/beta/api/planneruser-list-tasks.md
+++ b/api-reference/beta/api/planneruser-list-tasks.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/planner/tasks
-GET /users/<id>/planner/tasks
+GET /users/{id}/planner/tasks
 ```
 
 ## Request headers

--- a/api-reference/beta/api/privilegedapproval-get.md
+++ b/api-reference/beta/api/privilegedapproval-get.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /privilegedApproval/<id>
+GET /privilegedApproval/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
@@ -54,7 +54,7 @@ Here is an example of the request.
   "name": "get_privilegedapproval"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/privilegedApproval/<id>
+GET https://graph.microsoft.com/beta/privilegedApproval/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-privilegedapproval-csharp-snippets.md)]

--- a/api-reference/beta/api/privilegedapproval-update.md
+++ b/api-reference/beta/api/privilegedapproval-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-PATCH /privilegedApproval/<id>
+PATCH /privilegedApproval/{id}
 ```
 ## Optional request headers
 | Name       | Description|

--- a/api-reference/beta/api/privilegedrole-list-assignments.md
+++ b/api-reference/beta/api/privilegedrole-list-assignments.md
@@ -30,7 +30,7 @@ The requestor needs to have one of the following roles: _Privileged Role Adminis
 GET /privilegedRoles/{id}/assignments
 ```
 
-Note that ``<id>`` is the target role id.
+Note that ``{id}`` is the target role id.
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
 

--- a/api-reference/beta/api/privilegedrole-selfactivate.md
+++ b/api-reference/beta/api/privilegedrole-selfactivate.md
@@ -34,7 +34,7 @@ The requestor can only call ```selfActivate``` for the role that is assigned to 
 POST /privilegedRoles/{id}/selfActivate
 ```
 
-Note that ``<id>`` is the target role ID.
+Note that ``{id}`` is the target role ID.
 ## Request headers
 | Name       | Description|
 |:---------------|:----------|

--- a/api-reference/beta/api/privilegedrole-selfdeactivate.md
+++ b/api-reference/beta/api/privilegedrole-selfdeactivate.md
@@ -29,7 +29,7 @@ The requestor can only call ```selfDeactivate``` for the role that is assigned t
 POST /privilegedRoles/{id}/selfDeactivate
 ```
 
-Note that ``<id>`` is the target role id.
+Note that ``{id}`` is the target role id.
 ## Request headers
 | Name       | Description|
 |:---------------|:----------|

--- a/api-reference/beta/api/privilegedroleassignment-delete.md
+++ b/api-reference/beta/api/privilegedroleassignment-delete.md
@@ -30,7 +30,7 @@ The requestor needs to have _Privileged Role Administrator_ role.
 DELETE /privilegedRoleAssignments/{id}
 ```
 
-Note that ``<id>`` is in the format of 'userId_roleId', where userId is the GUID string for Azure AD user id, and roleId is the GUID string for Azure administrator role id.
+Note that ``{id}`` is in the format of 'userId_roleId', where userId is the GUID string for Azure AD user id, and roleId is the GUID string for Azure administrator role id.
 
 ## Request headers
 | Name       | Description|

--- a/api-reference/beta/api/program-delete.md
+++ b/api-reference/beta/api/program-delete.md
@@ -30,7 +30,7 @@ The signed in user must also be in a directory role that permits them to create 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /programs('<id>')
+DELETE /programs('{id}')
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/programcontrol-delete.md
+++ b/api-reference/beta/api/programcontrol-delete.md
@@ -26,7 +26,7 @@ The signed in user must also be in a directory role that permits them to delete 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /programControls('<id>')
+DELETE /programControls('{id}')
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/user-exportpersonaldata.md
+++ b/api-reference/beta/api/user-exportpersonaldata.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /users/<id>/exportPersonalData
+POST /users/{id}/exportPersonalData
 
 ```
 ## Request headers

--- a/api-reference/beta/api/user-findroomlists.md
+++ b/api-reference/beta/api/user-findroomlists.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/findRoomLists
-GET /users/<id>/findRoomLists
+GET /users/{id}/findRoomLists
 
 ```
 

--- a/api-reference/beta/api/user-findrooms.md
+++ b/api-reference/beta/api/user-findrooms.md
@@ -34,7 +34,7 @@ To get all the rooms in the tenant:
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/findRooms
-GET /users/<id>/findRooms
+GET /users/{id}/findRooms
 ```
 
 To get all the rooms in a specific room list of the tenant's:
@@ -42,7 +42,7 @@ To get all the rooms in a specific room list of the tenant's:
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/findRooms(RoomList='{room_list_emailAddress}')
-GET /users/<id>/findRooms(RoomList='{room_list_emailAddress}')
+GET /users/{id}/findRooms(RoomList='{room_list_emailAddress}')
 ```
 
 ## Query parameters

--- a/api-reference/beta/resources/patchcontentcommand.md
+++ b/api-reference/beta/resources/patchcontentcommand.md
@@ -41,7 +41,7 @@ Here is a JSON representation of the resource, which is sent in the body of the 
 |action|String|The action to perform on the target element. Possible values are: `replace`, `append`, `delete`, `insert`, or `prepend`.|
 |content|String|A string of well-formed HTML to add to the page, and any image or file binary data. If the content contains binary data, the request must be sent using the `multipart/form-data` content type with a "Commands" part. |
 |position|String|The location to add the supplied content, relative to the target element. Possible values are: `after` (default) or `before`.|
-|target|String|The element to update. Must be the `#<data-id>` or the generated `<id>` of the element, or the `body` or `title` keyword.|
+|target|String|The element to update. Must be the `#<data-id>` or the generated `{id}` of the element, or the `body` or `title` keyword.|
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->


### PR DESCRIPTION
Updated access review, bookings, planner, PIM, and other documents' HTTP request format to match Graph style.
- Changed argument-style api('\<id\>') pattern to path-based api/{id} pattern where this matched usage in example calls
- Replaced \<id\> with {id} in other path-based requests