### PR TITLE
Fixed typo in use-postman.md

### DIFF
--- a/concepts/use-postman.md
+++ b/concepts/use-postman.md
@@ -36,7 +36,7 @@ Consuming the collection is the easiest way to get started with Microsoft Graph 
 You should now see the **Microsoft Graph environment** in the top right environment drop down by the eye icon. Now you need to  [set up your environment](#using-the-collection).
 
 ## Using the collection
-After you have the **Microsoft Graph** collection and the **Microsoftr Graph environment** in Postman, follow these steps.
+After you have the **Microsoft Graph** collection and the **Microsoft Graph environment** in Postman, follow these steps.
 
 ### Set up application API calls
 


### PR DESCRIPTION
This commit fixes a typo - changing 'Microsoftr' to 'Microsoft'.