### PR TITLE
Rename instances of microsoft.graph.IdentityProvider to microsoft.graph.identityProvider

### DIFF
--- a/api-reference/beta/api/b2cuserflows-list-identityproviders.md
+++ b/api-reference/beta/api/b2cuserflows-list-identityproviders.md
@@ -75,7 +75,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.IdentityProvider"
+  "@odata.type": "microsoft.graph.identityProvider"
 } -->
 
 ```http

--- a/api-reference/beta/api/b2xuserflows-list-identityproviders.md
+++ b/api-reference/beta/api/b2xuserflows-list-identityproviders.md
@@ -75,7 +75,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.IdentityProvider"
+  "@odata.type": "microsoft.graph.identityProvider"
 } -->
 
 ```http

--- a/api-reference/beta/api/identityprovider-get.md
+++ b/api-reference/beta/api/identityprovider-get.md
@@ -91,7 +91,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.IdentityProvider"
+  "@odata.type": "microsoft.graph.identityProvider"
 } -->
 
 ```http

--- a/api-reference/beta/api/identityprovider-list.md
+++ b/api-reference/beta/api/identityprovider-list.md
@@ -92,7 +92,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.IdentityProvider",
+  "@odata.type": "microsoft.graph.identityProvider",
   "isCollection": true
 } -->
 

--- a/api-reference/beta/api/identityprovider-post-identityproviders.md
+++ b/api-reference/beta/api/identityprovider-post-identityproviders.md
@@ -128,7 +128,7 @@ The following is an example of the response.
 <!-- {
   "blockType": "response",
   "truncated": true,
-  "@odata.type": "microsoft.graph.IdentityProvider"
+  "@odata.type": "microsoft.graph.identityProvider"
 } -->
 
 ```http

--- a/api-reference/beta/resources/b2cuserflows.md
+++ b/api-reference/beta/resources/b2cuserflows.md
@@ -65,6 +65,6 @@ The following is a JSON representation of the resource.
     "id": "String (identifier)",
     "userFlowType": "String",
     "userFlowTypeVersion": "Single",
-    "identityProviders": [{"@odata.type": "microsoft.graph.IdentityProvider"}]
+    "identityProviders": [{"@odata.type": "microsoft.graph.identityProvider"}]
 }
 ```

--- a/api-reference/beta/resources/b2xuserflows.md
+++ b/api-reference/beta/resources/b2xuserflows.md
@@ -59,6 +59,6 @@ The following is a JSON representation of the resource.
     "id": "String (identifier)",
     "userFlowType": "String",
     "userFlowTypeVersion": "Single",
-    "identityProviders": [{"@odata.type": "microsoft.graph.IdentityProvider"}]
+    "identityProviders": [{"@odata.type": "microsoft.graph.identityProvider"}]
 }
 ```

--- a/api-reference/beta/resources/identityprovider.md
+++ b/api-reference/beta/resources/identityprovider.md
@@ -57,7 +57,7 @@ The following is a JSON representation of the resource.
 
 <!-- {
   "blockType": "resource",
-  "@odata.type": "microsoft.graph.IdentityProvider"
+  "@odata.type": "microsoft.graph.identityProvider"
 } -->
 
 ```json


### PR DESCRIPTION
I've renamed instances of microsoft.graph.IdentityProvider to microsoft.graph.identityProvider which is the correct way of naming entity types and also matches the metadata