### PR TITLE
Application.Read.All is the least needed privelege

### DIFF
--- a/api-reference/beta/api/serviceprincipal-list.md
+++ b/api-reference/beta/api/serviceprincipal-list.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Application.ReadWrite.All, Directory.Read.All |
+|Application | Application.Read.All, Application.ReadWrite.All, Directory.Read.All |
 
 ## HTTP request
 


### PR DESCRIPTION
An application will have enough permissions to list all servicePrincipals in Azure AD by being granted the Application.Read.All permission in Microsoft Graph