### PR TITLE
Changed dynamics {id} path syntax

### DIFF
--- a/api-reference/beta/api/contact-delta.md
+++ b/api-reference/beta/api/contact-delta.md
@@ -123,7 +123,7 @@ Content-type: application/json
 Content-length: 337
 
 {
-  "@odata.nextLink":"https://graph.microsoft.com/beta/me/contactfolders('{id}')/contacts/delta?$skiptoken={_skipToken_}",
+  "@odata.nextLink":"https://graph.microsoft.com/beta/me/contactfolders/{id}/contacts/delta?$skiptoken={_skipToken_}",
   "value": [
     {
       "parentFolderId": "parentFolderId-value",

--- a/api-reference/beta/api/dynamics-account-get.md
+++ b/api-reference/beta/api/dynamics-account-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/accounts('{id}')
+GET /financials/companies/{id}/accounts/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and an **accounts** 
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/accounts('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/accounts/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-agedaccountspayable-get.md
+++ b/api-reference/beta/api/dynamics-agedaccountspayable-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/agedAccountsPayable
+GET /financials/companies/{id}/agedAccountsPayable
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
@@ -45,7 +45,7 @@ If successful, this method returns a `200 OK` response code and an **agedAccount
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/agedAccountsPayable?$filter=periodLengthFilter eq '3M'
+GET https://graph.microsoft.com/beta/financials/companies/{id}/agedAccountsPayable?$filter=periodLengthFilter eq '3M'
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-agedaccountsreceivable-get.md
+++ b/api-reference/beta/api/dynamics-agedaccountsreceivable-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/agedAccountsReceivable
+GET /financials/companies/{id}/agedAccountsReceivable
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and an **agedAccount
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/agedAccountsReceivable?$filter=periodLengthFilter eq '3M'
+GET https://graph.microsoft.com/beta/financials/companies/{id}/agedAccountsReceivable?$filter=periodLengthFilter eq '3M'
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-companyinformation-get.md
+++ b/api-reference/beta/api/dynamics-companyinformation-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/companyInformation('{id}')
+GET /financials/companies/{id}/companyInformation/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
@@ -45,7 +45,7 @@ If successful, this method returns a `200 OK` response code and a **companyInfor
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/companyInformation('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/companyInformation/{id}
 ```
 
 **Response**
@@ -73,7 +73,7 @@ Here is an example of the response.
   "currencyCode": "USD",
   "currentFiscalYearStartDate": "2018-01-01",
   "industry": "",
-  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies('{id}')/companyInformation('{id}')/picture",
+  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies/{id}/companyInformation/{id}/picture",
   "businessProfileId": "",
   "lastModifiedDateTime": "2017-03-16T14:57:19.497Z"
 }

--- a/api-reference/beta/api/dynamics-companyinformation-update.md
+++ b/api-reference/beta/api/dynamics-companyinformation-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/companyInformation('{id}')
+PATCH /financials/companies/{id}/companyInformation/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated an **
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/companyInformation('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/companyInformation/{id}
 Content-type: application/json
 
 {
@@ -85,7 +85,7 @@ Content-type: application/json
   "currencyCode": "USD",
   "currentFiscalYearStartDate": "2018-01-01",
   "industry": "",
-  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies('{id}')/companyInformation('{id}')/picture",
+  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies/{id}/companyInformation/{id}/picture",
   "lastModifiedDateTime": "2017-03-16T14:57:19.497Z"
   }
 ```

--- a/api-reference/beta/api/dynamics-countriesregions-delete.md
+++ b/api-reference/beta/api/dynamics-countriesregions-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/countriesRegions('{id}')
+DELETE /financials/companies/{id}/countriesRegions/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
@@ -47,7 +47,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/countriesRegions('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/countriesRegions/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-countriesregions-get.md
+++ b/api-reference/beta/api/dynamics-countriesregions-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/countriesRegions('{id}')
+GET /financials/companies/{id}/countriesRegions/{id}
 ```
 
 ## Optional query parameters
@@ -46,7 +46,7 @@ If successful, this method returns a `200 OK` response code and a **countriesReg
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/countriesRegions('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/countriesRegions/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-countriesregions-update.md
+++ b/api-reference/beta/api/dynamics-countriesregions-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/countriesRegions('{id}')
+PATCH /financials/companies/{id}/countriesRegions/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **cou
 Here is an example of the request.
 
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/countriesRegions('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/countriesRegions/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-countriesregions.md
+++ b/api-reference/beta/api/dynamics-create-countriesregions.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/countriesRegions
+POST /financials/companies/{id}/countriesRegions
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **count
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/countriesRegions
+POST https://graph.microsoft.com/beta/financials/companies/{id}/countriesRegions
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-currencies.md
+++ b/api-reference/beta/api/dynamics-create-currencies.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/currencies
+POST /financials/companies/{id}/currencies
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **curre
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/currencies
+POST https://graph.microsoft.com/beta/financials/companies/{id}/currencies
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-customer.md
+++ b/api-reference/beta/api/dynamics-create-customer.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/customers
+POST /financials/companies/{id}/customers
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **custo
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/customers
+POST https://graph.microsoft.com/beta/financials/companies/{id}/customers
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-customerpayment.md
+++ b/api-reference/beta/api/dynamics-create-customerpayment.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+POST /financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns ```201 Created``` response code and a **custo
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournal('{id}')/customerPayments
+POST https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournal/{id}/customerPayments
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-customerpaymentsjournal.md
+++ b/api-reference/beta/api/dynamics-create-customerpaymentsjournal.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-POST /financials/companies('{id}')/customerPaymentJournals('{id}')
+POST /financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and a **custo
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals
+POST https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals
 Content-type: application/json
 
 ```json

--- a/api-reference/beta/api/dynamics-create-employee.md
+++ b/api-reference/beta/api/dynamics-create-employee.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/employees
+POST /financials/companies/{id}/employees
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and an **empl
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/employees
+POST https://graph.microsoft.com/beta/financials/companies/{id}/employees
 Content-type: application/json
 
 {
@@ -106,7 +106,7 @@ Content-type: application/json
   "terminationDate": "0001-01-01",
   "status": "Active",
   "birthDate": "1973-12-12",
-  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies('{id}')/employees('{id}')/picture",
+  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies/{id}/employees/{id}/picture",
   "lastModifiedDateTime": "2017-03-16T14:57:19.497Z" 
 }
 

--- a/api-reference/beta/api/dynamics-create-item.md
+++ b/api-reference/beta/api/dynamics-create-item.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/items
+POST /financials/companies/{id}/items
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns ```201 Created``` response code and an **item
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/items
+POST https://graph.microsoft.com/beta/financials/companies/{id}/items
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-itemcategories.md
+++ b/api-reference/beta/api/dynamics-create-itemcategories.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/itemCategories
+POST /financials/companies/{id}/itemCategories
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and an **item
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/itemCategories
+POST https://graph.microsoft.com/beta/financials/companies/{id}/itemCategories
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-journal.md
+++ b/api-reference/beta/api/dynamics-create-journal.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-POST /financials/companies('{id}')/journals('{id}')
+POST /financials/companies/{id}/journals/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and a **journ
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/journals
+POST https://graph.microsoft.com/beta/financials/companies/{id}/journals
 Content-type: application/json
 
 ```json

--- a/api-reference/beta/api/dynamics-create-journalline.md
+++ b/api-reference/beta/api/dynamics-create-journalline.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-POST /financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+POST /financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and **journal
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')/journalLines
+POST https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}/journalLines
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-paymentmethods.md
+++ b/api-reference/beta/api/dynamics-create-paymentmethods.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/paymentMethods
+POST /financials/companies/{id}/paymentMethods
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **payme
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/paymentMethods
+POST https://graph.microsoft.com/beta/financials/companies/{id}/paymentMethods
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-paymentterms.md
+++ b/api-reference/beta/api/dynamics-create-paymentterms.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/paymentTerms
+POST /financials/companies/{id}/paymentTerms
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **payme
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/paymentTerms
+POST https://graph.microsoft.com/beta/financials/companies/{id}/paymentTerms
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-shipmentmethods.md
+++ b/api-reference/beta/api/dynamics-create-shipmentmethods.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/shipmentMethods
+POST /financials/companies/{id}/shipmentMethods
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and a **shipm
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/shipmentMethods
+POST https://graph.microsoft.com/beta/financials/companies/{id}/shipmentMethods
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-taxarea.md
+++ b/api-reference/beta/api/dynamics-create-taxarea.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-POST /financials/companies('{id}')/taxAreas('{id}')
+POST /financials/companies/{id}/taxAreas/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and a **taxAr
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/taxAreas
+POST https://graph.microsoft.com/beta/financials/companies/{id}/taxAreas
 Content-type: application/json
 
 ```json

--- a/api-reference/beta/api/dynamics-create-taxgroups.md
+++ b/api-reference/beta/api/dynamics-create-taxgroups.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/taxGroups
+POST /financials/companies/{id}/taxGroups
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```201 Created``` response code and a **taxGr
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/taxGroups
+POST https://graph.microsoft.com/beta/financials/companies/{id}/taxGroups
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-unitsofmeasure.md
+++ b/api-reference/beta/api/dynamics-create-unitsofmeasure.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/unitsOfMeasure
+POST /financials/companies/{id}/unitsOfMeasure
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **units
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/unitsOfMeasure
+POST https://graph.microsoft.com/beta/financials/companies/{id}/unitsOfMeasure
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-create-vendor.md
+++ b/api-reference/beta/api/dynamics-create-vendor.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-POST /financials/companies('{id}')/vendors
+POST /financials/companies/{id}/vendors
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```201 Created``` response code and a **vendo
 Here is an example of a request.
 
 ```json
-POST https://graph.microsoft.com/beta/financials/companies('{id}')/vendors
+POST https://graph.microsoft.com/beta/financials/companies/{id}/vendors
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-currencies-delete.md
+++ b/api-reference/beta/api/dynamics-currencies-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/currencies('{id}')
+DELETE /financials/companies/{id}/currencies/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/currencies('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/currencies/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-currencies-get.md
+++ b/api-reference/beta/api/dynamics-currencies-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/currencies('{id}')
+GET /financials/companies/{id}/currencies/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and a **currencies**
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/currencies('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/currencies/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-currencies-update.md
+++ b/api-reference/beta/api/dynamics-currencies-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/currencies('{id}')
+PATCH /financials/companies/{id}/currencies/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **cur
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/currencies('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/currencies/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-customer-delete.md
+++ b/api-reference/beta/api/dynamics-customer-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/customers('{id}')
+DELETE /financials/companies/{id}/customers/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/customers('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/customers/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-customer-get.md
+++ b/api-reference/beta/api/dynamics-customer-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/customers('{id}')
+GET /financials/companies/{id}/customers/{id}
 ```
 
 ## Optional query parameters
@@ -45,7 +45,7 @@ If successful, this method returns a `200 OK` response code and a **customers** 
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/customers('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/customers/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-customer-update.md
+++ b/api-reference/beta/api/dynamics-customer-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/customers('{id}')
+PATCH /financials/companies/{id}/customers/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **cus
 Here is an example of the request.
 
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/customers('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/customers/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-customerpayment-delete.md
+++ b/api-reference/beta/api/dynamics-customerpayment-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+DELETE /financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-customerpayment-get.md
+++ b/api-reference/beta/api/dynamics-customerpayment-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+GET /financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **customerPaym
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-customerpayment-update.md
+++ b/api-reference/beta/api/dynamics-customerpayment-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+PATCH /financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **cus
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')/customerPayments('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}/customerPayments/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-customerpaymentsjournal-delete.md
+++ b/api-reference/beta/api/dynamics-customerpaymentsjournal-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/customerPaymentJournals('{id}')
+DELETE /financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-customerpaymentsjournal-get.md
+++ b/api-reference/beta/api/dynamics-customerpaymentsjournal-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/customerPaymentJournals('{id}')
+GET /financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and a **customerPaym
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-customerpaymentsjournal-update.md
+++ b/api-reference/beta/api/dynamics-customerpaymentsjournal-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/customerPaymentJournals('{id}')
+PATCH /financials/companies/{id}/customerPaymentJournals/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns a `200 OK` response code and an updated **cus
 Here is an example of the request.
 
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/customerPaymentJournals('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/customerPaymentJournals/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-dimension-get.md
+++ b/api-reference/beta/api/dynamics-dimension-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/dimensions('{id}')
+GET /financials/companies/{id}/dimensions/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **dimensions**
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/dimensions('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/dimensions/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-dimensionvalue-get.md
+++ b/api-reference/beta/api/dynamics-dimensionvalue-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/dimensions('{id}')/dimensionValues('{id}')
+GET /financials/companies/{id}/dimensions/{id}/dimensionValues/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **dimensionVal
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/dimensions('{id}')/dimensionValues('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/dimensions/{id}/dimensionValues/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-employee-delete.md
+++ b/api-reference/beta/api/dynamics-employee-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/employees('{id}')
+DELETE /financials/companies/{id}/employees/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/employees('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/employees/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-employee-get.md
+++ b/api-reference/beta/api/dynamics-employee-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/employees('{id}')
+GET /financials/companies/{id}/employees/{id}
 ```
 
 ## Optional query parameters
@@ -45,7 +45,7 @@ If successful, this method returns a `200 OK` response code and an **employees**
 Here is an example of the request.
 
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/employees('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/employees/{id}
 ```
 
 **Response**
@@ -78,7 +78,7 @@ Here is an example of the response.
   "terminationDate": "0001-01-01",
   "status": "Active",
   "birthDate": "1973-12-12",
-  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies('{id}')/employees('{id}')/picture",
+  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies/{id}/employees/{id}/picture",
   "lastModifiedDateTime": "2017-03-16T14:57:19.497Z"  
 }
 ```

--- a/api-reference/beta/api/dynamics-employee-update.md
+++ b/api-reference/beta/api/dynamics-employee-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/employees('{id}')
+PATCH /financials/companies/{id}/employees/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns a `200 OK` response code and an updated **emp
 Here is an example of the request.
 
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/employees('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/employees/{id}
 Content-type: application/json
 
 {
@@ -92,7 +92,7 @@ Content-type: application/json
   "terminationDate": "0001-01-01",
   "status": "Active",
   "birthDate": "1973-12-12",
-  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies('{id}')/employees('{id}')/picture",
+  "picture@odata.mediaReadLink": "https://api.financials.dynamics.com/v1.0/api/beta/companies/{id}/employees/{id}/picture",
   "lastModifiedDateTime": "2017-03-16T14:57:19.497Z" 
 }
 ```

--- a/api-reference/beta/api/dynamics-generalledgerentries-get.md
+++ b/api-reference/beta/api/dynamics-generalledgerentries-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/generalLedgerEntries('{id}')
+GET /financials/companies/{id}/generalLedgerEntries/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **generalLedge
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/generalLedgerEntries('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/generalLedgerEntries/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-item-delete.md
+++ b/api-reference/beta/api/dynamics-item-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/items('{id}')
+DELETE /financials/companies/{id}/items/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 
 Here is an example of the request.
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/items('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/items/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-item-get.md
+++ b/api-reference/beta/api/dynamics-item-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/items('{id}')
+GET /financials/companies/{id}/items/{id}
 ```
 
 ## Optional query parameters
@@ -46,7 +46,7 @@ If successful, this method returns a `200 OK` response code and an **items** obj
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/items('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/items/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-item-update.md
+++ b/api-reference/beta/api/dynamics-item-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/items('{id}')
+PATCH /financials/companies/{id}/items/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and an updated **ite
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/items('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/items/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-itemcategories-delete.md
+++ b/api-reference/beta/api/dynamics-itemcategories-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/itemCategories('{id}')
+DELETE /financials/companies/{id}/itemCategories/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/itemCategories('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/itemCategories/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-itemcategories-get.md
+++ b/api-reference/beta/api/dynamics-itemcategories-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/itemCategories('{id}')
+GET /financials/companies/{id}/itemCategories/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and an **itemCategor
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/itemCategories('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/itemCategories/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-itemcategories-update.md
+++ b/api-reference/beta/api/dynamics-itemcategories-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/itemCategories('{id}')
+PATCH /financials/companies/{id}/itemCategories/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **ite
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/itemCategories('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/itemCategories/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-journal-delete.md
+++ b/api-reference/beta/api/dynamics-journal-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/journals('{id}')
+DELETE /financials/companies/{id}/journals/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-journal-get.md
+++ b/api-reference/beta/api/dynamics-journal-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/journals('{id}')
+GET /financials/companies/{id}/journals/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **journals** o
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-journal-update.md
+++ b/api-reference/beta/api/dynamics-journal-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/journals('{id}')
+PATCH /financials/companies/{id}/journals/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **jou
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-journalline-delete.md
+++ b/api-reference/beta/api/dynamics-journalline-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+DELETE /financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-journalline-get.md
+++ b/api-reference/beta/api/dynamics-journalline-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+GET /financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **journalLines
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-journalline-update.md
+++ b/api-reference/beta/api/dynamics-journalline-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+PATCH /financials/companies/{id}/journals/{id}/journalLines/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **jou
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/journals('{id}')/journalLines('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/journals/{id}/journalLines/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-paymentmethods-delete.md
+++ b/api-reference/beta/api/dynamics-paymentmethods-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/paymentMethods('{id}')
+DELETE /financials/companies/{id}/paymentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/paymentMethods('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/paymentMethods/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-paymentmethods-get.md
+++ b/api-reference/beta/api/dynamics-paymentmethods-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/paymentMethods('{id}')
+GET /financials/companies/{id}/paymentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **paymentMetho
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/paymentMethods('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/paymentMethods/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-paymentmethods-update.md
+++ b/api-reference/beta/api/dynamics-paymentmethods-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/paymentMethods('{id}')
+PATCH /financials/companies/{id}/paymentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **pay
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/paymentMethods('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/paymentMethods/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-paymentterms-delete.md
+++ b/api-reference/beta/api/dynamics-paymentterms-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/paymentTerms('{id}')
+DELETE /financials/companies/{id}/paymentTerms/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/paymentTerms('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/paymentTerms/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-paymentterms-get.md
+++ b/api-reference/beta/api/dynamics-paymentterms-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/paymentTerms('{id}')
+GET /financials/companies/{id}/paymentTerms/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **paymentTerms
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/paymentTerms('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/paymentTerms/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-paymentterms-update.md
+++ b/api-reference/beta/api/dynamics-paymentterms-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/paymentTerms('{id}')
+PATCH /financials/companies/{id}/paymentTerms/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **pay
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/paymentTerms('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/paymentTerms/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-shipmentmethods-delete.md
+++ b/api-reference/beta/api/dynamics-shipmentmethods-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/shipmentMethods('{id}')
+DELETE /financials/companies/{id}/shipmentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204,No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/shipmentMethods('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/shipmentMethods/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-shipmentmethods-get.md
+++ b/api-reference/beta/api/dynamics-shipmentmethods-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/shipmentMethods('{id}')
+GET /financials/companies/{id}/shipmentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **shipmentMeth
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/shipmentMethods('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/shipmentMethods/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-shipmentmethods-update.md
+++ b/api-reference/beta/api/dynamics-shipmentmethods-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/shipmentMethods('{id}')
+PATCH /financials/companies/{id}/shipmentMethods/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **shi
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/shipmentMethods('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/shipmentMethods/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-taxGroups-update.md
+++ b/api-reference/beta/api/dynamics-taxGroups-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/taxGroups('{id}')
+PATCH /financials/companies/{id}/taxGroups/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **tax
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/taxGroups('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/taxGroups/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-taxarea-delete.md
+++ b/api-reference/beta/api/dynamics-taxarea-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/taxAreas('{id}')
+DELETE /financials/companies/{id}/taxAreas/{id}
 ```
 
 ## Optional query parameters
@@ -50,7 +50,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/taxAreas('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/taxAreas/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-taxarea-get.md
+++ b/api-reference/beta/api/dynamics-taxarea-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/taxAreas('{id}')
+GET /financials/companies/{id}/taxAreas/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **taxAreas** o
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/taxAreas('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/taxAreas/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-taxarea-update.md
+++ b/api-reference/beta/api/dynamics-taxarea-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/taxAreas('{id}')
+PATCH /financials/companies/{id}/taxAreas/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **tax
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/taxAreas('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/taxAreas/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-taxgroups-delete.md
+++ b/api-reference/beta/api/dynamics-taxgroups-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/taxGroups('{id}')
+DELETE /financials/companies/{id}/taxGroups/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204,No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/taxGroups('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/taxGroups/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-taxgroups-get.md
+++ b/api-reference/beta/api/dynamics-taxgroups-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/taxGroups('{id}')
+GET /financials/companies/{id}/taxGroups/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **taxGroups** 
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/taxGroups('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/taxGroups/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-trialbalance-get.md
+++ b/api-reference/beta/api/dynamics-trialbalance-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-GET /financials/companies('{id}')/trialBalance
+GET /financials/companies/{id}/trialBalance
 ```
 
 ## Optional query parameters
@@ -46,7 +46,7 @@ If successful, this method returns a `200 OK` response code and a **trialBalance
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/trialBalance?$orderby number&$filter=dateFilter ge 2019-01-01 and dateFilter le 2019-12-31
+GET https://graph.microsoft.com/beta/financials/companies/{id}/trialBalance?$orderby number&$filter=dateFilter ge 2019-01-01 and dateFilter le 2019-12-31
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-unitsofmeasure-delete.md
+++ b/api-reference/beta/api/dynamics-unitsofmeasure-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/unitsOfMeasure('{id}')
+DELETE /financials/companies/{id}/unitsOfMeasure/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/unitsOfMeasure('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/unitsOfMeasure/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-unitsofmeasure-get.md
+++ b/api-reference/beta/api/dynamics-unitsofmeasure-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/unitsOfMeasure('{id}')
+GET /financials/companies/{id}/unitsOfMeasure/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **unitsOfMeasu
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/unitsOfMeasure('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/unitsOfMeasure/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-unitsofmeasure-update.md
+++ b/api-reference/beta/api/dynamics-unitsofmeasure-update.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-PATCH /financials/companies('{id}')/unitsOfMeasure('{id}')
+PATCH /financials/companies/{id}/unitsOfMeasure/{id}
 ```
 
 ## Optional query parameters
@@ -49,7 +49,7 @@ If successful, this method returns a `200 OK` response code and an updated **uni
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/unitsOfMeasure('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/unitsOfMeasure/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/dynamics-vendor-delete.md
+++ b/api-reference/beta/api/dynamics-vendor-delete.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-DELETE /financials/companies('{id}')/vendors('{id}')
+DELETE /financials/companies/{id}/vendors/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns ```204 No Content``` response code. It does n
 Here is an example of the request.
 
 ```json
-DELETE https://graph.microsoft.com/beta/financials/companies('{id}')/vendors('{id}')
+DELETE https://graph.microsoft.com/beta/financials/companies/{id}/vendors/{id}
 ```
 
 **Response** 

--- a/api-reference/beta/api/dynamics-vendor-get.md
+++ b/api-reference/beta/api/dynamics-vendor-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 
 ```
-GET /financials/companies('{id}')/vendors('{id}')
+GET /financials/companies/{id}/vendors/{id}
 ```
 
 ## Optional query parameters
@@ -47,7 +47,7 @@ If successful, this method returns a `200 OK` response code and a **vendors** ob
 
 Here is an example of the request.
 ```json
-GET https://graph.microsoft.com/beta/financials/companies('{id}')/vendors('{id}')
+GET https://graph.microsoft.com/beta/financials/companies/{id}/vendors/{id}
 ```
 
 **Response**

--- a/api-reference/beta/api/dynamics-vendor-update.md
+++ b/api-reference/beta/api/dynamics-vendor-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 ```
-PATCH /financials/companies('{id}')/vendors('{id}')
+PATCH /financials/companies/{id}/vendors/{id}
 ```
 
 ## Optional query parameters
@@ -48,7 +48,7 @@ If successful, this method returns a `200 OK` response code and an updated **ven
 
 Here is an example of the request.
 ```json
-PATCH https://graph.microsoft.com/beta/financials/companies('{id}')/vendors('{id}')
+PATCH https://graph.microsoft.com/beta/financials/companies/{id}/vendors/{id}
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/educationsynchronizationerrors-get.md
+++ b/api-reference/beta/api/educationsynchronizationerrors-get.md
@@ -81,7 +81,7 @@ Content-type: application/json
 Content-length: 1568
 
 {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles('{id}')/errors",
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles/{id}/errors",
     "@odata.count": 14,
     "value": [
         {

--- a/api-reference/beta/api/educationsynchronizationprofilestatus-get.md
+++ b/api-reference/beta/api/educationsynchronizationprofilestatus-get.md
@@ -80,7 +80,7 @@ Content-type: application/json
 Content-length: 232
 
 {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles('{id}')/profileStatus/$entity",
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles/{id}/profileStatus/$entity",
     "status": "inProgress",
     "lastSynchronizationDateTime": "2017-07-04T22:06:37.6472621Z"
 }

--- a/api-reference/beta/api/message-delta.md
+++ b/api-reference/beta/api/message-delta.md
@@ -124,7 +124,7 @@ Content-type: application/json
 Content-length: 337
 
 {
-  "@odata.nextLink":"https://graph.microsoft.com/beta/me/mailfolders('{id}')/messages/delta?$skiptoken={_skipToken_}",
+  "@odata.nextLink":"https://graph.microsoft.com/beta/me/mailfolders/{id}/messages/delta?$skiptoken={_skipToken_}",
   "value": [
     {
       "receivedDateTime": "datetime-value",

--- a/api-reference/beta/api/program-delete.md
+++ b/api-reference/beta/api/program-delete.md
@@ -30,7 +30,7 @@ The signed in user must also be in a directory role that permits them to create 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /programs('{id}')
+DELETE /programs/{id}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/api/programcontrol-delete.md
+++ b/api-reference/beta/api/programcontrol-delete.md
@@ -26,7 +26,7 @@ The signed in user must also be in a directory role that permits them to delete 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /programControls('{id}')
+DELETE /programControls/{id}
 ```
 ## Request headers
 | Name         | Type        | Description |

--- a/api-reference/beta/resources/educationsynchronizationprofilestatus.md
+++ b/api-reference/beta/resources/educationsynchronizationprofilestatus.md
@@ -39,7 +39,7 @@ Represents the synchronization status of a school data [synchronization profile]
 
 ```json
 {
-    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles('{id}')/profileStatus/$entity",
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/synchronizationProfiles/{id}/profileStatus/$entity",
     "status": {"@odata.type":"microsoft.graph.educationSynchronizationStatus"},
     "lastSynchronizationDateTime": "DateTimeOffset"
 }

--- a/api-reference/v1.0/api/contact-delta.md
+++ b/api-reference/v1.0/api/contact-delta.md
@@ -128,7 +128,7 @@ Content-type: application/json
 Content-length: 337
 
 {
-  "@odata.nextLink":"https://graph.microsoft.com/v1.0/me/contactfolders('{id}')/contacts/delta?$skiptoken={_skipToken_}",
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/me/contactfolders/{id}/contacts/delta?$skiptoken={_skipToken_}",
   "value": [
     {
       "parentFolderId": "parentFolderId-value",

--- a/api-reference/v1.0/api/message-delta.md
+++ b/api-reference/v1.0/api/message-delta.md
@@ -129,7 +129,7 @@ Content-type: application/json
 Content-length: 337
 
 {
-  "@odata.nextLink":"https://graph.microsoft.com/v1.0/me/mailfolders('{id}')/messages/delta?$skiptoken={_skipToken_}",
+  "@odata.nextLink":"https://graph.microsoft.com/v1.0/me/mailfolders/{id}/messages/delta?$skiptoken={_skipToken_}",
   "value": [
     {
       "receivedDateTime": "datetime-value",

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -125,7 +125,7 @@ GET https://graph.microsoft.com/beta/bookingBusinesses?query=Fabrikam
 When attempting to access events in a calendar that has been shared by another user using the following operation:
 
 ```http
-GET /users('{id}')/calendars('{id}')/events
+GET /users/{id}/calendars/{id}/events
 ```
 
 You may get HTTP 500 with the error code `ErrorInternalServerTransientError`. The error occurs because:
@@ -150,7 +150,7 @@ A calendar shared with you in the new approach appears as just another calendar 
 events in the shared calendar, as if it's your own calendar. As an example:
 
 ```http
-GET /me/calendars('{id}')/events
+GET /me/calendars/{id}/events
 ```
 
 ### Adding and accessing ICS-based calendars in user's mailbox

--- a/concepts/people-example.md
+++ b/concepts/people-example.md
@@ -17,7 +17,7 @@ The People API is particularly useful for people picking scenarios, such as comp
 To call the People API in Microsoft Graph, your app will need the appropriate permissions:
 
 * People.Read - Use to make general People API calls; for example, `https://graph.microsoft.com/v1.0/me/people/`. People.Read requires end user consent.
-* People.Read.All - Required to retrieve the people most relevant to a specified user in the signed-in user’s organization (`https://graph.microsoft.com/v1.0/users('{id}')/people`) calls. People.Read.All requires admin consent.
+* People.Read.All - Required to retrieve the people most relevant to a specified user in the signed-in user’s organization (`https://graph.microsoft.com/v1.0/users/{id}/people`) calls. People.Read.All requires admin consent.
 
 ## Browse people
 


### PR DESCRIPTION
Changed syntax for Dynamics docs (and other pages) from ('{id}') to /{id} to standardize across other Graph documentation.