### PR TITLE
Correct invalid prototypes in Education Delta documentation

### DIFF
--- a/api-reference/beta/api/educationclass-delta.md
+++ b/api-reference/beta/api/educationclass-delta.md
@@ -30,8 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /education/classes/{id}/delta
-POST /education/me/classes/{id}/delta
+GET /education/classes/delta
 ```
 
 ## Request headers
@@ -65,14 +64,15 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/v1.0/education/classes/{id}/delta
+GET https://graph.microsoft.com/beta/education/classes/delta
 ```
 
 ##### Response
 
 The following is an example of the response.
 
-> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> [!NOTE]
+> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",
@@ -89,25 +89,18 @@ Content-length: 585
 {
   "value": [
     {
-      "displayName": "displayName-value",
-      "mailNickname": "mailNickname-value",
-      "description": "description-value",
-      "createdBy": {
-        "application": {
-          "displayName": "displayName-value",
-          "id": "id-value"
-        },
-        "device": {
-          "displayName": "displayName-value",
-          "id": "id-value"
-        },
-        "user": {
-          "displayName": "displayName-value",
-          "id": "id-value"
-        }
-      },
-      "classCode": "classCode-value",
-      "externalName": "externalName-value"
+      "classCode": "String",
+      "course": { "@odata.type": "microsoft.graph.educationCourse" },
+      "createdBy": { "@odata.type": "microsoft.graph.identitySet" },
+      "description": "String",
+      "displayName": "String",
+      "externalId": "String",
+      "externalName": "String",
+      "externalSource": "string",
+      "grade": "string",
+      "id": "String (identifier)",
+      "mailNickname": "String",
+      "term": { "@odata.type": "microsoft.graph.educationTerm" }
     }
   ]
 }

