### PR TITLE
illustrate how to use AdminRemove for removing assignments

### DIFF
--- a/api-reference/beta/api/accesspackageassignment-list.md
+++ b/api-reference/beta/api/accesspackageassignment-list.md
@@ -33,7 +33,7 @@ GET /identityGovernance/entitlementManagement/accessPackageAssignments
 
 ## Optional query parameters
 
-This method supports some of the OData query parameters to help customize the response. For example, to retrieve only delivered assignments, you can include a query `$filter=assignmentState eq 'Delivered'`. To retrieve only assignments for a particular user, you can include a query with assignments targeting the object ID for of that user `$filter=target/objectid+eq+'7deff43e-1f17-44ef-9e5f-d516b0ba11d4'`.
+This method supports some of the OData query parameters to help customize the response. For example, to also return the target user and access package, include `$expand=target,accessPackage`. To retrieve only delivered assignments, you can include a query `$filter=assignmentState eq 'Delivered'`. To retrieve only assignments for a particular user, you can include a query with assignments targeting the object ID of that user `$expand=target&$filter=target/objectid+eq+'7deff43e-1f17-44ef-9e5f-d516b0ba11d4'`.  To retrieve only assignments for a particular user and a particular access package, you can include a query with assignments targeting that access package and the object ID of that user `$expand=accessPackage,target&$filter=accessPackage/id eq '9bbe5f7d-f1e7-4eb1-a586-38cdf6f8b1ea' and target/objectid eq '7deff43e-1f17-44ef-9e5f-d516b0ba11d4'`.
 
 For general information, see [OData query parameters](/graph/query-parameters).
 

--- a/api-reference/beta/api/accesspackageassignmentrequest-list.md
+++ b/api-reference/beta/api/accesspackageassignmentrequest-list.md
@@ -33,7 +33,8 @@ GET /identityGovernance/entitlementManagement/accessPackageAssignmentRequests
 
 ## Optional query parameters
 
-This method supports some of the OData query parameters to help customize the response. For example, to retrieve the access package of each request, include `$expand=accessPackage` in the query.  For general information, see [OData query parameters](/graph/query-parameters).
+This method supports some of the OData query parameters to help customize the response. For example, to retrieve the access package of each request, include `$expand=accessPackage` in the query.  To retrieve only requests for a specific access package, include in the query a filter such as `$expand=accessPackage&$filter=accessPackage/id eq '9bbe5f7d-f1e7-4eb1-a586-38cdf6f8b1ea'`.
+For general information, see [OData query parameters](/graph/query-parameters).
 
 ## Request headers
 

--- a/api-reference/beta/api/accesspackageassignmentrequest-post.md
+++ b/api-reference/beta/api/accesspackageassignmentrequest-post.md
@@ -44,7 +44,7 @@ In the request body, supply a JSON representation of [accessPackageAssignmentReq
 
 To create an assignment for a user, the value of the **requestType** property is `AdminAdd`, and the **accessPackageAssignment** property contains the `targetId` of the user being assigned, the **assignmentPolicyId** property identifying the [accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md), and the **accessPackageId** property identifying the [accessPackage](../resources/accesspackage.md).
 
-To remove an assignment, the value of the **requestType** property is `AdminRemove`, and the **accessPackageAssignment** property contains the **id** property identifying the [accessPackageAssignment](../resources/accesspackageassignmen.md) being removed.
+To remove an assignment, the value of the **requestType** property is `AdminRemove`, and the **accessPackageAssignment** property contains the **id** property identifying the [accessPackageAssignment](../resources/accesspackageassignment.md) being removed.
 
 ## Response
 

--- a/api-reference/beta/api/accesspackageassignmentrequest-post.md
+++ b/api-reference/beta/api/accesspackageassignmentrequest-post.md
@@ -36,15 +36,15 @@ POST /identityGovernance/entitlementManagement/accessPackageAssignmentRequests
 | Name          | Description   |
 |:--------------|:--------------|
 | Authorization | Bearer \{token\}. Required. |
-| Content-Type  | application/json  |
+| Content-Type  | application/json. Required. |
 
 ## Request body
 
 In the request body, supply a JSON representation of [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.
 
-To create an assignment for a user, the value of the `requestType` property is `AdminAdd`, and the `accessPackageAssignment` property contains the `targetId` of the user being assigned, the `assignmentPolicyId` property identifying the [accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md), and `accessPackageId` property identifying the [accessPackage](../resources/accesspackage.md).
+To create an assignment for a user, the value of the **requestType** property is `AdminAdd`, and the **accessPackageAssignment** property contains the `targetId` of the user being assigned, the **assignmentPolicyId** property identifying the [accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md), and the **accessPackageId** property identifying the [accessPackage](../resources/accesspackage.md).
 
-To remove an assignment, the value of the `requestType` property is `AdminRemove`, and the `accessPackageAssignment` property contains the `id` property identifying the [accessPackageAssignment](../resources/accesspackageassignment.md) being removed.
+To remove an assignment, the value of the **requestType** property is `AdminRemove`, and the **accessPackageAssignment** property contains the **id** property identifying the [accessPackageAssignment](../resources/accesspackageassignmen.md) being removed.
 
 ## Response
 
@@ -54,7 +54,7 @@ If successful, this method returns a 200-series response code and a new [accessP
 
 ### Request
 
-The following is an example of the request for a direct assignment.  The value of the `targetID` is the object ID of a user being assigned, the value of the `accessPackageId` is the desired access package, and the value of `assignmentPolicyId` is a direct assignment policy in that access package.
+The following is an example of the request for a direct assignment.  The value of the **targetID** is the object ID of a user being assigned, the value of the **accessPackageId** is the desired access package, and the value of **assignmentPolicyId** is a direct assignment policy in that access package.
  
 
 # [HTTP](#tab/http)

--- a/api-reference/beta/api/accesspackageassignmentrequest-post.md
+++ b/api-reference/beta/api/accesspackageassignmentrequest-post.md
@@ -11,7 +11,7 @@ doc_type: "apiPageType"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), create a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.  This is used to assign a user to an access package, or to remove an access package assignment.
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), create a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.  This operation is used to assign a user to an access package, or to remove an access package assignment.
 
 ## Permissions
 

--- a/api-reference/beta/api/accesspackageassignmentrequest-post.md
+++ b/api-reference/beta/api/accesspackageassignmentrequest-post.md
@@ -11,7 +11,7 @@ doc_type: "apiPageType"
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), create a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), create a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.  This is used to assign a user to an access package, or to remove an access package assignment.
 
 ## Permissions
 
