### PR TITLE
Permissions column added for Teamwork API resources

### DIFF
--- a/api-reference/beta/resources/channel.md
+++ b/api-reference/beta/resources/channel.md
@@ -18,23 +18,23 @@ where files are shared, and where tabs are added.
 
 ## Methods
 
-| Method       | Return Type  |Description|
-|:---------------|:--------|:----------|
-|[List channels](../api/channel-list.md) | [channel](channel.md) collection | Get the list of channels in this team.|
-|[Create channel](../api/channel-post.md) | [channel](channel.md) | Create a new channel by including the display name and description.|
-|[Get channel](../api/channel-get.md) | [channel](channel.md) | Read properties and relationships of the channel.|
-|[Update channel](../api/channel-patch.md) | [channel](channel.md) | Update properties of the channel.|
-|[Delete channel](../api/channel-delete.md) | None | Delete a channel.|
-|[Get message delta](../api/chatmessage-delta.md)  | [chatMessage](../resources/chatmessage.md) | Get incremental messages in a channel. |
-|[List channel messages](../api/channel-list-messages.md)  | [chatMessage](../resources/chatmessage.md) | Get messages in a channel |
-|[List channel members](../api/conversationmember-list.md)| [conversationMember](conversationmember.md) collection| List the members of a channel. |
-|[Get channel member](../api/conversationmember-get.md)| [conversationMember](conversationmember.md)| Get a member of a channel. |
-|[Add channel member](../api/conversationmember-add.md) | [conversationMember](conversationmember.md)| Add a member to a channel. Only supported for `channelType` of `private`.|
-|[Update channel member](../api/conversationmember-update.md) | [conversationMember](conversationmember.md)| Update a member of a channel. Only supported for `channelType` of `private`.|
-|[Delete channel member](../api/conversationmember-delete.md) | [conversationMember](conversationmember.md)| Delete a member of a channel. Only supported for `channelType` of `private`.|
-|[Create chatMessage in a channel](../api/channel-post-messages.md) | [chatMessage](../resources/chatmessage.md) | Send a message to a channel. |
-|[Create chatMessage reply in a channel](../api/channel-post-messagereply.md) | [chatMessage](../resources/chatmessage.md) | Reply to a message in a channel.|
-|[Get files folder](../api/driveitem-get.md)| [driveItem](driveitem.md) | Retrieves the details of the SharePoint folder where the files for the channel are stored. |
+|  Method       |  Return Type  | Description| Permissions |
+|:---------------|:--------|:----------|---------------|
+|[List channels](../api/channel-list.md) | [channel](channel.md) collection | Get the list of channels in this team.| Delegated (user consent), Application, RSC |
+|[Create channel](../api/channel-post.md) | [channel](channel.md) | Create a new channel by including the display name and description.| Delegated (admin consent), Application, RSC | 
+|[Get channel](../api/channel-get.md) | [channel](channel.md) | Read properties and relationships of the channel.| Delegated (user consent), Application, RSC |
+|[Update channel](../api/channel-patch.md) | [channel](channel.md) | Update properties of the channel.| Delegated (admin consent), Application, RSC |
+|[Delete channel](../api/channel-delete.md) | None | Delete a channel.| Delegated (admin consent), Application, RSC | 
+|[Get message delta](../api/chatmessage-delta.md)  | [chatMessage](../resources/chatmessage.md) | Get incremental messages in a channel. | Delegated (admin consent), Application, RSC | 
+|[List channel messages](../api/channel-list-messages.md)  | [chatMessage](../resources/chatmessage.md) | Get messages in a channel | Delegated (admin consent), Application, RSC | 
+|[List channel members](../api/conversationmember-list.md)| [conversationMember](conversationmember.md) collection| List the members of a channel. | Delegated (user consent), Application |
+|[Get channel member](../api/conversationmember-get.md)| [conversationMember](conversationmember.md)| Get a member of a channel. | For **user** or **chat** resource: Delegated (user consent), Application <br> For **channel** resource: Delegated (admin consent), Application, RSC |
+|[Add channel member](../api/conversationmember-add.md) | [conversationMember](conversationmember.md)| Add a member to a channel. Only supported for `channelType` of `private`.| Delegated (admin consent), Application, RSC |
+|[Update channel member](../api/conversationmember-update.md) | [conversationMember](conversationmember.md)| Update a member of a channel. Only supported for `channelType` of `private`.| Delegated (admin consent), Application, RSC |
+|[Delete channel member](../api/conversationmember-delete.md) | [conversationMember](conversationmember.md)| Delete a member of a channel. Only supported for `channelType` of `private`. | Delegated (admin consent), Application, RSC |
+|[Create chatMessage in a channel](../api/channel-post-messages.md) | [chatMessage](../resources/chatmessage.md) | Send a message to a channel. | Delegated (admin consent), Application |
+|[Create chatMessage reply in a channel](../api/channel-post-messagereply.md) | [chatMessage](../resources/chatmessage.md) | Reply to a message in a channel.| Delegated (admin consent), Application | 
+|[Get files folder](../api/driveitem-get.md)| [driveItem](driveitem.md) | Retrieves the details of the SharePoint folder where the files for the channel are stored. | Delegated (user consent), Delegated (user consent), Application |
 
 ## Properties
 

