### PR TITLE
Using "authority" in MGT TeamsProvider

### DIFF
--- a/concepts/toolkit/providers/teams.md
+++ b/concepts/toolkit/providers/teams.md
@@ -26,6 +26,7 @@ The following example uses the provider in HTML (via CDN).
 <mgt-teams-provider
   client-id="<YOUR_CLIENT_ID>"
   auth-popup-url="https://<YOUR-DOMAIN>.com/AUTH-PATH"
+  authority=""
 ></mgt-teams-provider>
 ```
 
@@ -35,6 +36,8 @@ The following example uses the provider in HTML (via CDN).
 | auth-popup-url  | Absolute or relative path to the page that will handle auth in the popup (see Create the popup page). Required. |
 | scopes  | Comma separated strings for scopes the user must consent to on sign in. Optional. |
 | depends-on | Element selector string of another higher-priority provider component. Optional. |
+| authority    | Authority string - default is the common authority. For single-tenant apps, use your tenant ID or tenant name. For example, `https://login.microsoftonline.com/[your-tenant-name].onmicrosoft.com` or `https://login.microsoftonline.com/[your-tenant-id]`. Optional. |
+
 
 ### via NPM
 The following example uses the provider in JS modules (via NPM).


### PR DESCRIPTION
Added a small documentation update on the addition of "authority" attribute in the mgt-teams-provider. 