@@ -41,6 +41,10 @@ POST /identityGovernance/entitlementManagement/accessPackageAssignmentRequests
 ## Request body
 
 In the request body, supply a JSON representation of [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.
+
+To create an assignment for a user, the value of the `requestType` property is `AdminAdd`, and the `accessPackageAssignment` property contains the `targetId` of the user being assigned, the `assignmentPolicyId` property identifying the [accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md), and `accessPackageId` property identifying the [accessPackage](../resources/accesspackage.md).
+
+To remove an assignment, the value of the `requestType` property is `AdminRemove`, and the `accessPackageAssignment` property contains the `id` property identifying the [accessPackageAssignment](../resources/accesspackageassignment.md) being removed.
 
 ## Response
 

--- a/api-reference/beta/resources/accesspackageassignment.md
+++ b/api-reference/beta/resources/accesspackageassignment.md
@@ -19,7 +19,7 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |:-------------|:------------|:------------|
 | [List accessPackageAssignments](../api/accesspackageassignment-list.md) | [accessPackageAssignment](accesspackageassignment.md) collection | Retrieve a list of **accesspackageassignment** objects. |
 
->**Note:** You can't use a method to create an access package assignment. Instead, a client that wants to request an access package assignment for a user can [create an accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-post.md).
+>**Note:** You can't use a method to create or remove an access package assignment. Instead, a client that wants to request an access package assignment for a user, or remove an access package assignment from a user, can [create an accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-post.md).
 
 ## Properties
 
@@ -27,7 +27,7 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |:-------------|:------------|:------------|
 |accessPackageId|String|The identifier of the access package. Read-only.|
 |assignmentPolicyId|String|The identifier of the access package assignment policy. Read-only.|
-|assignmentState|String|Read-only.|
+|assignmentState|String|The state of the access package `Delivered` or `Expired`. Read-only.|
 |assignmentStatus|String|Read-only.|
 |catalogId|String|The identifier of the catalog containing the access package. Read-only.|
 |expiredDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|

--- a/api-reference/beta/resources/accesspackageassignment.md
+++ b/api-reference/beta/resources/accesspackageassignment.md
@@ -27,7 +27,7 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |:-------------|:------------|:------------|
 |accessPackageId|String|The identifier of the access package. Read-only.|
 |assignmentPolicyId|String|The identifier of the access package assignment policy. Read-only.|
-|assignmentState|String|The state of the access package `Delivered` or `Expired`. Read-only.|
+|assignmentState|String|The state of the access package. Possible values are `Delivered` or `Expired`. Read-only.|
 |assignmentStatus|String|Read-only.|
 |catalogId|String|The identifier of the catalog containing the access package. Read-only.|
 |expiredDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|

--- a/api-reference/beta/resources/accesspackageassignmentrequest.md
+++ b/api-reference/beta/resources/accesspackageassignmentrequest.md
@@ -31,10 +31,10 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |id|String| Read-only.|
 |isValidationOnly|Boolean|True if the request is not to be processed for assignment.|
 |justification|String|The requestor's supplied justification.|
-|requestState|String|One of `Denied`, `Delivered`, `PartiallyDelivered`. Read-only.|
+|requestState|String|One of `Denied`, `Delivered`, `PartiallyDelivered` or `Submitted`. Read-only.|
 |requestStatus|String|More information on the request processing status. Read-only.|
-|requestType|String|One of `UserAdd` or `UserRemove`. Read-only.|
-
+|requestType|String|One of `UserAdd`, `UserRemove`, `AdminAdd` or `AdminRemove`. Read-only.|
+|accessPackageAssignment|[accessPackageAssignment](accesspackageassignment.md)| An access package assignment requested to be created.|
 
 ## Relationships
 
@@ -59,7 +59,14 @@ The following is a JSON representation of the resource.
 
 ```json
 {
- 
+  "createdDateTime": "2020-02-12T22:06:58.303Z",
+  "completedDate": "2020-02-12T22:14:28.19Z",
+  "id": "1244d439-5baa-4b9a-be5f-e8fdef5a998b",
+  "requestType": "UserAdd",
+  "requestState": "Delivered",
+  "requestStatus": "FulfilledNotificationTriggered",
+  "isValidationOnly": false,
+  "justification": ""
 }
 ```
 


### PR DESCRIPTION
In Azure AD entitlement management, add more property values for accesspackageassignment and accesspackageassignmentrequest, illustrating how to remove an assignment. 