### PR TITLE
Remove trailing "." from permissions in tables

### DIFF
--- a/api-reference/beta/api/conversationmember-update.md
+++ b/api-reference/beta/api/conversationmember-update.md
@@ -26,9 +26,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission Type|Permissions (from least to most privileged)|
 |---------|-------------|
-|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All. In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All. |
+|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All. In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 |Delegated (personal Microsoft account)|Not supported|
-|Application| In teams: TeamMember.ReadWrite.All. In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All. |
+|Application| In teams: TeamMember.ReadWrite.All. In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored"} -->

--- a/api-reference/beta/api/conversationmember-update.md
+++ b/api-reference/beta/api/conversationmember-update.md
@@ -26,9 +26,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission Type|Permissions (from least to most privileged)|
 |---------|-------------|
-|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All. In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
+|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 |Delegated (personal Microsoft account)|Not supported|
-|Application| In teams: TeamMember.ReadWrite.All. In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
+|Application| In teams: TeamMember.ReadWrite.All In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored"} -->

--- a/api-reference/beta/api/conversationmember-update.md
+++ b/api-reference/beta/api/conversationmember-update.md
@@ -26,9 +26,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission Type|Permissions (from least to most privileged)|
 |---------|-------------|
-|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
+|Delegated (work or school account)| In teams: TeamMember.ReadWrite.All<br/>In channels: ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 |Delegated (personal Microsoft account)|Not supported|
-|Application| In teams: TeamMember.ReadWrite.All In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
+|Application| In teams: TeamMember.ReadWrite.All<br/>In channels:  ChannelMember.ReadWrite.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 
 ## HTTP request
 <!-- { "blockType": "ignored"} -->

--- a/api-reference/beta/api/informationprotection-list-threatassessmentrequests.md
+++ b/api-reference/beta/api/informationprotection-list-threatassessmentrequests.md
@@ -28,9 +28,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All             |
 | Delegated (personal Microsoft account) | Not supported.                              |
-| Application                            | ThreatAssessment.Read.All.                  |
+| Application                            | ThreatAssessment.Read.All                  |
 
 ## HTTP request
 

--- a/api-reference/beta/api/informationprotection-post-threatassessmentrequests.md
+++ b/api-reference/beta/api/informationprotection-post-threatassessmentrequests.md
@@ -28,7 +28,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All              |
 | Delegated (personal Microsoft account) | Not supported.                              |
 | Application                            | Not supported.                              |
 

--- a/api-reference/beta/api/place-update.md
+++ b/api-reference/beta/api/place-update.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Place.ReadWrite.All. |
+| Delegated (work or school account)     | Place.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported |
 

--- a/api-reference/beta/api/securescorecontrolprofiles-list.md
+++ b/api-reference/beta/api/securescorecontrolprofiles-list.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All.   |
+|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All   |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/beta/api/securescorecontrolprofiles-update.md
+++ b/api-reference/beta/api/securescorecontrolprofiles-update.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |   SecurityEvents.ReadWrite.All.  |
+|Delegated (work or school account) |   SecurityEvents.ReadWrite.All  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/beta/api/securescores-list.md
+++ b/api-reference/beta/api/securescores-list.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All.   |
+|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All   |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/beta/api/threatassessmentrequest-get.md
+++ b/api-reference/beta/api/threatassessmentrequest-get.md
@@ -28,9 +28,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All             |
 | Delegated (personal Microsoft account) | Not supported.                              |
-| Application                            | ThreatAssessment.Read.All.                  |
+| Application                            | ThreatAssessment.Read.All                  |
 
 ## HTTP request
 

--- a/api-reference/beta/api/trustframeworkkeyset-getactivekey.md
+++ b/api-reference/beta/api/trustframeworkkeyset-getactivekey.md
@@ -22,9 +22,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | TrustFrameworkKeySet.Read.All, TrustFrameworkKeySet.ReadWrite.All. |
+| Delegated (work or school account)     | TrustFrameworkKeySet.Read.All, TrustFrameworkKeySet.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | TrustFrameworkKeySet.Read.All, TrustFrameworkKeySet.ReadWrite.All. |
+| Application                            | TrustFrameworkKeySet.Read.All, TrustFrameworkKeySet.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/group-checkmembergroups.md
+++ b/api-reference/v1.0/api/group-checkmembergroups.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :------------------------------------------------------------------------------------------ |
 | Delegated (work or school account)     | GroupMember.Read.All, Group.Read.All, Directory.Read.All, Directory.ReadWrite.All, Directory.AccessAsUser.All |
 | Delegated (personal Microsoft account) | Not supported.                                                                              |
-| Application                            | GroupMember.Read.All, Group.Read.All, Directory.Read.All. Directory.ReadWrite.All                               |
+| Application                            | GroupMember.Read.All, Group.Read.All, Directory.Read.All, Directory.ReadWrite.All                               |
 
 
 

--- a/api-reference/v1.0/api/informationprotection-list-threatassessmentrequests.md
+++ b/api-reference/v1.0/api/informationprotection-list-threatassessmentrequests.md
@@ -24,9 +24,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All             |
 | Delegated (personal Microsoft account) | Not supported.                              |
-| Application                            | ThreatAssessment.Read.All.                  |
+| Application                            | ThreatAssessment.Read.All                  |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/informationprotection-post-threatassessmentrequests.md
+++ b/api-reference/v1.0/api/informationprotection-post-threatassessmentrequests.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All             |
 | Delegated (personal Microsoft account) | Not supported.                              |
 | Application                            | Not supported.                              |
 

--- a/api-reference/v1.0/api/place-update.md
+++ b/api-reference/v1.0/api/place-update.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | Place.ReadWrite.All. |
+| Delegated (work or school account)     | Place.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported |
 

--- a/api-reference/v1.0/api/securescorecontrolprofile-update.md
+++ b/api-reference/v1.0/api/securescorecontrolprofile-update.md
@@ -19,9 +19,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |   SecurityEvents.ReadWrite.All.  |
+|Delegated (work or school account) |   SecurityEvents.ReadWrite.All  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/security-list-securescorecontrolprofiles.md
+++ b/api-reference/v1.0/api/security-list-securescorecontrolprofiles.md
@@ -19,9 +19,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All.   |
+|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All   |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/security-list-securescores.md
+++ b/api-reference/v1.0/api/security-list-securescores.md
@@ -19,9 +19,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All.   |
+|Delegated (work or school account) |  SecurityEvents.Read.All, SecurityEvents.ReadWrite.All   |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All. |
+|Application | SecurityEvents.Read.All, SecurityEvents.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/threatassessmentrequest-get.md
+++ b/api-reference/v1.0/api/threatassessmentrequest-get.md
@@ -24,9 +24,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:--------------------------------------------|
-| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All.             |
+| Delegated (work or school account)     | ThreatAssessment.ReadWrite.All             |
 | Delegated (personal Microsoft account) | Not supported.                              |
-| Application                            | ThreatAssessment.Read.All.                  |
+| Application                            | ThreatAssessment.Read.All                  |
 
 ## HTTP request
 


### PR DESCRIPTION
Remove ~30 trailing periods from permission names in reference tables. They're inconsistent and interfere with docs parsing.