### PR TITLE
Add missing column information for places permissions

### DIFF
--- a/concepts/permissions-reference.md
+++ b/concepts/permissions-reference.md
@@ -1166,8 +1166,8 @@ For more complex scenarios involving multiple permissions, see [Permission scena
 
 |   Permission    |  Display String   |  Description | Admin Consent Required | Microsoft Account supported |
 |:----------------|:------------------|:-------------|:-----------------------|:--------------|
-| _Place.Read.All_ |Allows the app to read company places (conference rooms and room lists) set up in Exchange Online for the tenant. |Yes | No |
-| _Place.ReadWrite.All_ |Allows the app to read and write company places (conference rooms and room lists) set up in Exchange Online for the tenant. |Yes | No |
+| _Place.Read.All_ |   Read all company places | Allows the app to read company places (conference rooms and room lists) set up in Exchange Online for the tenant. |Yes | No |
+| _Place.ReadWrite.All_ |   Read and write all company places | Allows the app to read and write company places (conference rooms and room lists) set up in Exchange Online for the tenant. |Yes | No |
 
 #### Application permissions
 


### PR DESCRIPTION
I believe the documentenation of the places graph permissions is missing data in the 'Display Name' column. This causes the values of the other columns to shift left resulting in the wrong perception as an admin-consent is required!