### PR TITLE
Add hint that ID strings will be GUIDs

### DIFF
--- a/api-reference/beta/api/directoryobject-getbyids.md
+++ b/api-reference/beta/api/directoryobject-getbyids.md
@@ -1,6 +1,6 @@
 ---
-title: "Get directory objects from a list of ids"
-description: "select` query option is not available for this operation."
+title: "directoryObject: getByIds"
+description: "Returns the directory objects specified in a list of IDs. "
 author: "keylimesoda"
 localization_priority: Normal
 ms.prod: "microsoft-identity-platform"
@@ -13,12 +13,15 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Returns the directory objects specified in a list of ids.  NOTE: The directory objects returned are the full objects containing **all** their properties. The `$select` query option is not available for this operation.
+Returns the directory objects specified in a list of IDs.  
+
+> [!NOTE]
+> The directory objects returned are the full objects containing **all** their properties. The `$select` query option is not available for this operation.
 
 Some common uses for this function are to:
 
-* Resolve ids returned by functions (that return collections of ids) such as [getMemberObjects](/graph/api/directoryobject-getmemberobjects.md?view=graph-rest-beta) or [getMemberGroups](/graph/api/directoryobject-getmembergroups.md?view=graph-rest-beta)  to their backing directory objects.
-* Resolve ids persisted in an external store by the application to their backing directory objects.
+* Resolve IDs returned by functions (that return collections of IDs) such as [getMemberObjects](/graph/api/directoryobject-getmemberobjects.md?view=graph-rest-beta) or [getMemberGroups](/graph/api/directoryobject-getmembergroups.md?view=graph-rest-beta)  to their backing directory objects.
+* Resolve IDs persisted in an external store by the application to their backing directory objects.
 
 ## Permissions
 
@@ -46,7 +49,7 @@ POST /directoryObjects/getByIds
 | Name       | Type | Description|
 |:---------------|:--------|:----------|
 | Authorization  | string  | Bearer {token}. Required. |
-| Content-Type  | application/json  |
+| Content-type  | string | application/json. Required.  |
 
 ## Request body
 
@@ -54,16 +57,16 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter   | Type |Description|
 |:---------------|:--------|:----------|
-|ids|String collection| A collection of ids for which to return objects. You can specify up to 1000 ids. |
-|types|String collection| A collection of resource types that specifies the set of resource collections to search. If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta), which contains all of the resource types defined in the directory. Any object that derives from [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta) may be specified in the collection; for example: [user](/graph/api/resources/user?view=graph-rest-beta), [group](/graph/api/resources/group?view=graph-rest-beta), [device](/graph/api/resources/device?view=graph-rest-beta), and so on. To search for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization specify [directoryObjectPartnerReference](/graph/api/resources/directoryobjectpartnerreference?view=graph-rest-beta). If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta), which contains all of the resource types defined in the directory, except for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization. The values are not case-sensitive.|
+|ids|String collection| A collection of IDs for which to return objects. The IDs are GUIDs, represented as strings. You can specify up to 1000 IDs. |
+|types|String collection| A collection of resource types that specifies the set of resource collections to search. If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta), which contains all of the resource types defined in the directory. Any object that derives from [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta) may be specified in the collection; for example: [user](/graph/api/resources/user?view=graph-rest-beta), [group](/graph/api/resources/group?view=graph-rest-beta), [device](/graph/api/resources/device?view=graph-rest-beta), and so on. To search for references to a [Cloud Solution Provider](https://partner.microsoft.com/cloud-solution-provider) partner organization specify [directoryObjectPartnerReference](/graph/api/resources/directoryobjectpartnerreference?view=graph-rest-beta). If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-beta), which contains all of the resource types defined in the directory, except for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization. The values are not case-sensitive.|
 
 ## Response
 
-If successful, this method returns `200 OK` response code and String collection object in the response body.
+If successful, this method returns a `200 OK` response code and a string collection object in the response body.
 
 ## Example
 
-##### Request
+### Request
 
 
 # [HTTP](#tab/http)
@@ -96,9 +99,9 @@ Content-type: application/json
 ---
 
 
-##### Response
+### Response
 
-Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+>**Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/v1.0/api/directoryobject-getbyids.md
+++ b/api-reference/v1.0/api/directoryobject-getbyids.md
@@ -1,13 +1,13 @@
 ---
-title: "Get directory objects from a list of ids"
-description: "select` query option is not available for this operation."
+title: "directoryObject: getByIds"
+description: "Returns the directory objects specified in a list of IDs."
 author: "keylimesoda"
 localization_priority: Priority
 ms.prod: "microsoft-identity-platform"
 doc_type: apiPageType
 ---
 
-# Get directory objects from a list of ids
+# directoryObject: getByIds
 
 Namespace: microsoft.graph
 
@@ -50,7 +50,7 @@ POST /directoryObjects/getByIds
 | Name       | Type | Description|
 |:---------------|:--------|:----------|
 | Authorization  | string  | Bearer {token}. Required. |
-| Content-Type  | string | application/json  |
+| Content-type  | string | application/json. Required.  |
 
 ## Request body
 
@@ -58,7 +58,7 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter   | Type |Description|
 |:---------------|:--------|:----------|
-|ids|String collection| A collection of IDs for which to return objects.  The IDs are GUIDs, represented as Strings.  You can specify up to 1000 IDs. |
+|ids|String collection| A collection of IDs for which to return objects.  The IDs are GUIDs, represented as strings.  You can specify up to 1000 IDs. |
 |types|String collection| A collection of resource types that specifies the set of resource collections to search. If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0), which contains all of the resource types defined in the directory. Any object that derives from [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0) may be specified in the collection; for example: [user](/graph/api/resources/user?view=graph-rest-v1.0), [group](/graph/api/resources/group?view=graph-rest-v1.0), [device](/graph/api/resources/device?view=graph-rest-v1.0), and so on. To search for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization specify [directoryObjectPartnerReference](/graph/api/resources/directoryobjectpartnerreference?view=graph-rest-v1.0). If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0), which contains all of the resource types defined in the directory, except for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization. The values are not case sensitive.|
 
 ## Response
