### PR TITLE
allowNewTimeProposals not supported on v1.0

### DIFF
--- a/api-reference/v1.0/api/user-post-events.md
+++ b/api-reference/v1.0/api/user-post-events.md
@@ -703,7 +703,6 @@ Content-type: application/json
       "type": "required"
     }
   ],
-  "allowNewTimeProposals": true,
   "isOnlineMeeting": true,
   "onlineMeetingProvider": "teamsForBusiness"
 }
@@ -771,7 +770,6 @@ Content-type: application/json
     "onlineMeetingUrl":null,
     "isOnlineMeeting": true,
     "onlineMeetingProvider": "teamsForBusiness",
-    "allowNewTimeProposals": true,
     "responseStatus":{
         "response":"organizer",
         "time":"0001-01-01T00:00:00Z"


### PR DESCRIPTION
The "allowNewTimeProposals" property is not yet supported on the v1.0 Event resource.  It is only supported on beta endpoint.  Removing from examples for create event on v1.0.