### PR TITLE
Add changelog json files validation..

### DIFF
--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -1,0 +1,14 @@
+name: Validate changelog JSONs
+
+on: [pull_request,push]
+
+jobs:
+  verify-json-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Validate JSON
+        uses: docker://orrosenblatt/validate-json-action:latest
+        env:
+          INPUT_SCHEMA: /changelog/Changelog.Schema.json
+          INPUT_JSONS: /changelog/Manual.NonWorkloadChanges.json,/changelog/Microsoft.AAD.Reporting.json,/changelog/Microsoft.Analytics.json,/changelog/Microsoft.Excel.json,/changelog/changelog.json,/changelog/Microsoft.DirectoryServices.json,/changelog/Microsoft.EducationAssignment.json,/changelog/Microsoft.Exchange.json,/changelog/Microsoft.FileServices.json,/changelog/Microsoft.Intune.json,/changelog/Microsoft.NAV.json,/changelog/Microsoft.Office.Tasks.json,/changelog/Microsoft.OneNote.json,/changelog/Microsoft.Search.json,/changelog/Microsoft.SharePoint.json,/changelog/Microsoft.Skype.Calling.json,/changelog/Microsoft.SubscriptionServices.json,/changelog/Microsoft.Teams.Core.json,/changelog/Microsoft.ThreatAssessment.json

--- a/changelog/Changelog.Schema.json
+++ b/changelog/Changelog.Schema.json
@@ -1,0 +1,3636 @@
+{
+  "type": "object",
+  "properties": {
+    "changelog": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "ChangeList": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Id": {
+                      "type": "string"
+                    },
+                    "ApiChange": {
+                      "type": "string"
+                    },
+                    "ChangedApiName": {
+                      "type": "string"
+                    },
+                    "ChangeType": {
+                      "type": "string"
+                    },
+                    "Description": {
+                      "type": "string"
+                    },
+                    "Target": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "Id",
+                    "ApiChange",
+                    "ChangedApiName",
+                    "ChangeType",
+                    "Description",
+                    "Target"
+                  ]
+                }
+              ]
+            },
+            "Id": {
+              "type": "string"
+            },
+            "Cloud": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "CreatedDateTime": {
+              "type": "string"
+            },
+            "WorkloadArea": {
+              "type": "string"
+            },
+            "SubArea": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "ChangeList",
+            "Id",
+            "Cloud",
+            "Version",
+            "CreatedDateTime",
+            "WorkloadArea",
+            "SubArea"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "changelog"
+  ]
+}