@@ -106,7 +106,7 @@ Content-type: application/json
 
 ##### Response
 
-Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+>**Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/api-reference/v1.0/api/directoryobject-getbyids.md
+++ b/api-reference/v1.0/api/directoryobject-getbyids.md
@@ -22,7 +22,7 @@ Returns the directory objects specified in a list of IDs.
 Some common uses for this function are to:
 
 * Resolve IDs returned by functions (that return collections of IDs) such as [getMemberObjects](directoryobject-getmemberobjects.md) or [getMemberGroups](directoryobject-getmembergroups.md)  to their backing directory objects.
-* Resolve ids persisted in an external store by the application to their backing directory objects.
+* Resolve IDs persisted in an external store by the application to their backing directory objects.
 
 ## Permissions
 
@@ -63,11 +63,11 @@ In the request body, provide a JSON object with the following parameters.
 
 ## Response
 
-If successful, this method returns `200 OK` response code and String collection object in the response body.
+If successful, this method returns a `200 OK` response code and a string collection object in the response body.
 
 ## Example
 
-##### Request
+### Request
 
 
 # [HTTP](#tab/http)
@@ -104,7 +104,7 @@ Content-type: application/json
 ---
 
 
-##### Response
+### Response
 
 >**Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 <!-- {

--- a/api-reference/v1.0/api/directoryobject-getbyids.md
+++ b/api-reference/v1.0/api/directoryobject-getbyids.md
@@ -58,7 +58,7 @@ In the request body, provide a JSON object with the following parameters.
 
 | Parameter   | Type |Description|
 |:---------------|:--------|:----------|
-|ids|String collection| A collection of IDs for which to return objects. You can specify up to 1000 IDs. |
+|ids|String collection| A collection of IDs for which to return objects.  The IDs are GUIDs, represented as Strings.  You can specify up to 1000 IDs. |
 |types|String collection| A collection of resource types that specifies the set of resource collections to search. If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0), which contains all of the resource types defined in the directory. Any object that derives from [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0) may be specified in the collection; for example: [user](/graph/api/resources/user?view=graph-rest-v1.0), [group](/graph/api/resources/group?view=graph-rest-v1.0), [device](/graph/api/resources/device?view=graph-rest-v1.0), and so on. To search for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization specify [directoryObjectPartnerReference](/graph/api/resources/directoryobjectpartnerreference?view=graph-rest-v1.0). If not specified, the default is [directoryObject](/graph/api/resources/directoryobject?view=graph-rest-v1.0), which contains all of the resource types defined in the directory, except for references to a [Cloud Solution Provider](https://partner.microsoft.com/en-us/cloud-solution-provider) partner organization. The values are not case sensitive.|
 
 ## Response


### PR DESCRIPTION
Folks are getting "invalid GUID" when sending in non-GUID requests here.  This is a small change to help set expectations that the strings being submitted here are expected to be GUIDs, without resorting to strong typing.

https://github.com/microsoftgraph/microsoft-graph-docs/issues/7063