### PR TITLE
update permissions to match what service expects

### DIFF
--- a/api-reference/beta/api/directory-list-featurerolloutpolicies.md
+++ b/api-reference/beta/api/directory-list-featurerolloutpolicies.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.Read.All |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/directory-post-featurerolloutpolicies.md
+++ b/api-reference/beta/api/directory-post-featurerolloutpolicies.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.ReadWrite.FeatureRollout |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/featurerolloutpolicy-delete-appliesto.md
+++ b/api-reference/beta/api/featurerolloutpolicy-delete-appliesto.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.ReadWrite.FeatureRollout |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/featurerolloutpolicy-delete.md
+++ b/api-reference/beta/api/featurerolloutpolicy-delete.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.ReadWrite.FeatureRollout |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/featurerolloutpolicy-get.md
+++ b/api-reference/beta/api/featurerolloutpolicy-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.Read.All |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/featurerolloutpolicy-post-appliesto.md
+++ b/api-reference/beta/api/featurerolloutpolicy-post-appliesto.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.ReadWrite.FeatureRollout |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/featurerolloutpolicy-update.md
+++ b/api-reference/beta/api/featurerolloutpolicy-update.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Policy.ReadWrite.FeatureRollout |
+| Delegated (work or school account)     | Directory.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 


### PR DESCRIPTION
Dev from Hybrid Authentication service that owns these APIs here.

In our services implementation we expect Directory.ReadWrite.All. Based on git commit history we have never supported the permissions that the documentation here suggests that we should. This PR brings the documentation up to date with what our service expects.