### PR TITLE
Change aadConversationMember to aadUserConversationMember

### DIFF
--- a/api-reference/beta/api/conversationmember-add.md
+++ b/api-reference/beta/api/conversationmember-add.md
@@ -68,7 +68,7 @@ content-type: application/json
 content-length: 26
 
 {
-  "@odata.type": "microsoft.graph.aadConversationMember",
+  "@odata.type": "microsoft.graph.aadUserConversationMember",
   "roles": [],
   "user@odata.bind": "https://graph.microsoft.com/beta/users/8b081ef6-4792-4def-b2c9-c363a1bf41d5"
 }


### PR DESCRIPTION
When adding a user to a private channel or chat the @odata.type parameter should be microsoft.graph.aadUserConversationMember, not microsoft.graph.aadConversationMember