### PR TITLE
Update opentypeextension-get.md

### DIFF
--- a/api-reference/v1.0/api/opentypeextension-get.md
+++ b/api-reference/v1.0/api/opentypeextension-get.md
@@ -75,7 +75,8 @@ GET /groups/{Id}/threads/{Id}/posts/{Id}?$expand=extensions($filter=id eq '{exte
 GET /users/{Id|userPrincipalName}/messages/{Id}?$expand=extensions($filter=id eq '{extensionId}')
 GET /users/{Id|userPrincipalName}/contacts/{Id}?$expand=extensions($filter=id eq '{extensionId}')
 ```
-
+>**Note:** that equals signs inside the $expand extensions expression need to be uri encoded, thus sections like `$expand=extensions($filter=id eq '{extensionId}')` should be transmitted as `$expand=extensions($filter%3Did eq '{extensionId}')`  
+Failing to correctly encode the = symbol will result in an HTTP 400 with the message: Parsing OData Select and Expand failed: Found an unbalanced bracket expression.
 
 For the device, group, organization, and user resource types, you must also use a `$select` parameter to include
 the **id** property and any other properties you want from the resource instance:


### PR DESCRIPTION
The current state of the example documentation is causing confusion and developer issues when trying to use the `$expand=extensions($filter=<filter_expression>)` syntax

Adding a note to call out the expectation that the equals symbol needs to be encoded and reference to the specific error message given in this instance to allow for ease for searchability when trying to resolve these issues.

Ref: https://stackoverflow.com/questions/62686415/receiving-400s-and-500s-when-attempting-to-get-singlevalueextendedproperties
https://stackoverflow.com/questions/62475512/openextensions-find-and-retrieve-events-with-a-given-extension