### PR TITLE
Generalized note about $filter support for Directory Objects

### DIFF
--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -168,7 +168,7 @@ The following table shows some examples that use the `$filter` query parameter.
 | List all Microsoft 365 groups in an organization. | [`https://graph.microsoft.com/v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')`](https://developer.microsoft.com/graph/graph-explorer?request=groups?$filter=groupTypes/any(c:c+eq+'Unified')&method=GET&version=v1.0) |
 | Use OData cast to get transitive membership in groups with a display name that starts with 'a' including a count of returned objects. | [`https://graph.microsoft.com/beta/me/transitiveMemberOf/microsoft.graph.group?$count=true&$filter=startswith(displayName, 'a')`](https://developer.microsoft.com/graph/graph-explorer?request=me/transitiveMemberOf/microsoft.graph.group?$count=true&$orderby=displayName&$filter=startswith(displayName,'a')&method=GET&version=v1.0) |
 
-> **Note:** Please read the documentation for the specific Directory Objects (Azure AD resources) to learn more about `$filter` operators support.
+> **Note:** Please read the documentation for the specific directory objects (Azure AD resources) to learn more about `$filter` operator support.
 > The `contains` string operator is currently not supported on any Microsoft Graph resources.
 
 ## format parameter

--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -139,6 +139,7 @@ GET https://graph.microsoft.com/v1.0/users?$filter=startswith(displayName,'J')
 Support for `$filter` operators varies across Microsoft Graph APIs. The following logical operators are generally supported: 
 
 - equals (`eq`)
+- in (`in`)
 - not equals (`ne`)
 - greater than (`gt`)
 - greater than or equals (`ge`)
@@ -167,7 +168,8 @@ The following table shows some examples that use the `$filter` query parameter.
 | List all Microsoft 365 groups in an organization. | [`https://graph.microsoft.com/v1.0/groups?$filter=groupTypes/any(c:c+eq+'Unified')`](https://developer.microsoft.com/graph/graph-explorer?request=groups?$filter=groupTypes/any(c:c+eq+'Unified')&method=GET&version=v1.0) |
 | Use OData cast to get transitive membership in groups with a display name that starts with 'a' including a count of returned objects. | [`https://graph.microsoft.com/beta/me/transitiveMemberOf/microsoft.graph.group?$count=true&$filter=startswith(displayName, 'a')`](https://developer.microsoft.com/graph/graph-explorer?request=me/transitiveMemberOf/microsoft.graph.group?$count=true&$orderby=displayName&$filter=startswith(displayName,'a')&method=GET&version=v1.0) |
 
-> **Note:** The following `$filter` operators are not supported for Azure AD resources:  `ne`, `gt`, `ge`, `lt`, `le`, and `not`. The `contains` string operator is currently not supported on any Microsoft Graph resources.
+> **Note:** Please read the documentation for the specific Directory Objects (Azure AD resources) to learn more about `$filter` operators support.
+> The `contains` string operator is currently not supported on any Microsoft Graph resources.
 
 ## format parameter
 


### PR DESCRIPTION
$filter operator support for Directory Objects varies when using ConsistencyLevel = eventual header, and also varies per individual property.
It's impossible to describe every nuance in the overall concept page, so will redirect the user to the documentation of the individual objects.