### PR TITLE
Change subscription: adds the content type header for validation request

### DIFF
--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -142,6 +142,7 @@ Microsoft Graph validates the notification endpoint provided in the `notificatio
 1. Microsoft Graph sends a POST request to the notification URL:
 
     ``` http
+    Content-Type: text/plain; charset=utf-8
     POST https://{notificationUrl}?validationToken={opaqueTokenCreatedByMicrosoftGraph}
     ```
 


### PR DESCRIPTION
This change will help developers building their notification infrastructure so they better understand how to map/route requests coming from the Graph