### PR TITLE
Non working Example 1

### DIFF
--- a/api-reference/beta/api/channel-post-messages.md
+++ b/api-reference/beta/api/channel-post-messages.md
@@ -67,8 +67,10 @@ POST https://graph.microsoft.com/beta/teams/{id}/channels/{id}/messages
 Content-type: application/json
 
 {
-  "body": {
-    "content": "Hello World"
+  "rootMessage": {
+    "body": {
+      "content": "Ahoj"
+    }
   }
 }
 ```


### PR DESCRIPTION
Based on actual test, the former example doesn't work. Error message: "chatThread.RootMessage cannot be null.\r\nParameter name: chatThread.RootMessage" so it has to contain rootMessage.