### PR TITLE
Add reportOnly mode as a state to conditional access policies

### DIFF
--- a/api-reference/beta/resources/conditionalaccesspolicy.md
+++ b/api-reference/beta/resources/conditionalaccesspolicy.md
@@ -35,7 +35,7 @@ Represents an Azure Active Directory conditional access policy. Conditional acce
 |id|String| Specifies the identifier of a conditionalAccessPolicy object. Read-only.|
 |modifiedDateTime| DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`. Readonly. |
 |sessionControls|[conditionalAccessSessionControls](conditionalaccesssessioncontrols.md)| Specifies the session controls that are enforced after sign-in. |
-|state|string| Specifies the state of the conditionalAccessPolicy object. Possible values are: `enabled`, `disabled`. Required. |
+|state|string| Specifies the state of the conditionalAccessPolicy object. Possible values are: `enabled`, `disabled`, `enabledForReportingButNotEnforced`. Required. |
 
 ## Relationships
 

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -100,6 +100,7 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 | **Change type** | **Version** | **Description**                  |
 |:----------------|:------------|:-----------------------------------------|
 | Addition | beta | Added application-level Policy.Read.All permission for read operations in both conditional access policies and named locations.|
+| Addition | beta | Added support for report-only state: `enabledForReportingButNotEnforced`.|
 
 ### People and workplace intelligence
 


### PR DESCRIPTION
Besides enabled/disabled states, we now support report-only mode