### PR TITLE
Fix typo: change 'reanges' to 'ranges'

### DIFF
--- a/api-reference/v1.0/api/driveitem-createuploadsession.md
+++ b/api-reference/v1.0/api/driveitem-createuploadsession.md
@@ -177,7 +177,7 @@ You may see multiple ranges specified, indicating parts of the file that the ser
 This is useful if you need to resume a transfer that was interrupted and your client is unsure of the state on the service.
 
 You should always determine the size of your byte ranges according to the best practices below. 
-Do not assume that **nextExpectedRanges** will return reanges of proper size for a byte range to upload.
+Do not assume that **nextExpectedRanges** will return ranges of proper size for a byte range to upload.
 The **nextExpectedRanges** property indicates ranges of the file that have not been received and not a pattern for how your app should upload the file.
 
 <!-- { "blockType": "ignored", "@odata.type": "microsoft.graph.uploadSession", "truncated": true } -->


### PR DESCRIPTION
Seems to be a duplicate of #3314 which has been merged before, but it still shows incorrect on https://docs.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0