### PR TITLE
Update http url for workbook comment APIs

### DIFF
--- a/api-reference/beta/api/workbookcomment-get.md
+++ b/api-reference/beta/api/workbookcomment-get.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/drive/root/workbook/comments/{id}
+GET https://graph.microsoft.com/beta/drive/items/{id}/workbook/comments/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-workbookcomment-csharp-snippets.md)]

--- a/api-reference/beta/api/workbookcomment-list-replies.md
+++ b/api-reference/beta/api/workbookcomment-list-replies.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/drive/root/workbook/comments/{id}/replies
+GET https://graph.microsoft.com/beta/drive/items/{id}/workbook/comments/{id}/replies
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-replies-csharp-snippets.md)]

--- a/api-reference/beta/api/workbookcomment-post-replies.md
+++ b/api-reference/beta/api/workbookcomment-post-replies.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/drive/root/workbook/comments/{id}/replies
+POST https://graph.microsoft.com/beta/drive/items/{id}/workbook/comments/{id}/replies
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/workbookcommentreply-get.md
+++ b/api-reference/beta/api/workbookcommentreply-get.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/drive/root/workbook/comments/{id}/replies/{id}
+GET https://graph.microsoft.com/beta/drive/items/{id}/workbook/comments/{id}/replies/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-workbookcommentreply-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookcomment-get.md
+++ b/api-reference/v1.0/api/workbookcomment-get.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/drive/root/workbook/comments/{id}
+GET https://graph.microsoft.com/v1.0/drive/items/{id}/workbook/comments/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-workbookcomment-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookcomment-list-replies.md
+++ b/api-reference/v1.0/api/workbookcomment-list-replies.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/drive/root/workbook/comments/{id}/replies
+GET https://graph.microsoft.com/v1.0/drive/items/{id}/workbook/comments/{id}/replies
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-replies-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookcomment-post-replies.md
+++ b/api-reference/v1.0/api/workbookcomment-post-replies.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/v1.0/drive/root/workbook/comments/{id}/replies
+POST https://graph.microsoft.com/v1.0/drive/items/{id}/workbook/comments/{id}/replies
 Content-type: application/json
 
 {

--- a/api-reference/v1.0/api/workbookcommentreply-get.md
+++ b/api-reference/v1.0/api/workbookcommentreply-get.md
@@ -56,7 +56,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/drive/root/workbook/comments/{id}/replies/{id}
+GET https://graph.microsoft.com/v1.0/drive/items/{id}/workbook/comments/{id}/replies/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-workbookcommentreply-csharp-snippets.md)]


### PR DESCRIPTION
We got a feedback that point out there is a mistake in workbook comments doc. The http sample's url is not correct. The url should let user to input items id. Updated the docs accordingly. 