### PR TITLE
Update CSS supportability

### DIFF
--- a/concepts/tutorials.md
+++ b/concepts/tutorials.md
@@ -32,6 +32,8 @@ The following tutorials build an app that authenticates a user and accesses date
 
 Don't see your preferred language or platform? Request a tutorial for it on [UserVoice](https://microsoftgraph.uservoice.com/forums/920506-microsoft-graph-feature-requests).
 
+For any issues with the sample code please refer to their own GitHub project.
+
 ## Scenario-based tutorials
 
 The following tutorials focus on specific scenarios for using the Microsoft Graph.


### PR DESCRIPTION
Stating the supportability limits for the tutorials from Microsoft CSS. 
Tutorials should be supported by the GitHub project community who created them. Microsoft only can help with Microsoft languages and not anything else.