### PR TITLE
Explicit `userAgentApplication` passed to mgt

### DIFF
--- a/concepts/toolkit/providers/msal.md
+++ b/concepts/toolkit/providers/msal.md
@@ -47,7 +47,11 @@ import {UserAgentApplication} from "msal";
 Providers.globalProvider = new MsalProvider(config: MsalConfig);
 ```
 
-where MsalConfig is:
+There are two configuration options for the `MsalProvider` constructor parameter:
+
+#### Provide a `clientId` to create a new `UserAgentApplication`
+
+This option makes sense when Graph Toolkit is responsible for all authentication in your application.
 
 ```ts
 interface MsalConfig {
@@ -61,7 +65,20 @@ interface MsalConfig {
 }
 ```
 
-You must provide a `clientId` (to create a new `UserAgentApplication`).
+#### Pass an existing `UserAgentApplication` in the `userAgentApplication` property.
+
+Use this when your app uses MSAL functionality beyond what's exposed by the `MsalProvider` and other Graph Toolkit features. This is particularly appropriate if a framework automatically instantiates and exposes a `UserAgentApplication` for you, for example when using [msal-angular](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-angular).
+
+Be sure to understand opportunities for collisions when using this option. By its very nature, there is a risk that the `MsalProvider` could change the state of a session, for example by having the user log in or consent to additional scopes. Ensure your app and other frameworks respond gracefully to these changes in state, or else consider a [Custom Provider](https://docs.microsoft.com/en-us/graph/toolkit/providers/custom) instead.
+
+```ts
+interface MsalConfig {
+  userAgentApplication: UserAgentApplication;
+  scopes?: string[];
+  loginType?: LoginType; // LoginType.Popup or LoginType.Redirect (redirect is default)
+  loginHint?: string;
+}
+```
 
 To learn more about MSAL.js and for additional options you can use when initializing the MSAL library, see the [MSAL documentation](https://docs.microsoft.com/azure/active-directory/develop/msal-js-initializing-client-applications).
 

--- a/concepts/toolkit/providers/msal.md
+++ b/concepts/toolkit/providers/msal.md
@@ -67,9 +67,9 @@ interface MsalConfig {
 
 #### Pass an existing `UserAgentApplication` in the `userAgentApplication` property.
 
-Use this when your app uses MSAL functionality beyond what's exposed by the `MsalProvider` and other Graph Toolkit features. This is particularly appropriate if a framework automatically instantiates and exposes a `UserAgentApplication` for you, for example when using [msal-angular](https://docs.microsoft.com/en-us/azure/active-directory/develop/tutorial-v2-angular).
+Use this when your app uses MSAL functionality beyond what's exposed by the `MsalProvider` and other Graph Toolkit features. This is particularly appropriate if a framework automatically instantiates and exposes a `UserAgentApplication` for you, for example when using [msal-angular](https://docs.microsoft.com/azure/active-directory/develop/tutorial-v2-angular).
 
-Be sure to understand opportunities for collisions when using this option. By its very nature, there is a risk that the `MsalProvider` could change the state of a session, for example by having the user log in or consent to additional scopes. Ensure your app and other frameworks respond gracefully to these changes in state, or else consider a [Custom Provider](https://docs.microsoft.com/en-us/graph/toolkit/providers/custom) instead.
+Be sure to understand opportunities for collisions when using this option. By its very nature, there is a risk that the `MsalProvider` could change the state of a session, for example by having the user log in or consent to additional scopes. Ensure your app and other frameworks respond gracefully to these changes in state, or else consider a [Custom Provider](https://docs.microsoft.com/graph/toolkit/providers/custom) instead.
 
 ```ts
 interface MsalConfig {


### PR DESCRIPTION
Docs for PR: https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/576

Probably needs some wordsmithing. It's late, I'm tired. But this should hit the key points as a draft.

I wasn't sure on the best way to communicate the polymorphic nature of `MsalConfig`. It seems weird to me having the two interface declarations with the same name, but I didn't want to make up names either.

I also wasn't sure whether this repo supports `[!Note]` syntax. It didn't preview, and I can't find examples in the Graph docs, but one of those felt appropriate for the "be sure to understand collisions" paragraph.