### PR TITLE
Fix incorrect paths in recently released profileCardProperties docs

### DIFF
--- a/api-reference/beta/api/organizationsettings-list-profilecardproperties.md
+++ b/api-reference/beta/api/organizationsettings-list-profilecardproperties.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-GET https://graph.microsoft.com/beta/organization/settings/profileCardProperties
+GET https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties
 ```
 
 ## Optional query parameters
@@ -67,7 +67,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/organization/settings/profileCardProperties
+GET https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-profilecardproperties-csharp-snippets.md)]

--- a/api-reference/beta/api/organizationsettings-post-profilecardproperties.md
+++ b/api-reference/beta/api/organizationsettings-post-profilecardproperties.md
@@ -34,7 +34,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST https://graph.microsoft.com/beta/organization/settings/profileCardProperties
+POST https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties
 ```
 
 ## Request headers
@@ -65,7 +65,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/organization/settings/profileCardProperties
+POST https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/profilecardproperty-delete.md
+++ b/api-reference/beta/api/profilecardproperty-delete.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-DELETE https://graph.microsoft.com/beta/organization/settings/profileCardProperties/{directoryPropertyName-Value}
+DELETE https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/{directoryPropertyName-Value}
 ```
 
 ## Request headers
@@ -62,7 +62,7 @@ The following example shows how to delete the attribute named "Fax" from the pro
 }-->
 
 ```http
-DELETE https://graph.microsoft.com/beta/organization/settings/profileCardProperties/fax
+DELETE https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/fax
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-profilecardproperty-csharp-snippets.md)]

--- a/api-reference/beta/api/profilecardproperty-get.md
+++ b/api-reference/beta/api/profilecardproperty-get.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-GET https://graph.microsoft.com/beta/organization/settings/profileCardProperties/{id}
+GET https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/{id}
 ```
 
 ## Optional query parameters
@@ -66,7 +66,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/organization/settings/profileCardProperties/{id}
+GET https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/{id}
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-profilecardproperty-csharp-snippets.md)]

--- a/api-reference/beta/api/profilecardproperty-update.md
+++ b/api-reference/beta/api/profilecardproperty-update.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-PATCH https://graph.microsoft.com/beta/organization/settings/profileCardProperties/{id}
+PATCH https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/{id}
 ```
 
 ## Request headers
@@ -68,7 +68,7 @@ The following example adds a localized label "Kostnads Senter" for the locale "n
 }-->
 
 ```http
-PATCH https://graph.microsoft.com/beta/organization/settings/profileCardProperties/CustomAttribute1
+PATCH https://graph.microsoft.com/beta/organization/{organizationId}/settings/profileCardProperties/CustomAttribute1
 Content-type: application/json
 
 {


### PR DESCRIPTION
Early customer feedback that we missed specifying that the organization is needed in the path of the calls to retrieve.

