### PR TITLE
Update to appRoleAssignments and appRoleAssignedTo on servicePrincipals

### DIFF
--- a/api-reference/beta/api/approleassignment-delete.md
+++ b/api-reference/beta/api/approleassignment-delete.md
@@ -3,8 +3,8 @@ title: "Delete appRoleAssignment"
 description: "Delete appRoleAssignment."
 localization_priority: Normal
 doc_type: apiPageType
-ms.prod: ""
-author: ""
+ms.prod: "microsoft-identity-platform"
+author: "psignoret"
 ---
 
 # Delete appRoleAssignment
@@ -25,8 +25,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 DELETE /users/{id | userPrincipalName}/appRoleAssignments/{id}
-DELETE /servicePrincipals/{id}/appRoleAssignedTo
 DELETE /groups/{id}/appRoleAssignments/{id}
+DELETE /servicePrincipals/{id}/appRoleAssignments/{id}
+DELETE /servicePrincipals/{id}/appRoleAssignedTo/{id}
 
 ```
 ## Request headers
@@ -51,7 +52,7 @@ Here is an example of the request.
   "name": "delete_approleassignment"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/appRoleAssignments/{id}
+DELETE https://graph.microsoft.com/beta/servicePrincipals/{id}/appRoleAssignedTo/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-approleassignment-csharp-snippets.md)]

--- a/api-reference/beta/api/approleassignment-get.md
+++ b/api-reference/beta/api/approleassignment-get.md
@@ -3,8 +3,8 @@ title: "Get appRoleAssignment"
 description: "Retrieve the properties and relationships of approleassignment object."
 localization_priority: Priority
 doc_type: apiPageType
-ms.prod: ""
-author: ""
+ms.prod: "microsoft-identity-platform"
+author: "psignoret"
 ---
 
 # Get appRoleAssignment
@@ -25,8 +25,9 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /users/{id | userPrincipalName}/appRoleAssignments/{id}
-GET /servicePrincipals/{id}/appRoleAssignedTo
 GET /groups/{id}/appRoleAssignments/{id}
+GET /servicePrincipals/{id}/appRoleAssignments/{id}
+GET /servicePrincipals/{id}/appRoleAssignedTo/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](https://developer.microsoft.com/graph/docs/concepts/query_parameters) to help customize the response.
@@ -52,7 +53,7 @@ Here is an example of the request.
   "name": "get_approleassignment"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/appRoleAssignments/{id}
+GET https://graph.microsoft.com/beta/servicePrincipals/{id}/appRoleAssignedTo/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-approleassignment-csharp-snippets.md)]

--- a/api-reference/beta/resources/approleassignment.md
+++ b/api-reference/beta/resources/approleassignment.md
@@ -3,8 +3,8 @@ title: "appRoleAssignment resource type"
 description: "Used to record when a user or group is assigned to an application. In this case, the role assignment will result in an application tile showing up on the user's app access panel. This entity may also be used to grant another application (modeled as a service principal) access to a resource application in a particular role. You can create, read, update, and delete role assignments."
 localization_priority: Priority
 doc_type: resourcePageType
-ms.prod: ""
-author: ""
+ms.prod: "microsoft-identity-platform"
+author: "psignoret"
 ---
 
 # appRoleAssignment resource type

--- a/api-reference/beta/resources/serviceprincipal.md
+++ b/api-reference/beta/resources/serviceprincipal.md
@@ -69,8 +69,8 @@ This resource supports using [delta query](/graph/delta-query-overview) to track
 ## Relationships
 | Relationship | Type |Description|
 |:---------------|:--------|:----------|
-|appRoleAssignedTo|[appRoleAssignment](approleassignment.md)|Principals (users, groups, and service principals) that are assigned to this service principal. Read-only.|
-|appRoleAssignments|[appRoleAssignment](approleassignment.md) collection|Applications that the service principal is assigned to. Read-only. Nullable.|
+|appRoleAssignedTo|[appRoleAssignment](approleassignment.md)|Principals (users, groups, and service principals) that are assigned to this service principal.|
+|appRoleAssignments|[appRoleAssignment](approleassignment.md) collection|Applications that the service principal is assigned to.|
 |createdObjects|[directoryObject](directoryobject.md) collection|Directory objects created by this service principal. Read-only. Nullable.|
 |memberOf|[directoryObject](directoryobject.md) collection|Roles that this service principal is a member of. HTTP Methods: GET Read-only. Nullable.|
 |oauth2PermissionGrants|[oAuth2PermissionGrant](oauth2permissiongrant.md) collection|User impersonation grants associated with this service principal. Read-only. Nullable.|

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -16,6 +16,7 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 ### Identity and access (Azure AD)
 | **Change type** | **Version**   | **Description**                          |
 |:---|:---|:---|
+|Change | beta |Flipped **appRoleAssignments** and **appRoleAssignedTo** relationships on [ServicePrincipal](/graph/api/resoureces/serviceprincipal.md) to match documentation. **appRoleAssignments** returns app roles granted to the service principal and **appRoleAssignedTo** returns principals granted app roles to the service principal.|
 |Addition|beta, v1.0|Added support for returning a limited amount of information when your application does not have access to some of the types in a response's collection. For more details, see [Limited information returned for inaccessible member objects](permissions-reference.md#limited-information-returned-for-inaccessible-member-objects).|
 
 

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -16,7 +16,7 @@ For details about known issues with Microsoft Graph APIs, see [Known issues](kno
 ### Identity and access (Azure AD)
 | **Change type** | **Version**   | **Description**                          |
 |:---|:---|:---|
-|Change | beta |Flipped **appRoleAssignments** and **appRoleAssignedTo** relationships on [ServicePrincipal](/graph/api/resoureces/serviceprincipal.md) to match documentation. **appRoleAssignments** returns app roles granted to the service principal and **appRoleAssignedTo** returns principals granted app roles to the service principal.|
+|Change | beta |Updated the behavior of the **appRoleAssignments** and **appRoleAssignedTo** relationships on [servicePrincipal](/graph/api/resoureces/serviceprincipal.md) to return the roles as documented. **appRoleAssignments** returns app roles granted to the service principal and **appRoleAssignedTo** returns principals granted app roles to the service principal.|
 |Addition|beta, v1.0|Added support for returning a limited amount of information when your application does not have access to some of the types in a response's collection. For more details, see [Limited information returned for inaccessible member objects](permissions-reference.md#limited-information-returned-for-inaccessible-member-objects).|
 
 


### PR DESCRIPTION
The **appRoleAssignments** and **appRoleAssignedTo** navigations on **servicePrincipals** have been updated to match the documentation, and align with **appRoleAssignments** navigation on users and groups.