### PR TITLE
Added missing option to fetch drive item

### DIFF
--- a/api-reference/v1.0/api/driveitem-get.md
+++ b/api-reference/v1.0/api/driveitem-get.md
@@ -35,10 +35,11 @@ GET /groups/{group-id}/drive/items/{item-id}
 GET /groups/{group-id}/drive/root:/{item-path}
 GET /me/drive/items/{item-id}
 GET /me/drive/root:/{item-path}
-GET /sites/{siteId}/drive/items/{itemId}
-GET /sites/{siteId}/drive/root:/{item-path}
-GET /users/{userId}/drive/items/{itemId}
-GET /users/{userId}/drive/root:/{item-path}
+GET /sites/{site-id}/drive/items/{item-id}
+GET /sites/{site-id}/drive/root:/{item-path}
+GET /sites/{site-id}/lists/{list-id}/items/{item-id}/driveItem
+GET /users/{user-id}/drive/items/{item-id}
+GET /users/{user-id}/drive/root:/{item-path}
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
Added `GET /sites/{site-id}/lists/{list-id}/items/{item-id}/driveItem` and changed all variables to hyphen separator instead of mixing hyphen and camelcase.