### PR TITLE
Removed the "$select doesn't work" warning

### DIFF
--- a/api-reference/beta/api/directoryobject-getbyids.md
+++ b/api-reference/beta/api/directoryobject-getbyids.md
@@ -13,10 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Returns the directory objects specified in a list of IDs.  
-
-> [!NOTE]
-> The directory objects returned are the full objects containing **all** their properties. The `$select` query option is not available for this operation.
+Return the directory objects specified in a list of IDs.  
 
 Some common uses for this function are to:
 

--- a/api-reference/v1.0/api/directoryobject-getbyids.md
+++ b/api-reference/v1.0/api/directoryobject-getbyids.md
@@ -14,9 +14,6 @@ Namespace: microsoft.graph
 Returns the directory objects specified in a list of IDs.
 
 >[!NOTE]
->The directory objects returned are the full objects containing all their properties. The `$select` query option is not available for this operation.
-
->[!NOTE]
 >This API has a [known issue](/graph/known-issues#incomplete-objects-when-using-getbyids-request). Not all directory objects returned are the full objects containing all their properties.
 
 Some common uses for this function are to:

--- a/api-reference/v1.0/api/directoryobject-getbyids.md
+++ b/api-reference/v1.0/api/directoryobject-getbyids.md
@@ -11,7 +11,7 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Returns the directory objects specified in a list of IDs.
+Return the directory objects specified in a list of IDs.
 
 >[!NOTE]
 >This API has a [known issue](/graph/known-issues#incomplete-objects-when-using-getbyids-request). Not all directory objects returned are the full objects containing all their properties.


### PR DESCRIPTION
Per @dkershaw10 , $select is now supported.  Updated the documentation to remove the warning.

https://github.com/microsoftgraph/microsoft-graph-docs/issues/6783#event-3211131404