### PR TITLE
Remove broken hyperlink

### DIFF
--- a/concepts/onenote-error-codes.md
+++ b/concepts/onenote-error-codes.md
@@ -328,7 +328,7 @@ The context does not specify a valid user ID. One common error is that PUID/CID 
 ### 20166
 The application has issued too many requests on behalf of a user in a short period of time. To help ensure that the OneNote API remains stable and responsive, the API returns a 429 status code and this error when it detects that an application is using too many resources. 
 
-For more information, see [Microsoft Graph service specific throttling guidance](https://docs.microsoft.com/en-us/graph/throttling#service-specific-limits).
+For more information, see [Microsoft Graph service-specific throttling guidance](/graph/throttling#service-specific-limits).
 
 ### 20168
 The video source specified in the request is not supported. See [Supported video sites](onenote-images-files.md#adding-videos) for the current list.

--- a/concepts/onenote-error-codes.md
+++ b/concepts/onenote-error-codes.md
@@ -328,7 +328,7 @@ The context does not specify a valid user ID. One common error is that PUID/CID 
 ### 20166
 The application has issued too many requests on behalf of a user in a short period of time. To help ensure that the OneNote API remains stable and responsive, the API returns a 429 status code and this error when it detects that an application is using too many resources. 
 
-For more information, see [OneNote API throttling and how to avoid it](https://blogs.msdn.com/b/onenotedev/archive/2016/01/13/onenote-api-throttling-and-best-practices.aspx).
+For more information, see [Microsoft Graph service specific throttling guidance](https://docs.microsoft.com/en-us/graph/throttling#service-specific-limits).
 
 ### 20168
 The video source specified in the request is not supported. See [Supported video sites](onenote-images-files.md#adding-videos) for the current list.


### PR DESCRIPTION
This pull request fixes issue #6737 

Replaces the broken link with a link to the Throttling Guidance that also includes OneNote specific guidance.