### PR TITLE
Update externalconnection-post-schema.md

### DIFF
--- a/api-reference/beta/api/externalconnection-post-schema.md
+++ b/api-reference/beta/api/externalconnection-post-schema.md
@@ -94,7 +94,6 @@ Prefer: respond-async
       "type": "String",
       "isQueryable": "true",
       "isRetrievable": "true",
-      "isRefinable": "true",
       "isSearchable": "false"
     },
     {


### PR DESCRIPTION
A property of 'String' datatype can't be marked as 'refinable' - doc bug pointed out by customer - updating the example