--- a/changelog/Manual.NonWorkloadChanges.json
+++ b/changelog/Manual.NonWorkloadChanges.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.AAD.Reporting.json
+++ b/changelog/Microsoft.AAD.Reporting.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.AAD.Reporting.json
+++ b/changelog/Microsoft.AAD.Reporting.json
@@ -1,5 +1,5 @@
 {
-  "Changelog": [
+  "changelog": [
     {
       "ChangeList": [
         {

--- a/changelog/Microsoft.AAD.Reporting.json
+++ b/changelog/Microsoft.AAD.Reporting.json
@@ -1,5 +1,5 @@
 {
-  "changelog": [
+  "Changelog": [
     {
       "ChangeList": [
         {

--- a/changelog/Microsoft.Analytics.json
+++ b/changelog/Microsoft.Analytics.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -16,7 +16,7 @@
           "ChangedApiName": "itemInsightsSettings",
           "ChangeType": "Addition",
           "Description": "Added the **itemInsightsSettings** entity and the following operations: ,  [Get itemInsightSettings](https://docs.microsoft.com/en-us/graph/api/iteminsightssettings-get?view=graph-rest-beta) ,  [Update itemInsightSettings](https://docs.microsoft.com/en-us/graph/api/iteminsightssettings-update?view=graph-rest-beta)",
-          "Target": "Get itemInsightSettings,Update itemInsightSettings"
+          "Target": "Get itemInsightSettings, Update itemInsightSettings"
         }
       ],
       "Id": "39cd76e7-31c8-41fd-84d0-e7a5502668fe",

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -40,7 +40,7 @@
           "ChangedApiName": "acquireAccessToken,synchronization",
           "ChangeType": "Addition",
           "Description": "Added the [acquireAccessToken](https://docs.microsoft.com/en-us/graph/api/synchronization-synchronization-acquireAccessToken?view=graph-rest-beta) method to the [synchronization](https://docs.microsoft.com/en-us/graph/api/resources/synchronization-synchronization?view=graph-rest-beta) resource",
-          "Target": "acquireAccessToken,synchronization"
+          "Target": "acquireAccessToken, synchronization"
         },
         {
           "Id": "4d0e93d9-7b06-4b52-91d9-9766a15d3615",
@@ -82,7 +82,7 @@
           "ChangedApiName": "getAvailableExtensionProperties,directoryObject",
           "ChangeType": "Addition",
           "Description": "Added the [getAvailableExtensionProperties](https://docs.microsoft.com/en-us/graph/api/directoryObject-getAvailableExtensionProperties?view=graph-rest-1.0) method to the [directoryObject](https://docs.microsoft.com/en-us/graph/api/resources/directoryObject?view=graph-rest-1.0) resource.",
-          "Target": "getAvailableExtensionProperties,directoryObject"
+          "Target": "getAvailableExtensionProperties, directoryObject"
         },
         {
           "Id": "4d0e93d9-7b06-4b52-91d9-9766a15d3615",

--- a/changelog/Microsoft.EducationAssignment.json
+++ b/changelog/Microsoft.EducationAssignment.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -39,7 +39,7 @@
         {
           "Id": "48e0620e-acee-47f6-b9b9-dbca1b922f40",
           "ApiChange": "Resource",
-          "ChangedApiName": "lms,educationExternalSource",
+          "ChangedApiName": "lms, educationExternalSource",
           "ChangeType": "Change",
           "Description": "Added **lms** to the list of possible values for **educationExternalSource**.",
           "Target": ""

--- a/changelog/Microsoft.Excel.json
+++ b/changelog/Microsoft.Excel.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -16,7 +16,7 @@
           "ChangedApiName": "Get workbookOperation,workbookOperation",
           "ChangeType": "Addition",
           "Description": "Added the  [Get workbookOperation](https://docs.microsoft.com/en-us/graph/api/workbookoperation-get) method to the [workbookOperation](https://docs.microsoft.com/en-us/graph/api/resources/workbookoperation?view=graph-rest-beta) entity",
-          "Target": "Get workbookOperation,workbookOperation"
+          "Target": "Get workbookOperation, workbookOperation."
         }
       ],
       "Id": "bba36a0a-f4c7-4e3a-a1cc-3510c632b7e2",

--- a/changelog/Microsoft.Exchange.json
+++ b/changelog/Microsoft.Exchange.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -24,7 +24,7 @@
           "ChangedApiName": "proposedNewTime,responseType",
           "ChangeType": "Addition",
           "Description": "Added the [eventMessageResponse](https://docs.microsoft.com/en-us/graph/api/resources/eventmessageresponse?view=graph-rest-1.0) entity that is based on [eventMessage](https://docs.microsoft.com/en-us/graph/api/resources/eventmessage?view=graph-rest-1.0), and in addition, includes the **proposedNewTime** and **responseType** properties.",
-          "Target": "eventMessageResponse,eventMessage"
+          "Target": "eventMessageResponse, eventMessage"
         },
         {
           "Id": "db75e287-7a99-46be-983e-90825180bf6e",

--- a/changelog/Microsoft.FileServices.json
+++ b/changelog/Microsoft.FileServices.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -48,7 +48,7 @@
           "ChangedApiName": "storagePlanInformation",
           "ChangeType": "Addition",
           "Description": "Added the [storagePlanInformation](https://docs.microsoft.com/en-us/graph/api/resources/storagePlanInformation?view=graph-rest-1.0) resource. The **storagePlanInformation** resource applies to the [quota](https://docs.microsoft.com/en-us/graph/api/resources/quota?view=graph-rest-1.0) resource.",
-          "Target": "storagePlanInformation,quota"
+          "Target": "storagePlanInformation, quota"
         },
         {
           "Id": "0d1e22ba-ddea-45b5-8aa4-7a5111e9a936",

--- a/changelog/Microsoft.Intune.json
+++ b/changelog/Microsoft.Intune.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [
@@ -24,7 +24,7 @@
           "ChangedApiName": "printTask,printTaskDefinition,printTaskStatus,printTaskTrigger",
           "ChangeType": "Addition",
           "Description": "Added the following resources to the Universal Print API: \u003Cul\u003E\u003Cli\u003E[printTask](https://docs.microsoft.com/en-us/graph/api/resources/printtask?view=graph-rest-beta)\u003C/li\u003E\u003Cli\u003E[printTaskDefinition](https://docs.microsoft.com/en-us/graph/api/resources/printtaskdefinition?view=graph-rest-beta)\u003C/li\u003E\u003Cli\u003E[printTaskStatus](https://docs.microsoft.com/en-us/graph/api/resources/printtaskstatus?view=graph-rest-beta)\u003C/li\u003E\u003Cli\u003E[printTaskTrigger](https://docs.microsoft.com/en-us/graph/api/resources/printtasktrigger?view=graph-rest-beta)\u003C/li\u003E\u003C/ul\u003E",
-          "Target": "printTask,printTaskDefinition,printTaskStatus,printTaskTrigger"
+          "Target": "printTask, printTaskDefinition, printTaskStatus, printTaskTrigger"
         },
         {
           "Id": "135e564d-8b5b-4af0-ad8e-0aea2a692996",

--- a/changelog/Microsoft.NAV.json
+++ b/changelog/Microsoft.NAV.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.Office.Tasks.json
+++ b/changelog/Microsoft.Office.Tasks.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.OneNote.json
+++ b/changelog/Microsoft.OneNote.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.Search.json
+++ b/changelog/Microsoft.Search.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.SharePoint.json
+++ b/changelog/Microsoft.SharePoint.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.Skype.Calling.json
+++ b/changelog/Microsoft.Skype.Calling.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.SubscriptionServices.json
+++ b/changelog/Microsoft.SubscriptionServices.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/Microsoft.ThreatAssessment.json
+++ b/changelog/Microsoft.ThreatAssessment.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "changelog": [
     {
       "ChangeList": [

--- a/changelog/changelog.json
+++ b/changelog/changelog.json
@@ -23,7 +23,7 @@
         {
           "Id": "2d94636a-2d78-44d6-8b08-ff2a9121214b",
           "ApiChange": "Resource",
-          "ChangedApiName": "schema extensions,Microsoft Cloud for US Government",
+          "ChangedApiName": "schema extensions,Microsoft Cloud for US Government.",
           "ChangeType": "Addition",
           "Description": "The [schema extensions](https://docs.microsoft.com/en-us/graph/api/resources/schemaextension) feature is now generally available in [Microsoft Cloud for US Government](https://docs.microsoft.com/en-us/graph/deployments).",
           "Target": "schema extensions,Microsoft Cloud for US Government"


### PR DESCRIPTION
This PR adds changelog json validations.

It uses [OrRosenblatt's validate-json-action](https://github.com/OrRosenblatt/validate-json-action) Github action. 

A json schema has been created against which changelog json files are being validated.

In addition this PR also fixes EOL file format issues that currently exist in the json files.