### PR TITLE
Add note not to use creationOptions

### DIFF
--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -107,6 +107,8 @@ This resource supports:
 
 ## Properties
 
+> **Note:** The `resourceProvisioningOptions` property should not be used to determine the app that created a group and it may be deprecated at a future date.  Instead use the `createdByAppId` property for the App ID of the app used to create the group. 
+
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |allowExternalSenders|Boolean| Indicates if people external to the organization can send messages to the group. Default value is **false**. <br><br>Returned only on $select. |

--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -107,7 +107,7 @@ This resource supports:
 
 ## Properties
 
-> **Note:** The `resourceProvisioningOptions` property should not be used to determine the app that created a group and it may be deprecated at a future date.  Instead use the `createdByAppId` property for the App ID of the app used to create the group. 
+> **Note:** The `creationOptions` property should not be used to determine the app that created a group and it will be deprecated at a future date.  Instead use the `createdByAppId` property for the App ID of the app used to create the group.  In many cases the value of `createdByAppId` will be null as it was introduced in April 2020.
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|

--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -107,8 +107,6 @@ This resource supports:
 
 ## Properties
 
-> **Note:** In many cases the value of **createdByAppId** will be null as it was introduced in April 2020.
-
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |allowExternalSenders|Boolean| Indicates if people external to the organization can send messages to the group. Default value is **false**. <br><br>Returned only on $select. |
@@ -116,7 +114,7 @@ This resource supports:
 |assignedLicenses|[assignedLicense](assignedlicense.md) collection|The licenses that are assigned to the group. <br><br>Returned only on $select. Read-only.|
 |autoSubscribeNewMembers|Boolean|Indicates if new members added to the group will be auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group. Default value is **false**. <br><br>Returned only on $select.|
 |classification|String|Describes a classification for the group (such as low, medium or high business impact). Valid values for this property are defined by creating a ClassificationList [setting](directorysetting.md) value, based on the [template definition](directorysettingtemplate.md).<br><br>Returned by default.|
-|createdByAppId|String|App ID of the app used to create the group. Can be null for some groups. <br><br>Returned by default. Read-only. Supports $filter.|
+|createdByAppId|String|App ID of the app used to create the group. Can be null for some groups as this property was introduced in April 2020.<br><br>Returned by default. Read-only. Supports $filter.|
 |createdDateTime|DateTimeOffset| Timestamp of when the group was created. The value cannot be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`. <br><br>Returned by default. Read-only. |
 |deletedDateTime|DateTimeOffset| For some Azure Active Directory objects (user, group, application), if the object is deleted, it is first logically deleted, and this property is updated with the date and time when the object was deleted. Otherwise this property is null. If the object is restored, this property is updated to null. |
 |description|String|An optional description for the group. <br><br>Returned by default.|

--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -107,7 +107,7 @@ This resource supports:
 
 ## Properties
 
-> **Note:** The **creationOptions** property should not be used to determine the app that created a group and it will be deprecated.  Instead use the **createdByAppId** property for the App ID of the app used to create the group.  In many cases the value of **createdByAppId** will be null as it was introduced in April 2020.
+> **Note:** In many cases the value of **createdByAppId** will be null as it was introduced in April 2020.
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|

--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -107,7 +107,7 @@ This resource supports:
 
 ## Properties
 
-> **Note:** The `creationOptions` property should not be used to determine the app that created a group and it will be deprecated at a future date.  Instead use the `createdByAppId` property for the App ID of the app used to create the group.  In many cases the value of `createdByAppId` will be null as it was introduced in April 2020.
+> **Note:** The **creationOptions** property should not be used to determine the app that created a group and it will be deprecated.  Instead use the **createdByAppId** property for the App ID of the app used to create the group.  In many cases the value of **createdByAppId** will be null as it was introduced in April 2020.
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|

--- a/api-reference/v1.0/resources/group.md
+++ b/api-reference/v1.0/resources/group.md
@@ -107,6 +107,9 @@ This resource supports:
 |[resetUnseenCount](../api/group-resetunseencount.md)|None|Reset the unseenCount to 0 of all the posts that the signed-in user has not seen since their last visit. Supported for only Office 365 groups.|
 
 ## Properties
+
+> **Note:** The `creationOptions` property should not be used to determine the app that created a group and it will be deprecated at a future date.
+
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |allowExternalSenders|Boolean| Indicates if people external to the organization can send messages to the group. Default value is **false**. <br><br>Returned only on $select. |

--- a/api-reference/v1.0/resources/group.md
+++ b/api-reference/v1.0/resources/group.md
@@ -108,7 +108,7 @@ This resource supports:
 
 ## Properties
 
-> **Note:** The `creationOptions` property should not be used to determine the app that created a group and it will be deprecated at a future date.
+> **Note:** The **creationOptions** property should not be used to determine the app that created a group and it will be deprecated at a future date.
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
@@ -117,6 +117,7 @@ This resource supports:
 |autoSubscribeNewMembers|Boolean|Indicates if new members added to the group will be auto-subscribed to receive email notifications. You can set this property in a PATCH request for the group; do not set it in the initial POST request that creates the group. Default value is **false**. <br><br>Returned only on $select.|
 |classification|String|Describes a classification for the group (such as low, medium or high business impact). Valid values for this property are defined by creating a ClassificationList [setting](groupsetting.md) value, based on the [template definition](groupsettingtemplate.md).<br><br>Returned by default.|
 |createdDateTime|DateTimeOffset| Timestamp of when the group was created. The value cannot be modified and is automatically populated when the group is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`. <br><br>Returned by default. Read-only. |
+|creationOptions|String|Do not use. This property will be deprecated. Use **resourceBehaviorOptions** instead.|
 |deletedDateTime|DateTimeOffset| For some Azure Active Directory objects (user, group, application), if the object is deleted, it is first logically deleted, and this property is updated with the date and time when the object was deleted. Otherwise this property is null. If the object is restored, this property is updated to null. |
 |description|String|An optional description for the group. <br><br>Returned by default.|
 |displayName|String|The display name for the group. This property is required when a group is created and cannot be cleared during updates. <br><br>Returned by default. Supports $filter and $orderby. |


### PR DESCRIPTION
Add note not to use resourceProvisioningOptions (may be deprecated in future) but instead use createdByAppId.