### PR TITLE
mgt people-picker missing props

### DIFF
--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -29,6 +29,8 @@ By default, the `mgt-people-picker` component fetches people from the `/me/peopl
 | group-type     | groupType      | The group type to search for. Available options are: `unified`, `security`, `mailenabledsecurity`, `distribution`, `any`. Default value is `any`. This attribute has no effect if the `type` property is set to `person`.                                                                           |
 |  selected-people  | selectedPeople     | An array of selected people. Set this value to select people programmatically.|
 | people   | people    | An array of people found and rendered in the search result |
+| placeholder   | placeholder    | A string representing input placeholder text. Default is "Start typing a name".
+| selection-mode   | selectionMode   | A string value allows developer to specify whether the component supports multiple selected people or just one. Default is "multiple", "single" being the other option.
 
 The following is a `show-max` example.
 


### PR DESCRIPTION
adds documentation to `mgt-people-picker`

1. **placeholder** - allows modifications of placeholder text. Default is "Start typing a name"

2. **selection-mode** - allows developer to specify whether the component supports multiple selected people or just one.   Default is "multiple", "single" being the other option. 

missing reference per:
https://github.com/microsoftgraph/microsoft-graph-docs/issues/9523#event-3654409250