### PR TITLE
Corrected error in request URL

### DIFF
--- a/api-reference/beta/api/serviceprincipal-delete-homerealmdiscoverypolicies.md
+++ b/api-reference/beta/api/serviceprincipal-delete-homerealmdiscoverypolicies.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-DELETE /servicePrincipals/{id}/homeRealmDiscoveryPolicies/{id}$ref
+DELETE /servicePrincipals/{servicePrincipalId}/homeRealmDiscoveryPolicies/{policyId}/$ref
 ```
 
 ## Request headers
@@ -60,7 +60,7 @@ The following is an example of the request.
 }-->
 
 ```http
-DELETE https://graph.microsoft.com/beta/servicePrincipals/{id}/homeRealmDiscoveryPolicies/{id}/$ref
+DELETE https://graph.microsoft.com/beta/servicePrincipals/{servicePrincipalId}/homeRealmDiscoveryPolicies/{policyId}/$ref
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-homerealmdiscoverypolicy-from-serviceprincipal-csharp-snippets.md)]


### PR DESCRIPTION
Added missing forward slash after the {id} segment in the HTTP request URL and updated both {id} placeholder values to be more specific - {servicePrincipalId} and {policyId}, respectively.