### PR TITLE
Add example of authority with single-tenant apps

### DIFF
--- a/concepts/toolkit/providers/msal.md
+++ b/concepts/toolkit/providers/msal.md
@@ -31,7 +31,7 @@ Initializing the MSAL provider in HTML is the simplest way to create a new provi
 | client-id   | String client ID (see Creating an app/client ID). Required.|
 | login-type  | Enumeration between `redirect` and `popup` - default value is `redirect`. Optional. |
 | scopes  | Comma separated strings for scopes the user must consent to on sign in. Optional.|
-| authority  | Authority string - default is the common authority. For single-tenant apps, use your tenant ID or tenant name. For example `https://login.microsoftonline.com/[your-tenant-name].onmicrosoft.com` or `https://login.microsoftonline.com/[your-tenant-id]` Optional.|
+| authority  | Authority string - default is the common authority. For single-tenant apps, use your tenant ID or tenant name. For example, `https://login.microsoftonline.com/[your-tenant-name].onmicrosoft.com` or `https://login.microsoftonline.com/[your-tenant-id]`. Optional.|
 | depends-on | Element selector string of another higher priority provider component. Optional. |
 
 ### Initialize in JavaScript

--- a/concepts/toolkit/providers/msal.md
+++ b/concepts/toolkit/providers/msal.md
@@ -31,7 +31,7 @@ Initializing the MSAL provider in HTML is the simplest way to create a new provi
 | client-id   | String client ID (see Creating an app/client ID). Required.|
 | login-type  | Enumeration between `redirect` and `popup` - default value is `redirect`. Optional. |
 | scopes  | Comma separated strings for scopes the user must consent to on sign in. Optional.|
-| authority  | Authority string - default is the common authority. Optional.|
+| authority  | Authority string - default is the common authority. For single-tenant apps, use your tenant ID or tenant name. For example `https://login.microsoftonline.com/[your-tenant-name].onmicrosoft.com` or `https://login.microsoftonline.com/[your-tenant-id]` Optional.|
 | depends-on | Element selector string of another higher priority provider component. Optional. |
 
 ### Initialize in JavaScript
@@ -65,4 +65,4 @@ To learn more, see the [MSAL documentation](https://github.com/AzureAD/microsoft
 
 For details about how to register an app and get a client ID, see the [Register an app quick start](/azure/active-directory/develop/quickstart-register-app).
 
->**Note:** MSAL only supports the Implicit Flow for OAuth. Make sure to enable Implicit Flow in your application in the Azure Portal (it is not enabled by default). Under **Authentication**, find the **Implicit grant** section and select the checkboxes for **Access tokens** and **ID tokens**.
+>**Note:** MSAL only supports the Implicit Flow for OAuth. Make sure to enable Implicit Flow in your application in the Azure Portal (it is not enabled by default). Under **Authentication**, find the **Implicit grant** section and select the checkboxes for **Access tokens** and **ID tokens**. To use the common authority, set **Account in any organizational directory**. To use a specific tenant, set the `authority` during initialization.


### PR DESCRIPTION
adds note on authority and app settings during registration to mark the app registration as multitenant or set the authority for single tenant apps