--- a/api-reference/beta/api/educationclass-delta.md
+++ b/api-reference/beta/api/educationclass-delta.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code and an [educationCla
 
 The following example shows how to call this API.
 
-##### Request
+### Request
 
 The following is an example of the request.
 
@@ -67,12 +67,11 @@ The following is an example of the request.
 GET https://graph.microsoft.com/beta/education/classes/delta
 ```
 
-##### Response
+### Response
 
 The following is an example of the response.
 
-> [!NOTE]
-> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/educationschool-delta.md
+++ b/api-reference/beta/api/educationschool-delta.md
@@ -30,10 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /education/schools/{id}/delta
-POST /education/me/schools/{id}/delta
-POST /education/users/{id}/schools/{id}/delta
-
+GET /education/schools/delta
 ```
 
 ## Request headers
@@ -67,14 +64,15 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/v1.0/education/schools/{id}/delta
+GET https://graph.microsoft.com/beta/education/schools/delta
 ```
 
 ##### Response
 
 The following is an example of the response.
 
-> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> [!NOTE]
+> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",
@@ -91,12 +89,20 @@ Content-length: 313
 {
   "value": [
     {
-      "principalEmail": "principalEmail-value",
-      "principalName": "principalName-value",
-      "externalPrincipalId": "externalPrincipalId-value",
-      "lowestGrade": "lowestGrade-value",
-      "highestGrade": "highestGrade-value",
-      "schoolNumber": "schoolNumber-value"
+      "address": { "@odata.type": "microsoft.graph.physicalAddress" },
+      "createdBy": { "@odata.type": "microsoft.graph.identitySet" },
+      "description": "String",
+      "displayName": "String",
+      "externalId": "String",
+      "externalPrincipalId": "String",
+      "externalSource": "string",
+      "highestGrade": "String",
+      "id": "String (identifier)",
+      "lowestGrade": "String",
+      "phone": "String",
+      "principalEmail": "String",
+      "principalName": "String",
+      "schoolNumber": "String"
     }
   ]
 }

--- a/api-reference/beta/api/educationschool-delta.md
+++ b/api-reference/beta/api/educationschool-delta.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code and an [educationSch
 
 The following example shows how to call this API.
 
-##### Request
+### Request
 
 The following is an example of the request.
 
@@ -67,12 +67,11 @@ The following is an example of the request.
 GET https://graph.microsoft.com/beta/education/schools/delta
 ```
 
-##### Response
+### Response
 
 The following is an example of the response.
 
-> [!NOTE]
-> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/educationuser-delta.md
+++ b/api-reference/beta/api/educationuser-delta.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code and an [educationUse
 
 The following example shows how to call this API.
 
-##### Request
+### Request
 
 The following is an example of the request.
 
@@ -67,12 +67,11 @@ The following is an example of the request.
 GET https://graph.microsoft.com/beta/education/users/delta
 ```
 
-##### Response
+### Response
 
 The following is an example of the response.
 
-> [!NOTE]
-> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/educationuser-delta.md
+++ b/api-reference/beta/api/educationuser-delta.md
@@ -19,20 +19,18 @@ Get newly created or updated [educationUser](../resources/educationuser.md) with
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-| Permission type                        | Permissions (from least to most privileged)     |
-| :------------------------------------- | :---------------------------------------------- |
-| Delegated (work or school account)     | Not supported.                                  |
-| Delegated (personal Microsoft account) | Not supported.                                  |
-| Application                            | EduRoster.Read.All, or EduRoster.WriteWrite.All |
+| Permission type                        | Permissions (from least to most privileged)                              |
+| :------------------------------------- | :----------------------------------------------------------------------- |
+| Delegated (work or school account)     | EduRoster.ReadBasic, EduRoster.Read, or EduRoster.ReadWrite              |
+| Delegated (personal Microsoft account) | Not supported.                                                           |
+| Application                            | EduRoster.ReadBasic.All, EduRoster.Read.All, or EduRoster.WriteWrite.All |
 
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /education/me/delta
-POST /education/users/{id}/delta
-POST /education/schools/{id}/users/{id}/delta
+GET /education/users/delta
 ```
 
 ## Request headers
@@ -66,14 +64,15 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/v1.0/education/me/delta
+GET https://graph.microsoft.com/beta/education/users/delta
 ```
 
 ##### Response
 
 The following is an example of the response.
 
-> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+> [!NOTE]
+> The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
 
 <!-- {
   "blockType": "response",
@@ -90,35 +89,37 @@ Content-length: 1039
 {
   "value": [
     {
-      "primaryRole": "primaryRole-value",
-      "middleName": "middleName-value",
-      "externalSource": "externalSource-value",
-      "residenceAddress": {
-        "type": "type-value",
-        "postOfficeBox": "postOfficeBox-value",
-        "street": "street-value",
-        "city": "city-value",
-        "state": "state-value",
-        "countryOrRegion": "countryOrRegion-value",
-        "postalCode": "postalCode-value"
+      "accountEnabled": true,
+      "assignedLicenses": [{ "@odata.type": "microsoft.graph.assignedLicense" }],
+      "assignedPlans": [{ "@odata.type": "microsoft.graph.assignedPlan" }],
+      "businessPhones": ["String"],
+      "createdBy": { "@odata.type": "microsoft.graph.identitySet" },
+      "department": "String",
+      "displayName": "String",
+      "externalSource": "string",
+      "givenName": "String",
+      "id": "String (identifier)",
+      "mail": "String",
+      "mailNickname": "String",
+      "mailingAddress": { "@odata.type": "microsoft.graph.physicalAddress" },
+      "middleName": "String",
+      "mobilePhone": "String",
+      "officeLocation": "String",
+      "onPremisesInfo": {
+        "@odata.type": "microsoft.graph.educationOnPremisesInfo"
       },
-      "mailingAddress": {
-        "type": "type-value",
-        "postOfficeBox": "postOfficeBox-value",
-        "street": "street-value",
-        "city": "city-value",
-        "state": "state-value",
-        "countryOrRegion": "countryOrRegion-value",
-        "postalCode": "postalCode-value"
-      },
-      "student": {
-        "graduationYear": "graduationYear-value",
-        "grade": "grade-value",
-        "birthDate": "datetime-value",
-        "gender": "gender-value",
-        "studentNumber": "studentNumber-value",
-        "externalId": "externalId-value"
-      }
+      "passwordPolicies": "String",
+      "passwordProfile": { "@odata.type": "microsoft.graph.passwordProfile" },
+      "preferredLanguage": "String",
+      "primaryRole": "string",
+      "provisionedPlans": [{ "@odata.type": "microsoft.graph.provisionedPlan" }],
+      "residenceAddress": { "@odata.type": "microsoft.graph.physicalAddress" },
+      "student": { "@odata.type": "microsoft.graph.educationStudent" },
+      "surname": "String",
+      "teacher": { "@odata.type": "microsoft.graph.educationTeacher" },
+      "usageLocation": "String",
+      "userPrincipalName": "String",
+      "userType": "String"
     }
   ]
 }


### PR DESCRIPTION
Corrects a number of issues with the call and object prototypes in the Delta documentation for `educationUser`, `educationClass`, and `educationSchool` resources. 