### PR TITLE
Removed note for v2.0 auth endpoint not supported in National Clouds

### DIFF
--- a/concepts/deployments.md
+++ b/concepts/deployments.md
@@ -34,8 +34,6 @@ Before calling the Microsoft Graph APIs, you should first register your applicat
 
 To learn more about Azure AD access tokens and Microsoft Graph, see [authentication basics](./auth/auth-concepts.md). For Azure AD authentication scenarios, see [Azure AD authentication basics](https://docs.microsoft.com/azure/active-directory/develop/authentication-scenarios).
 
-> **Note:** The [Azure AD v2.0 authorization and token endpoints](https://docs.microsoft.com/azure/active-directory/develop/v2-overview) are available on the global service only; they are not yet supported for use with national cloud deployments.
-
 
 ## Microsoft Graph and Graph Explorer service root endpoints
 


### PR DESCRIPTION
v2.0 authorization endpoints are supported in National Clouds, so removed the note to avoid confusion.