### PR TITLE
Doc bug

### DIFF
--- a/api-reference/v1.0/api/directory-deleteditems-delete.md
+++ b/api-reference/v1.0/api/directory-deleteditems-delete.md
@@ -32,7 +32,7 @@ For users:
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | User.ReadWrite.All, Directory.AccessAsUser.All |
 |Delegated (personal Microsoft account) | Not supported. |
-|Application | User.ReadWrite.All |
+|Application | Not supported. |
 
 For groups:
 
@@ -40,7 +40,7 @@ For groups:
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | Group.ReadWrite.All, Directory.AccessAsUser.All |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Group.ReadWrite.All |
+|Application | Not supported. |
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
User.ReadWrite.All doesn't support app only hard delete because it requires a scope check to ensure the calling user is in a role which is allowed to permanently delete users.

Group.ReadWrite.All doesn't support hard deletion of Groups.