### PR TITLE
Graph API beta - trust framework - keyset - get active key request method from POST to GET

### DIFF
--- a/api-reference/beta/api/trustframeworkkeyset-getactivekey.md
+++ b/api-reference/beta/api/trustframeworkkeyset-getactivekey.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /trustFramework/keySets/{id}/getActiveKey
+GET /trustFramework/keySets/{id}/getActiveKey
 ```
 
 ## Request headers
@@ -61,7 +61,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/trustFramework/keySets/{id}/getActiveKey
+GET https://graph.microsoft.com/beta/trustFramework/keySets/{id}/getActiveKey
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/trustframeworkkeyset-getactivekey-csharp-snippets.md)]

--- a/api-reference/beta/includes/snippets/csharp/trustframeworkkeyset-getactivekey-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/trustframeworkkeyset-getactivekey-csharp-snippets.md
@@ -9,6 +9,6 @@ GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 await graphClient.TrustFramework.KeySets["{id}"]
 	.GetActiveKey()
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/beta/includes/snippets/javascript/trustframeworkkeyset-getactivekey-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/trustframeworkkeyset-getactivekey-javascript-snippets.md
@@ -12,6 +12,6 @@ const client = Client.init(options);
 
 let res = await client.api('/trustFramework/keySets/{id}/getActiveKey')
 	.version('beta')
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/objc/trustframeworkkeyset-getactivekey-objc-snippets.md
+++ b/api-reference/beta/includes/snippets/objc/trustframeworkkeyset-getactivekey-objc-snippets.md
@@ -8,7 +8,7 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/beta/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/trustFramework/keySets/{id}/getActiveKey"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {


### PR DESCRIPTION
See: [https://docs.microsoft.com/en-us/graph/api/trustframeworkkeyset-getactivekey](https://docs.microsoft.com/en-us/graph/api/trustframeworkkeyset-getactivekey)

If you attempt to POST to this endpoint, you get error 
```
VERBOSE: POST https://graph.microsoft.com/beta/trustframework/keySets/B2C_1A_TEST/getActiveKey with 0-byte payload
VERBOSE: received 577-byte response of content type application/json
{
  "error": {
    "code": "UnknownError",
    "message": "{\"message\":\"No HTTP resource was found that matches the request URI 'https://cpim.windows.net/graph/trustFramework/keySets('B2C_1A_TEST')/Microsoft.Cpim.Api.DataModels.getActiveKey'.\",\"messageDetail\":\"No action was found on the controller 'trustframework' that matches the request.\",\"stackTrace\":null}",
    "innerError": {
      "date": "2020-09-17T18:38:24",
      "request-id": "364c373b-8f32-4e36-a669-23fd3710d3bb",
      "client-request-id": "364c373b-8f32-4e36-a669-23fd3710d3bb"
    }
  }
}
```

Works with GET:
```
VERBOSE: GET https://graph.microsoft.com/beta/trustframework/keySets/B2C_1A_TEST/getActiveKey with 0-byte payload
VERBOSE: received 641-byte response of content type application/json
VERBOSE: Content encoding: utf-8
@{@odata.context=https://graph.microsoft.com/beta/$metadata#microsoft.graph.trustFrameworkKey; k=; x5c=System.Object[]; x.... **<redacted data goes here>**}
```