### PR TITLE
Added additional permissions for default templates

### DIFF
--- a/concepts/toolkit/components/agenda.md
+++ b/concepts/toolkit/components/agenda.md
@@ -123,7 +123,6 @@ The following events are fired from the control.
 | --- | --- |
 | eventClick | The user clicks or taps an event.|
 
-
 ## Permissions
 
 This component uses the following Microsoft Graph APIs and permissions:
@@ -133,6 +132,13 @@ This component uses the following Microsoft Graph APIs and permissions:
 | [/me/calendarview](/graph/api/calendar-list-calendarview?view=graph-rest-1.0) | Calendars.Read |
 
 The component allows you to specify a different Microsoft Graph query to call (such as `/groups/{id}/calendar/calendarView`). In this case, append the permission to the end of the string, delimited by `|`.
+
+When using the default template and default `renderAttendees` template, additional APIs and permissions are required. The default template for this component uses a [mgt-people](people.md) component for events that have attendees, which requires the following.
+
+| Resource | Permission |
+| - | - |
+| [/me/calendarview](/graph/api/user-list-people?view=graph-rest-1.0) | People.Read |
+| [/me/calendarview](/graph/api/user-list-contacts?view=graph-rest-1.0) | Contacts.Read |
 
 ## Authentication
 

--- a/concepts/toolkit/components/agenda.md
+++ b/concepts/toolkit/components/agenda.md
@@ -137,6 +137,7 @@ When using the default template and default `renderAttendees` template, addition
 
 | Resource | Permission |
 | - | - |
+| [/users](user-list) | Users.ReadBasic.All |
 | [/me/calendarview](/graph/api/user-list-people?view=graph-rest-1.0) | People.Read |
 | [/me/calendarview](/graph/api/user-list-contacts?view=graph-rest-1.0) | Contacts.Read |
 

--- a/concepts/toolkit/components/agenda.md
+++ b/concepts/toolkit/components/agenda.md
@@ -137,7 +137,7 @@ When using the default template and default `renderAttendees` template, addition
 
 | Resource | Permission |
 | - | - |
-| [/users](user-list) | Users.ReadBasic.All |
+| [/users](/graph/api/user-list?view=graph-rest-1.0) | Users.ReadBasic.All |
 | [/me/calendarview](/graph/api/user-list-people?view=graph-rest-1.0) | People.Read |
 | [/me/calendarview](/graph/api/user-list-contacts?view=graph-rest-1.0) | Contacts.Read |
 

--- a/concepts/toolkit/components/people.md
+++ b/concepts/toolkit/components/people.md
@@ -92,7 +92,7 @@ When using the default templates, additional APIs and permissions are required. 
 
 | Resource | Permission |
 | - | - |
-| [/users](user-list) | Users.ReadBasic.All |
+| [/users](/graph/api/user-list?view=graph-rest-1.0) | Users.ReadBasic.All |
 | [/me/calendarview](/graph/api/user-list-contacts?view=graph-rest-1.0) | Contacts.Read |
 
 ## Authentication

--- a/concepts/toolkit/components/people.md
+++ b/concepts/toolkit/components/people.md
@@ -88,6 +88,13 @@ This component uses the following Microsoft Graph APIs and permissions:
 | - | - |
 | [/me/people](/graph/api/user-list-people?view=graph-rest-1.0) | `People.Read` |
 
+When using the default templates, additional APIs and permissions are required. The default template for this component uses a [mgt-person](person.md) component, which requires the following.
+
+| Resource | Permission |
+| - | - |
+| [/users](user-list) | Users.ReadBasic.All |
+| [/me/calendarview](/graph/api/user-list-contacts?view=graph-rest-1.0) | Contacts.Read |
+
 ## Authentication
 
 The control uses the global authentication provider described in the [authentication documentation](./../providers.md).


### PR DESCRIPTION
Tricky to explain this I suppose, since theoretically you wouldn't need them if you overrode the template to omit the `mgt-people` or `mgt-person` controls. But out of the box, with an mgt-agenda, you get prompted for `user.readbasic.all`, `people.read`, and `contacts.read`.