### PR TITLE
Fix directoryobject/validateproperties beta permissions table

### DIFF
--- a/api-reference/beta/api/directoryobject-validateproperties.md
+++ b/api-reference/beta/api/directoryobject-validateproperties.md
@@ -18,9 +18,14 @@ The following validations are performed for the display name and mail nickname p
 
 This API returns with the first failure encountered. If one or more properties fail multiple validations, only the property with the first validation failure is returned. However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy.
 
-## Prerequisites
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-The following **permission** is required to execute this API: *Group.Read.All*
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Group.Read.All, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | Group.Read.All, Group.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/directorysetting-delete.md
+++ b/api-reference/beta/api/directorysetting-delete.md
@@ -13,7 +13,7 @@ doc_type: apiPageType
 
 Delete a directory setting.
 
-> **Note**: The /beta version of this API is only applies to groups. The /v1.0 version of this API has been renamed to *Delete groupSettings*.
+> **Note**: The /beta version of this API only applies to groups. The /v1.0 version of this API has been renamed to *Delete groupSettings*.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/directorysetting-get.md
+++ b/api-reference/beta/api/directorysetting-get.md
@@ -13,7 +13,7 @@ doc_type: apiPageType
 
 Retrieve the properties of a specific directory setting object.
 
-> **Note**: The /beta version of this API is only applies to groups. The /v1.0 version of this API has been renamed to *Get groupSettings*.
+> **Note**: The /beta version of this API only applies to groups. The /v1.0 version of this API has been renamed to *Get groupSettings*.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/directorysetting-post-settings.md
+++ b/api-reference/beta/api/directorysetting-post-settings.md
@@ -13,7 +13,7 @@ doc_type: apiPageType
 
 Use this API to create a new setting, based on the templates available in directorySettingTemplates. These settings can be at the tenant-level or at an object level (currently only for groups). The creation request must provide settingValues for all the settings defined in the template. For group-specific settings, only the setting governing whether members of a group can invite guest users can be set. This will govern this behavior once the ability to add guest users to a group is generally available.
 
-> **Note**: The /beta version of this API is only applies to groups. The /v1.0 version of this API has been renamed to *Create groupSettings*.
+> **Note**: The /beta version of this API only applies to groups. The /v1.0 version of this API has been renamed to *Create groupSettings*.
 
 For a list of templates and the properties they support in beta, use a [directorySettingTemplate query](https://developer.microsoft.com/graph/graph-explorer?request=directorySettingTemplates&version=beta). (For v1.0 endpoints, call [groupSettingTemplates](https://developer.microsoft.com/graph/graph-explorer?request=groupSettingTemplates&version=v1.0).)
 

--- a/api-reference/beta/api/directorysetting-update.md
+++ b/api-reference/beta/api/directorysetting-update.md
@@ -13,7 +13,7 @@ doc_type: apiPageType
 
 Update the properties of a specific directory setting object.
 
-> **Note**: The /beta version of this API is only applies to groups. The /v1.0 version of this API has been renamed to *Update groupSettings*.
+> **Note**: The /beta version of this API only applies to groups. The /v1.0 version of this API has been renamed to *Update groupSettings*.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).


### PR DESCRIPTION
Beta page was missing table that had been added to v1.0.