### PR TITLE
I added information about sending attachment via javascript sdk and a…

### DIFF
--- a/api-reference/v1.0/api/user-sendmail.md
+++ b/api-reference/v1.0/api/user-sendmail.md
@@ -6,7 +6,7 @@ localization_priority: Priority
 ms.prod: "microsoft-identity-platform"
 doc_type: apiPageType
 ---
-
+ 
 # Send mail
 
 Namespace: microsoft.graph
@@ -188,6 +188,9 @@ HTTP/1.1 202 Accepted
 ##### Request 3
 
 The next example creates a message with a file attachment and sends the message.
+
+> [!NOTE]
+> Using the javascript sdk, the attachment's "contentByte" property should contain Base64 encoded data gotten from your file. For example, if you read a file into an ArrayBuffer, you will have to encode it to Base64 before sending the message.
 
 
 # [HTTP](#tab/http)

--- a/api-reference/v1.0/includes/snippets/csharp/user-sendmail-with-attachment-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/user-sendmail-with-attachment-csharp-snippets.md
@@ -5,6 +5,8 @@ description: "Automatically generated file. DO NOT MODIFY"
 ```csharp
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
+MemoryStream fileStream = new MemoryStream();
+file.CopyTo(fileStream);
 
 var message = new Message
 {
@@ -30,7 +32,10 @@ var message = new Message
 		{
 			Name = "attachment.txt",
 			ContentType = "text/plain",
-			ContentBytes = "SGVsbG8gV29ybGQh"
+			ContentBytes = fileStream.ToArray(),
+            Size = (int) file.Length,
+            Id = Guid.NewGuid().ToString(),
+            ODataType = "#microsoft.graph.fileAttachment"
 		}
 	}
 };

--- a/api-reference/v1.0/includes/snippets/csharp/user-sendmail-with-attachment-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/user-sendmail-with-attachment-csharp-snippets.md
@@ -5,8 +5,6 @@ description: "Automatically generated file. DO NOT MODIFY"
 ```csharp
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
-MemoryStream fileStream = new MemoryStream();
-file.CopyTo(fileStream);
 
 var message = new Message
 {
@@ -32,10 +30,7 @@ var message = new Message
 		{
 			Name = "attachment.txt",
 			ContentType = "text/plain",
-			ContentBytes = fileStream.ToArray(),
-            Size = (int) file.Length,
-            Id = Guid.NewGuid().ToString(),
-            ODataType = "#microsoft.graph.fileAttachment"
+			ContentBytes = "SGVsbG8gV29ybGQh"
 		}
 	}
 };


### PR DESCRIPTION
I added information about sending attachment via javascript sdk and ameliorated the C# example which seamed not totally correct. I was working with the graph api recently and I followed this documentation "JS and C# examples" to send attachments via mail, but I had difficulties sending a mail with attachments. 
So, I added to this doc some code and a little tips which helped me overcome the problem.