### PR TITLE
Fix HTTP sample query "Projec}" to "Project"

### DIFF
--- a/api-reference/beta/api/driveitem-search.md
+++ b/api-reference/beta/api/driveitem-search.md
@@ -58,7 +58,7 @@ The following example searches for a match for "Contoso Project" across several 
 <!-- { "blockType": "request", "name": "item_search" }-->
 
 ```msgraph-interactive
-GET /me/drive/root/search(q='Contoso Projec}')
+GET /me/drive/root/search(q='Contoso Project')
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/item-search-csharp-snippets.md)]


### PR DESCRIPTION
Only appears on the beta doc.  Updating HTTP sample and should update snippets once backend processing completed.