--- a/api-reference/beta/resources/chatmessage.md
+++ b/api-reference/beta/resources/chatmessage.md
@@ -17,26 +17,26 @@ Represents an individual chat message within a [channel](channel.md) or [chat](c
 
 ## Methods
 
-| Method       | Return Type  |Description|
-|:---------------|:--------|:----------|
+| Method       | Return Type  |Description| Permissions |
+|:---------------|:--------|:----------| :--------------- |
 |**Channel messages**| | |
-|[List channel chatMessage](../api/channel-list-messages.md) | [chatMessage](chatmessage.md) collection | List of all root chat messages in a channel.|
-|[Get chatMessages in a channel delta](../api/chatmessage-delta.md)  | [chatMessage](../resources/chatmessage.md) | Get incremental chat messages in a channel. |
-|[Create subscription for new channel messages](../api/subscription-post-subscriptions.md) | [subscription](subscription.md) | Listen for new and edited channel messages, and reactions to them. |
-|[Get channel chatMessage](../api/channel-get-message.md) | [chatMessage](chatmessage.md) | Get a single root chat message from a channel.|
-|[Create chatMessage in a channel](../api/channel-post-messages.md) | [chatMessage](chatmessage.md)| Create a new top-level chat message in a channel.|
+|[List channel chatMessage](../api/channel-list-messages.md) | [chatMessage](chatmessage.md) collection | List of all root chat messages in a channel.| Delegated (admin consent), Application, RSC |
+|[Get chatMessages in a channel delta](../api/chatmessage-delta.md)  | [chatMessage](../resources/chatmessage.md) | Get incremental chat messages in a channel. | Delegated (admin consent), Application, RSC |
+|[Create subscription for new channel messages](../api/subscription-post-subscriptions.md) | [subscription](subscription.md) | Listen for new and edited channel messages, and reactions to them. | Delegated (user consent), Delegated (user consent), Application |
+|[Get channel chatMessage](../api/channel-get-message.md) | [chatMessage](chatmessage.md) | Get a single root chat message from a channel.| Delegated(admin consent), Application, RSC |
+|[Create chatMessage in a channel](../api/channel-post-messages.md) | [chatMessage](chatmessage.md)| Create a new top-level chat message in a channel.| Delegated (admin consent), Application | 
 |**Channel message replies**| | |
-|[List replies to a chatMessage](../api/channel-list-messagereplies.md) | [chatMessage](chatmessage.md) collection| List of all replies to a chat message in channel.|
-|[Get a reply to a chatMessage](../api/channel-get-messagereply.md) | [chatMessage](chatmessage.md)| Get a single reply to a chat message in a channel.|
-|[Reply to a chatMessage in a channel](../api/channel-post-messagereply.md) | [chatMessage](chatmessage.md)| Reply to an existing chat message in a channel.|
+|[List replies to a chatMessage](../api/channel-list-messagereplies.md) | [chatMessage](chatmessage.md) collection| List of all replies to a chat message in channel.| Delegated (admin consent), Application, RSC |
+|[Get a reply to a chatMessage](../api/channel-get-messagereply.md) | [chatMessage](chatmessage.md)| Get a single reply to a chat message in a channel.| Delegated (admin consent), Application, RSC |  
+|[Reply to a chatMessage in a channel](../api/channel-post-messagereply.md) | [chatMessage](chatmessage.md)| Reply to an existing chat message in a channel.| Delegated (admin consent, Application |
 |**1:1 and group chat messages**| | |
-|[Create chatMessage in a chat](../api/chat-post-messages.md) | [chatMessage](chatmessage.md)| Send a chat message in an existing 1:1 or group chat conversation.|
-|[List chatMessages in a chat](../api/chatmessage-list.md)  | [chatMessage](../resources/chatmessage.md) | List chat messages in a 1:1 or group chat. |
-|[Create subscription for new chat messages](../api/subscription-post-subscriptions.md) | [subscription](subscription.md) | Listen for new and edited chat messages, and reactions to them. |
-|[Get chatMessage in chat](../api/chatmessage-get.md)  | [chatMessage](../resources/chatmessage.md) | Get a single chat message in a chat. |
+|[Create chatMessage in a chat](../api/chat-post-messages.md) | [chatMessage](chatmessage.md)| Send a chat message in an existing 1:1 or group chat conversation.| Delegated (user consent), Application |
+|[List chatMessages in a chat](../api/chatmessage-list.md)  | [chatMessage](../resources/chatmessage.md) | List chat messages in a 1:1 or group chat. | Delegated (user consent), Application |
+|[Create subscription for new chat messages](../api/subscription-post-subscriptions.md) | [subscription](subscription.md) | Listen for new and edited chat messages, and reactions to them. | Delegated (user consent), Application |
+|[Get chatMessage in chat](../api/chatmessage-get.md)  | [chatMessage](../resources/chatmessage.md) | Get a single chat message in a chat. | Delegated (user consent), Application |
 |**Hosted content**| | |
-|[List all hosted content](../api/chatmessage-list-chatmessagehostedcontents.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) collection| Get all hosted content in a chat message.|
-|[Get hosted content](../api/chatmessagehostedcontent-get.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) | Get hosted content from a chat message.|
+|[List all hosted content](../api/chatmessage-list-chatmessagehostedcontents.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) collection| Get all hosted content in a chat message.| For **user** or **chat** resource: Delegated (user consent), Application <br> For**channel** resource: Delegated (admin consent), Application, RSC|
+|[Get hosted content](../api/chatmessagehostedcontent-get.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) | Get hosted content from a chat message.| For **user** or **chat** resource: Delegated (user consent), Application <br> For**channel** resource: Delegated (admin consent), Application, RSC|
 
 ## Properties
 

--- a/api-reference/beta/resources/chatmessage.md
+++ b/api-reference/beta/resources/chatmessage.md
@@ -23,7 +23,7 @@ Represents an individual chat message within a [channel](channel.md) or [chat](c
 |[List channel chatMessage](../api/channel-list-messages.md) | [chatMessage](chatmessage.md) collection | List of all root chat messages in a channel.| Delegated (admin consent), Application, RSC |
 |[Get chatMessages in a channel delta](../api/chatmessage-delta.md)  | [chatMessage](../resources/chatmessage.md) | Get incremental chat messages in a channel. | Delegated (admin consent), Application, RSC |
 |[Create subscription for new channel messages](../api/subscription-post-subscriptions.md) | [subscription](subscription.md) | Listen for new and edited channel messages, and reactions to them. | Delegated (user consent), Delegated (user consent), Application |
-|[Get channel chatMessage](../api/channel-get-message.md) | [chatMessage](chatmessage.md) | Get a single root chat message from a channel.| Delegated(admin consent), Application, RSC |
+|[Get channel chatMessage](../api/channel-get-message.md) | [chatMessage](chatmessage.md) | Get a single root chat message from a channel.| Delegated (admin consent), Application, RSC |
 |[Create chatMessage in a channel](../api/channel-post-messages.md) | [chatMessage](chatmessage.md)| Create a new top-level chat message in a channel.| Delegated (admin consent), Application | 
 |**Channel message replies**| | |
 |[List replies to a chatMessage](../api/channel-list-messagereplies.md) | [chatMessage](chatmessage.md) collection| List of all replies to a chat message in channel.| Delegated (admin consent), Application, RSC |
@@ -36,7 +36,7 @@ Represents an individual chat message within a [channel](channel.md) or [chat](c
 |[Get chatMessage in chat](../api/chatmessage-get.md)  | [chatMessage](../resources/chatmessage.md) | Get a single chat message in a chat. | Delegated (user consent), Application |
 |**Hosted content**| | |
 |[List all hosted content](../api/chatmessage-list-chatmessagehostedcontents.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) collection| Get all hosted content in a chat message.| For **user** or **chat** resource: Delegated (user consent), Application <br> For**channel** resource: Delegated (admin consent), Application, RSC|
-|[Get hosted content](../api/chatmessagehostedcontent-get.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) | Get hosted content from a chat message.| For **user** or **chat** resource: Delegated (user consent), Application <br> For**channel** resource: Delegated (admin consent), Application, RSC|
+|[Get hosted content](../api/chatmessagehostedcontent-get.md) | [chatMessageHostedContent](../resources/chatmessagehostedcontent.md) | Get hosted content from a chat message.| For **user** or **chat** resource: Delegated (user consent), Application <br> For **channel** resource: Delegated (admin consent), Application, RSC|
 
 ## Properties
 

--- a/api-reference/beta/resources/teamsapp.md
+++ b/api-reference/beta/resources/teamsapp.md
@@ -19,12 +19,12 @@ Users can see these apps in the Microsoft Teams Store, and these apps can be ins
 
 ## Methods
 
-| Method       | Return Type  |Description|
+| Method       | Return Type  |Description| Permissions |
 |:---------------|:--------|:----------|
-|[List published apps](../api/teamsapp-list.md) | [teamsApp](teamsapp.md) collection | List published apps from the Microsoft Teams apps catalog.|
-|[Publish an app](../api/teamsapp-publish.md) | [teamsApp](teamsapp.md) | Publish an app to your organization's app catalog.|
-|[Update a published app](../api/teamsapp-update.md) | [teamsApp](teamsapp.md) | Update a published app in your organization's app catalog.|
-|[Remove a published app](../api/teamsapp-delete.md) | None | Remove a published app from your organization's app catalog.|
+|[List published apps](../api/teamsapp-list.md) | [teamsApp](teamsapp.md) collection | List published apps from the Microsoft Teams apps catalog.| Delegated (admin consent), Application |
+|[Publish an app](../api/teamsapp-publish.md) | [teamsApp](teamsapp.md) | Publish an app to your organization's app catalog.| Delegated (admin consent), Application |
+|[Update a published app](../api/teamsapp-update.md) | [teamsApp](teamsapp.md) | Update a published app in your organization's app catalog.| Delegated (admin consent), Application | 
+|[Remove a published app](../api/teamsapp-delete.md) | None | Remove a published app from your organization's app catalog.| Delegated (admin consent), Application |
 
 ## Properties
 

--- a/api-reference/beta/resources/teamsapp.md
+++ b/api-reference/beta/resources/teamsapp.md
@@ -20,7 +20,7 @@ Users can see these apps in the Microsoft Teams Store, and these apps can be ins
 ## Methods
 
 | Method       | Return Type  |Description| Permissions |
-|:---------------|:--------|:----------|
+|:---------------|:--------|:----------|:----------|
 |[List published apps](../api/teamsapp-list.md) | [teamsApp](teamsapp.md) collection | List published apps from the Microsoft Teams apps catalog.| Delegated (admin consent), Application |
 |[Publish an app](../api/teamsapp-publish.md) | [teamsApp](teamsapp.md) | Publish an app to your organization's app catalog.| Delegated (admin consent), Application |
 |[Update a published app](../api/teamsapp-update.md) | [teamsApp](teamsapp.md) | Update a published app in your organization's app catalog.| Delegated (admin consent), Application | 

--- a/api-reference/beta/resources/teamstab.md
+++ b/api-reference/beta/resources/teamstab.md
@@ -17,13 +17,13 @@ A teamsTab is a [tab](../resources/teamstab.md) that's pinned (attached) to a [c
 
 ## Methods
 
-| Method       | Return Type  |Description|
-|:---------------|:--------|:----------|
-|[List tabs](../api/teamstab-list.md) | [teamsTab](teamstab.md) | Lists tabs pinned to a channel.|
-|[Get tab](../api/teamstab-get.md) | [teamsTab](teamstab.md) | Reads a tab pinned to a channel.|
-|[Add tab](../api/teamstab-add.md) | [teamsTab](teamstab.md) | Adds (pins) a tab to a channel.|
-|[Delete tab](../api/teamstab-delete.md) | None | Removes (unpins) a tab from a channel.|
-|[Update tab](../api/teamstab-update.md) | [teamsTab](teamstab.md) | Updates the tab properties.|
+| Method       | Return Type  |Description| Permissions |
+|:---------------|:--------|:----------| :----------|
+|[List tabs](../api/teamstab-list.md) | [teamsTab](teamstab.md) | Lists tabs pinned to a channel.| Delegated (admin consent), Application, RSC |
+|[Get tab](../api/teamstab-get.md) | [teamsTab](teamstab.md) | Reads a tab pinned to a channel.| Delegated (admin consent), Application, RSC |
+|[Add tab](../api/teamstab-add.md) | [teamsTab](teamstab.md) | Adds (pins) a tab to a channel.| Delegated (admin consent), Application, RSC |
+|[Delete tab](../api/teamstab-delete.md) | None | Removes (unpins) a tab from a channel.| Delegated (admin consent), Application, RSC |
+|[Update tab](../api/teamstab-update.md) | [teamsTab](teamstab.md) | Updates the tab properties.| Delegated (admin consent), Application, RSC |
 
 
 ## Properties


### PR DESCRIPTION
Hi Nick,
Please check the permissions column added in the 'Channel', 'Chat Message', 'AppCatalog', and 'Tabs' resources.