### PR TITLE
Update documentation to reflect admin center changes

### DIFF
--- a/concepts/cloud-communications-phone-number.md
+++ b/concepts/cloud-communications-phone-number.md
@@ -57,9 +57,9 @@ Assign a virtual user license to your application instance. For details, see [Ph
 
 ### Assign a phone number to the application instance (only tenant admin)
 
-To assign the phone number to the application instance, the tenant addmin:
+To assign the phone number to the application instance, the tenant admin:
 
-1. Signs in to the Teams admin center as a tenant admin
+1. Signs in to the Teams admin center as a tenant admin.
 2. Goes to **Teams Admin center** > **Voice** > **Phone Numbers**.
 3. Assigns a service phone number (+11D format) using the following cmdlet.
 

--- a/concepts/cloud-communications-phone-number.md
+++ b/concepts/cloud-communications-phone-number.md
@@ -59,10 +59,9 @@ Assign a virtual user license to your application instance. For details, see [Ph
 
 To assign the phone number to the application instance, the tenant addmin:
 
-1. Signs in to the Skype for Business admin center as a tenant admin
-2. Goes to **Admin center** > **Teams and Skype** > **Skype legacy admin**.
-3. Goes to **Voice** > **Phone numbers**
-4. Assigns a service phone number (+11D format) using the following cmdlet.
+1. Signs in to the Teams admin center as a tenant admin
+2. Goes to **Teams Admin center** > **Voice** > **Phone Numbers**.
+3. Assigns a service phone number (+11D format) using the following cmdlet.
 
   `PS C:\> Set-CsOnlineVoiceApplicationInstance -Identity <user@contoso.com> -TelephoneNumber <phone_number>`
 


### PR DESCRIPTION
Update docs to reflect the fact that Teams Admin Center now has service number provisioning (remove reference to SFB).