### PR TITLE
Documentation for sync on events

### DIFF
--- a/api-reference/beta/api/event-delta.md
+++ b/api-reference/beta/api/event-delta.md
@@ -143,7 +143,7 @@ Content-length: 359
 }
 ```
 
-# event: delta
+## event: delta
 By using delta query on **events**, you can get new, updated, or deleted events in a user’s default calendar or a specific calendar. The returned events will include single instance meetings and series master with a minimal set of details. For the returned list of events, client can expand the event using the [Get Event](../api/event-get.md) as needed. 
 
  The delta data enables you to maintain and synchronize a local store of a user's events, without having to fetch the entire set of the user's events from the server every time. 

--- a/api-reference/beta/api/event-delta.md
+++ b/api-reference/beta/api/event-delta.md
@@ -7,7 +7,7 @@ ms.prod: "outlook"
 doc_type: apiPageType
 ---
 
-# event: delta
+# calendarView: delta
 
 Namespace: microsoft.graph
 
@@ -139,6 +139,125 @@ Content-length: 359
       "reminderMinutesBeforeStart": 99,
       "isReminderOn": true
     }
+  ]
+}
+```
+
+# event: delta
+By using delta query on **events**, you can get new, updated, or deleted events in a user’s default calendar or a specific calendar. The returned events will include single instance meetings and series master with a minimal set of details. For the returned list of events, client can expand the event using the [Get Event](../api/event-get.md) as needed. 
+
+ The delta data enables you to maintain and synchronize a local store of a user's events, without having to fetch the entire set of the user's events from the server every time. 
+
+ ## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /me/events/delta 
+GET /users/{id | userPrincipalName}/events/delta 
+
+GET /me/calendar/events/delta 
+GET /users/{id | userPrincipalName}/calendar/events/delta 
+
+GET /me/calendars/{id}/events/delta 
+GET /users/{id | userPrincipalName}/calendars/{id}/events/delta 
+
+GET /me/calendargroup/calendars/{id}/events/delta 
+GET /users/{id | userPrincipalName}/calendargroup/calendars/{id}/events/delta 
+
+GET /me/calendargroups/{id}/calendars/{id}/events/delta 
+GET /users/{id | userPrincipalName}/calendargroups/{id}/calendars/{id}/events/delta 
+
+```
+
+## Query parameters
+
+Tracking changes in events incurs a round of one or more **delta** function calls. If you use any query parameter (other than `$deltatoken` and `$skiptoken`), you must specify
+it in the initial **delta** request. Microsoft Graph automatically encodes any specified parameters
+into the token portion of the `nextLink` or `deltaLink` URL provided in the response. You only need to specify any desired query parameters once upfront.
+In subsequent requests, simply copy and apply the `nextLink` or `deltaLink` URL from the previous response, as that URL already
+includes the encoded, desired parameters.
+
+
+| Query parameter	   | Type	|Description|
+|:---------------|:--------|:----------|
+|startDateTime|String|The start date and time of the time range, represented in ISO 8601 format. For example, "2020-05-08T19:00:00.0000000".|
+| $deltatoken | string | A [state token](/graph/delta-query-overview) returned in the `deltaLink` URL of the previous **delta** function call for the same calendar events, indicating the completion of that round of change tracking. Save and apply the entire `deltaLink` URL including this token in the first request of the next round of change tracking for that calendar's events.|
+| $skiptoken | string | A [state token](/graph/delta-query-overview) returned in the `nextLink` URL of the previous **delta** function call, indicating there are further changes to be tracked in the same calendar's events. |
+
+When you do a delta query on events, expect to get only Event Id, start date time, end date time and event type in the response. `$select` and `$filter` are not supported in this case.
+
+
+## Request headers
+| Name       | Type | Description |
+|:---------------|:----------|:----------|
+| Authorization  | string  | Bearer {token}. Required. |
+| Content-Type  | string  | application/json. Required. |
+| Prefer | string  | odata.maxpagesize={x}. Optional. |
+| Prefer | string | {Time zone}. Optional, UTC assumed if absent.|
+
+## Response
+
+If successful, this method returns a `200 OK` response code and [event](../resources/event.md) collection object in the response body.
+
+## Example
+##### Request
+
+The following example shows how to make a single **delta** function call, and limit the maximum number of events
+in the response body to 2.
+
+To track changes in a calendar view, you would make one or more **delta** function calls, with
+appropriate [state tokens](/graph/delta-query-overview), to get the set of incremental changes since the last delta query.
+
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "event_delta"
+}-->
+```msgraph-interactive
+GET https://graph.microsoft.com//beta/events/delta?startdatetime={start_datetime}
+
+Prefer: odata.maxpagesize=2
+```
+# [C#](#tab/csharp)
+
+# [JavaScript](#tab/javascript)
+---
+
+
+##### Response
+If the request is successful, the response would include a state token, which is either a _skipToken_
+(in an _@odata.nextLink_ response header) or a _deltaToken_ (in an _@odata.deltaLink_ response header).
+Respectively, they indicate whether you should continue with the round or you have completed
+getting all the changes for that round.
+
+The response below shows a _skipToken_ in an _@odata.nextLink_ response header.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.event",
+  "isCollection": true
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 359
+
+{
+  "@odata.nextLink":"https://graph.microsoft.com/beta/me/calendarview/delta?$skiptoken={_skipToken_}",
+  "value": [
+    { 
+      "id": " AAMkADllMWMwNDkzLWJlY2EtNDIyOS1iZjAA=", 
+      "type": "singleInstance", 
+      "start": {  
+             "DateTime": "2020-02-19T10:00:00.0000000",  
+             "TimeZone": "UTC" 
+         },  
+       "end": {  
+                "DateTime": "2020-02-19T11:00:00.0000000",  
+                "TimeZone": "UTC"        
+          }  
+        } 
   ]
 }
 ```


### PR DESCRIPTION
Current sync that is made available on MS-Graph is on calendar view. This work is for making sync on events (that has been private behavior for quite sometime) to be publicly available.

Document reference on the difference between calendar view delta and event delta:

https://microsoft.sharepoint-df.com/:w:/r/teams/CalendarService/_layouts/15/Doc.aspx?sourcedoc=%7B491F6293-C2B2-4911-A3F1-67B4D061AE30%7D&file=EventSync%20Graph%20documentation.docx&action=default&mobileredirect=true

@angelgolfer-ms 
Kindly review the PR for all the edits needed :-)

