### PR TITLE
Add missing links for create rubrics and category

### DIFF
--- a/api-reference/beta/resources/educationcategory.md
+++ b/api-reference/beta/resources/educationcategory.md
@@ -20,8 +20,8 @@ A category that can be applied to assignments.
 
 | Method		   | Return Type	|Description|
 |:---------------|:--------|:----------|
-|[Get educationCategory](../api/educationcategory-get.md) | [educationCategory](educationcategory.md) | Get an existing **educationCategory**.|
 |[Create category](../api/educationclass-post-category.md) | [educationCategory](educationcategory.md) | Create a new **educationCategory**.|
+|[Get educationCategory](../api/educationcategory-get.md) | [educationCategory](educationcategory.md) | Get an existing **educationCategory**.|
 |[Delete category](../api/educationcategory-delete.md) | None | Remove an **educationCategory**.|
 
 

--- a/api-reference/beta/resources/educationcategory.md
+++ b/api-reference/beta/resources/educationcategory.md
@@ -21,6 +21,7 @@ A category that can be applied to assignments.
 | Method		   | Return Type	|Description|
 |:---------------|:--------|:----------|
 |[Get educationCategory](../api/educationcategory-get.md) | [educationCategory](educationcategory.md) | Get an existing **educationCategory**.|
+|[Create category](../api/educationclass-post-category.md) | [educationCategory](educationcategory.md) | Create a new **educationCategory**.|
 |[Delete category](../api/educationcategory-delete.md) | None | Remove an **educationCategory**.|
 
 

--- a/api-reference/beta/resources/educationrubric.md
+++ b/api-reference/beta/resources/educationrubric.md
@@ -22,6 +22,7 @@ See [Education rubric overview](https://developer.microsoft.com/graph/docs/conce
 | Method       | Return Type | Description |
 |:-------------|:------------|:------------|
 | [Get educationRubric](../api/educationrubric-get.md) | [educationRubric](educationrubric.md) | Read properties and relationships of educationRubric object. |
+| [Create educationRubric](../api/educationuser-post-rubrics.md) | [educationRubric](educationrubric.md) | Create a new educationRubric object. |
 | [Update educationRubric](../api/educationrubric-update.md) | [educationRubric](educationrubric.md) | Update educationRubric object. |
 | [Delete educationRubric](../api/educationrubric-delete.md) | None | Delete educationRubric object. |
 

--- a/api-reference/beta/resources/educationrubric.md
+++ b/api-reference/beta/resources/educationrubric.md
@@ -21,8 +21,8 @@ See [Education rubric overview](https://developer.microsoft.com/graph/docs/conce
 
 | Method       | Return Type | Description |
 |:-------------|:------------|:------------|
-| [Get educationRubric](../api/educationrubric-get.md) | [educationRubric](educationrubric.md) | Read properties and relationships of educationRubric object. |
 | [Create educationRubric](../api/educationuser-post-rubrics.md) | [educationRubric](educationrubric.md) | Create a new educationRubric object. |
+| [Get educationRubric](../api/educationrubric-get.md) | [educationRubric](educationrubric.md) | Read properties and relationships of educationRubric object. |
 | [Update educationRubric](../api/educationrubric-update.md) | [educationRubric](educationrubric.md) | Update educationRubric object. |
 | [Delete educationRubric](../api/educationrubric-delete.md) | None | Delete educationRubric object. |
 

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -8015,6 +8015,8 @@
         items:
         - name: Get category
           href: api/educationcategory-get.md
+        - name: Create category
+          href: api/educationclass-post-category.md
         - name: Delete category
           href: api/educationcategory-delete.md
       - name: Rubric
@@ -8022,6 +8024,8 @@
         items:
         - name: Get rubric
           href: api/educationrubric-get.md
+        - name: Create rubric
+          href: api/educationuser-post-rubrics.md
         - name: Update rubric
           href: api/educationrubric-update.md
         - name: Delete rubric

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -8013,19 +8013,19 @@
       - name: Category
         href: resources/educationcategory.md
         items:
-        - name: Get category
-          href: api/educationcategory-get.md
         - name: Create category
           href: api/educationclass-post-category.md
+        - name: Get category
+          href: api/educationcategory-get.md
         - name: Delete category
           href: api/educationcategory-delete.md
       - name: Rubric
         href: resources/educationrubric.md
         items:
-        - name: Get rubric
-          href: api/educationrubric-get.md
         - name: Create rubric
           href: api/educationuser-post-rubrics.md
+        - name: Get rubric
+          href: api/educationrubric-get.md
         - name: Update rubric
           href: api/educationrubric-update.md
         - name: Delete rubric


### PR DESCRIPTION
Docs for creating educationRubrics and educationCategories are missing links in the TOC and the base doc pages for rubrics and categories. Add the missing references