### PR TITLE
faq: Fix linking

### DIFF
--- a/concepts/quick-start-faq.md
+++ b/concepts/quick-start-faq.md
@@ -48,15 +48,15 @@ The following table lists the corresponding tutorial and GitHub repository for e
 | Android | [Tutorial](/graph/tutorials/android) | [GitHub](https://github.com/microsoftgraph/msgraph-training-android) |
 | Angular | [Tutorial](/graph/tutorials/angular) | [GitHub](https://github.com/microsoftgraph/msgraph-training-angularspa) |
 | ASP.NET MVC | [Tutorial](/learn/modules/msgraph-build-aspnetmvc-apps) | [GitHub](https://github.com/microsoftgraph/msgraph-training-aspnetmvcapp) |
-| iOS Swift | [Tutorial](/graph/tutorials/ios-swift | [GitHub](https://github.com/microsoftgraph/msgraph-training-ios-swift) |
-| iOS Objective-C | [Tutorial](/graph/tutorials/ios-objectivec | [GitHub](https://github.com/microsoftgraph/msgraph-training-ios-objectivec) |
+| iOS Swift | [Tutorial](/graph/tutorials/ios-swift) | [GitHub](https://github.com/microsoftgraph/msgraph-training-ios-swift) |
+| iOS Objective-C | [Tutorial](/graph/tutorials/ios-objectivec) | [GitHub](https://github.com/microsoftgraph/msgraph-training-ios-objectivec) |
 | Node.js | [Tutorial](/graph/tutorials/node) | [GitHub](https://github.com/microsoftgraph/msgraph-training-nodeexpressapp) |
 | PHP | [Tutorial](/graph/tutorials/php) | [GitHub](https://github.com/microsoftgraph/msgraph-training-phpapp) |
 | Python | [Tutorial](/graph/tutorials/python) | [GitHub](https://github.com/microsoftgraph/msgraph-training-pythondjangoapp) |
 | React | [Tutorial](/graph/tutorials/react) | [GitHub](https://github.com/microsoftgraph/msgraph-training-reactspa) |
 | Ruby | [Tutorial](/graph/tutorials/ruby) | [GitHub](https://github.com/microsoftgraph/msgraph-training-rubyrailsapp) |
 | UWP | [Tutorial](/graph/tutorials/uwp) | [GitHub](https://github.com/microsoftgraph/msgraph-training-uwp) |
-| Xamarin | [Tutorial](/graph/tutorials/xamarin | [GitHub](https://github.com/microsoftgraph/msgraph-training-xamarin) |
+| Xamarin | [Tutorial](/graph/tutorials/xamarin) | [GitHub](https://github.com/microsoftgraph/msgraph-training-xamarin) |
 
 ### Why don't any of the quick start samples show advanced authentication use cases?
 


### PR DESCRIPTION
Fix linking by adding missing closing parentheses.