### PR TITLE
Updated the Throttling pattern link to AAC

### DIFF
--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -55,7 +55,7 @@ The following resources currently provide a `Retry-After` header:
 - [People and social](/graph/api/resources/social-overview?view=graph-rest-beta)
 - [Drive (OneDrive)](/graph/api/resources/drive?view=graph-rest-1.0)
 
-For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://msdn.microsoft.com/library/office/dn589798.aspx).
+For a broader discussion of throttling on the Microsoft Cloud, see [Throttling Pattern](https://docs.microsoft.com/azure/architecture/patterns/throttling).
 
 > [!NOTE]
 > If no `Retry-After` header is provided by the response, we recommend implementing an exponential backoff retry policy. You can also implement [more advanced patterns](https://docs.microsoft.com/azure/architecture/patterns/category/resiliency) when building large-scale applications. 


### PR DESCRIPTION
It was previously pointing to an MSDN link that is being deprecated.