### PR TITLE
Update team-get-primarychannel.md

### DIFF
--- a/api-reference/beta/api/team-get-primarychannel.md
+++ b/api-reference/beta/api/team-get-primarychannel.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /teams/{id}/channels/{id}/primaryChannel
+GET /teams/{id}/primaryChannel
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
First example URL incorrectly included a segment for channel ID. This results in 400 BadRequest. Second example is correct (team id only, no channel id). Corrected first example.