### PR TITLE
- removes changenotification sequencenumber that was introduced by error

### DIFF
--- a/api-reference/beta/resources/changenotification.md
+++ b/api-reference/beta/resources/changenotification.md
@@ -32,7 +32,6 @@ None.
 | id | string | Unique ID for the notification. Optional. |
 | resource | string | The URI of the resource that emitted the change notification relative to `https://graph.microsoft.com`. Required. |
 | resourceData | [microsoft.graph.resourceData](resourcedata.md) | The content of this property depends on the type of resource being subscribed to. Required. |
-| sequenceNumber | int | A number in sequence for a notification, to help the client app identify if notifications are in sequence or if a notification is missing. Optional. |
 | subscriptionExpirationDateTime | [dateTime](https://tools.ietf.org/html/rfc3339) | The expiration time for the subscription. Required. |
 | subscriptionId | string | The unique identifier of the subscription that generated the notification. |
 | tenantId | guid | The unique identifier of the tenant from which the change notification originated. |
@@ -59,7 +58,6 @@ The following is a JSON representation of the resource.
   "changeType": "created",
   "clientState": "client state provided when creating subscription",
   "id": "15ee1d1f-af7b-42d9-885b-9d00db065dd9",
-  "sequenceNumber": 20,
   "tenantId": "2c937fad-a8a7-496c-b0e4-bf77dcc7eb2a",
   "subscriptionExpirationDateTime": "2020-04-12T23:20:50.52Z",
   "resource": "teams('d29828b8-c04d-4e2a-b2f6-07da6982f0f0')/channels('19:f127a8c55ad949d1a238464d22f0f99e@thread.skype')/messages('1565045424600')/replies('1565047490246')",

--- a/api-reference/v1.0/resources/changenotification.md
+++ b/api-reference/v1.0/resources/changenotification.md
@@ -28,7 +28,6 @@ None.
 | id | string | Unique ID for the notification. Optional. |
 | resource | string | The URI of the resource that emitted the change notification relative to `https://graph.microsoft.com`. Required. |
 | resourceData | [microsoft.graph.resourceData](resourcedata.md) | The content of this property depends on the type of resource being subscribed to. Required. |
-| sequenceNumber | int | A number in sequence for a notification, to help the client app identify if notifications are in sequence or if a notification is missing. Optional. |
 | subscriptionExpirationDateTime | [dateTime](https://tools.ietf.org/html/rfc3339) | The expiration time for the subscription. Required. |
 | subscriptionId | string | The unique identifier of the subscription that generated the notification. |
 | tenantId | guid | The unique identifier of the tenant from which the change notification originated. |
@@ -55,7 +54,6 @@ The following is a JSON representation of the resource.
   "changeType": "created",
   "clientState": "client state provided when creating subscription",
   "id": "15ee1d1f-af7b-42d9-885b-9d00db065dd9",
-  "sequenceNumber": 20,
   "tenantId": "2c937fad-a8a7-496c-b0e4-bf77dcc7eb2a",
   "subscriptionExpirationDateTime": "2020-04-12T23:20:50.52Z",
   "resource": "teams('d29828b8-c04d-4e2a-b2f6-07da6982f0f0')/channels('19:f127a8c55ad949d1a238464d22f0f99e@thread.skype')/messages('1565045424600')/replies('1565047490246')",

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -16,7 +16,7 @@ For a summary of the value of these API changes, as well as recent tools, compon
 ### Change notifications
 | **Change type** | **Version**   | **Description**                          |
 | :-------------- | :------------ | :--------------------------------------- |
-| Removal | beta and v1.0 | Removed the erronously introduced sequenceNumber from [changeNotification](/graph/api/resources/changenotification) type.|
+| Removal | beta and v1.0 | Removed the erronously introduced **sequenceNumber** property from the [changeNotification](/graph/api/resources/changenotification) type.|
 
 ### Devices and apps | Cloud printing
 | **Change type** | **Version**   | **Description**                          |

--- a/concepts/changelog.md
+++ b/concepts/changelog.md
@@ -13,6 +13,11 @@ For a summary of the value of these API changes, as well as recent tools, compon
 
 ### July 2020
 
+### Change notifications
+| **Change type** | **Version**   | **Description**                          |
+| :-------------- | :------------ | :--------------------------------------- |
+| Removal | beta and v1.0 | Removed the erronously introduced sequenceNumber from [changeNotification](/graph/api/resources/changenotification) type.|
+
 ### Devices and apps | Cloud printing
 | **Change type** | **Version**   | **Description**                          |
 | :-------------- | :------------ | :--------------------------------------- |

--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -208,7 +208,6 @@ When many changes occur, Microsoft Graph may send multiple notifications that co
   "value": [
     {
       "id": "lsgTZMr9KwAAA",
-      "sequenceNumber": 10,
       "subscriptionId":"{subscription_guid}",
       "subscriptionExpirationDateTime":"2016-03-19T22:11:09.952Z",
       "clientState":"secretClientValue",

--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -109,7 +109,6 @@ GA of the [shifts API](/graph/api/resources/shift?view=graph-rest-1.0) in v1.0 -
 
 ### Change notifications
 - Use formally schematized types [changeNotification](/graph/api/resources/changenotification?view=graph-rest-beta) and [changeNotificationCollection](/graph/api/resources/changenotificationcollection?view=graph-rest-beta) to process resource change notifications. 
-- Track if notifications are in sequence or if a notification is missing by using the **sequenceNumber** property on the **changeNotification** resource.
 
 ### Devices and apps | Cloud printing
 - The [printer](/graph/api/resources/printer?view=graph-rest-beta) and [printerShare](/graph/api/resources/printershare?view=graph-rest-beta) resources are now in parity and have the same properties as each other.

--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -109,6 +109,7 @@ GA of the [shifts API](/graph/api/resources/shift?view=graph-rest-1.0) in v1.0 -
 
 ### Change notifications
 - Use formally schematized types [changeNotification](/graph/api/resources/changenotification?view=graph-rest-beta) and [changeNotificationCollection](/graph/api/resources/changenotificationcollection?view=graph-rest-beta) to process resource change notifications. 
+- Track if notifications are in sequence or if a notification is missing by using the **sequenceNumber** property on the **changeNotification** resource.
 
 ### Devices and apps | Cloud printing
 - The [printer](/graph/api/resources/printer?view=graph-rest-beta) and [printerShare](/graph/api/resources/printershare?view=graph-rest-beta) resources are now in parity and have the same properties as each other.


### PR DESCRIPTION
@angelgolfer-ms after some more internal reviews it looks like I've accidently introduced a property that never existed at the first place (POC that never went public). I'm doing the work to get this removed from schema ASAP.
I've already reviewed with @dkershaw10 the fact that this property never existed for customers and that it's ok to "discretely" remove it.