### PR TITLE
Typo "**@odata.nextLink**"→"**\@odata.nextLink**"

### DIFF
--- a/concepts/onenote-get-content.md
+++ b/concepts/onenote-get-content.md
@@ -542,7 +542,7 @@ Get pages 51 to 100. The API returns 20 entries by default with a maximum of 100
 ```
 
 > **Note:**
-> GET requests for pages that retrieve the default number of entries (that is, they don't specify a **top** expression) return an **@odata.nextLink** link in the response that you can use to get the next 20 entries.
+> GET requests for pages that retrieve the default number of entries (that is, they don't specify a **top** expression) return an **\@odata.nextLink** link in the response that you can use to get the next 20 entries.
  
 
 <a name="supported-odata-query-string-options"></a>


### PR DESCRIPTION
bold with escape characters

https://docs.microsoft.com/en-us/graph/onenote-get-content