### PR TITLE
Update channel-post-messages.md

### DIFF
--- a/api-reference/beta/api/channel-post-messages.md
+++ b/api-reference/beta/api/channel-post-messages.md
@@ -238,6 +238,9 @@ Content-length: 160
 
 #### Request
 The following is an example of the request.
+
+> Note: The attachment's ID must be unique and can be a new randomly generated GUID. However, the attachment's ID must be the same in the _body_ and _attachments_ elements.
+
 <!-- {
   "blockType": "request",
   "name": "create_chatmessage_from_channel"


### PR DESCRIPTION
Enhanced documentation with note about how to handle the attachment's ID.

fixed: #6565 