### PR TITLE
Fixing links in the Universal Print documentation

### DIFF
--- a/api-reference/beta/resources/printer.md
+++ b/api-reference/beta/resources/printer.md
@@ -41,7 +41,6 @@ Represents a physical printer device that has been registered with the Universal
 |name|String|The name of the printer.|
 |manufacturer|String|The manufacturer reported by the printer. Read-only.|
 |model|String|The model name reported by the printer. Read-only.|
-|registeredBy|[userIdentity](useridentity.md)|The user who registered the printer.|
 |registeredDateTime|DateTimeOffset|The DateTimeOffset when the printer was registered. Read-only.|
 |status|[printerStatus](printerstatus.md)|The processing status of the printer, including any errors. Read-only.|
 |isShared|Boolean|True if the printer is shared; false otherwise. Read-only.|
@@ -81,7 +80,6 @@ The following is a JSON representation of the resource.
   "isShared": true,
   "registeredDateTime": "String (timestamp)",
   "acceptingJobs": true,
-  "registeredBy": {"@odata.type": "microsoft.graph.userIdentity"},
   "location": {"@odata.type": "microsoft.graph.printerLocation"},
   "status": {"@odata.type": "microsoft.graph.printerStatus"},
   "defaults": {"@odata.type": "microsoft.graph.printerDefaults"}

--- a/api-reference/beta/resources/printer.md
+++ b/api-reference/beta/resources/printer.md
@@ -41,6 +41,7 @@ Represents a physical printer device that has been registered with the Universal
 |name|String|The name of the printer.|
 |manufacturer|String|The manufacturer reported by the printer. Read-only.|
 |model|String|The model name reported by the printer. Read-only.|
+|registeredBy|[userIdentity](useridentity.md)|The user who registered the printer.|
 |registeredDateTime|DateTimeOffset|The DateTimeOffset when the printer was registered. Read-only.|
 |status|[printerStatus](printerstatus.md)|The processing status of the printer, including any errors. Read-only.|
 |isShared|Boolean|True if the printer is shared; false otherwise. Read-only.|
@@ -80,6 +81,7 @@ The following is a JSON representation of the resource.
   "isShared": true,
   "registeredDateTime": "String (timestamp)",
   "acceptingJobs": true,
+  "registeredBy": {"@odata.type": "microsoft.graph.userIdentity"},
   "location": {"@odata.type": "microsoft.graph.printerLocation"},
   "status": {"@odata.type": "microsoft.graph.printerStatus"},
   "defaults": {"@odata.type": "microsoft.graph.printerDefaults"}

--- a/concepts/universal-print-concept-overview.md
+++ b/concepts/universal-print-concept-overview.md
@@ -33,7 +33,7 @@ To get started with the Universal Print API:
 
 Keeping track of an organization's printers, printer configurations, and printer usage is a complex task. The Universal Print API enables integration in all three areas.
 
-* **Keep an eye on printer status, configurations, and availability** by using [List printers](/graph/api/print-list-printers?view=graph-rest-beta) and [printerStatus](/graph/resources/printerstatus?view=graph-rest-beta).
+* **Keep an eye on printer status, configurations, and availability** by using [List printers](/graph/api/print-list-printers?view=graph-rest-beta) and [printerStatus](/graph/api/resources/printerstatus?view=graph-rest-beta).
 
 * **See who's using your printers and how much they're printing** by using the reporting APIs:
   * [List dailyPrintUsageSummariesByUser](/graph/api/reportroot-list-dailyprintusagesummariesbyuser?view=graph-rest-beta)
@@ -44,23 +44,23 @@ Keeping track of an organization's printers, printer configurations, and printer
 * **Configure user permissions** by modifying user and group membership on printers:
   * [List allowedUsers](/graph/api/printer-list-allowedusers?view=graph-rest-beta)
   * [Add allowedUser](/graph/api/printer-post-allowedusers?view=graph-rest-beta)
-  * [Remove allowedUser](/graph/api/printer-delete-allowedusers?view=graph-rest-beta)
+  * [Remove allowedUser](/graph/api/printer-delete-alloweduser?view=graph-rest-beta)
   * [List allowedGroups](/graph/api/printer-list-allowedgroups?view=graph-rest-beta)
-  * [Add allowedGroup](/graph/api/printer-post-allowedgroup?view=graph-rest-beta)
+  * [Add allowedGroup](/graph/api/printer-post-allowedgroups?view=graph-rest-beta)
   * [Remove allowedGroup](/graph/api/printer-delete-allowedgroup?view=graph-rest-beta)
 
 ### Seamlessly replace or update printer hardware
 
 Printers are not visible to users until they are [shared](/graph/api/print-post-printershares?view=graph-rest-beta), providing administrators fine-grained control over which printer hardware is available at a given time.
 
-Sharing a printer creates a [printerShare](/graph/resources/printershare?view=graph-rest-beta) resource that can be updated at any time to point to a different printer, making it easy to replace broken printer hardware or take printers offline for maintenance.
+Sharing a printer creates a [printerShare](/graph/api/resources/printershare?view=graph-rest-beta) resource that can be updated at any time to point to a different printer, making it easy to replace broken printer hardware or take printers offline for maintenance.
 
 To use this in your application, use [Update printerShare](/graph/api/printershare-update?view=graph-rest-beta) to update the printerShare's `printer` reference.
 
 ## API reference
 Looking for the API reference for this service?
 
-- [Universal Print API in Microsoft Graph beta](/graph/resources/print?view=graph-rest-beta)
+- [Universal Print API in Microsoft Graph beta](/graph/api/resources/print?view=graph-rest-beta)
 
 ## See also
 


### PR DESCRIPTION
Some links on the Universal Print overview page are broken.