### PR TITLE
Update listitem-get.md

### DIFF
--- a/api-reference/beta/api/listitem-get.md
+++ b/api-reference/beta/api/listitem-get.md
@@ -28,7 +28,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Sites.Read.All, Sites.ReadWrite.All, Sites.Manage.All |
 
-> **Note**: The application permission _Sites.Manage.All_ will be required if the SharePoint list has content approval settings turned on. Otherwise, Graph won't retrieve those list items that have an approval status other than Approved.
+> **Note**: The application permission Sites.Manage.All is required if the SharePoint list has content approval settings turned on. Otherwise, Microsoft Graph won't retrieve list items that have an approval status other than Approved.
 
 ## HTTP request
 

--- a/api-reference/beta/api/listitem-get.md
+++ b/api-reference/beta/api/listitem-get.md
@@ -24,9 +24,11 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Sites.Read.All, Sites.ReadWrite.All    |
+|Delegated (work or school account) | Sites.Read.All, Sites.ReadWrite.All |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Sites.Read.All, Sites.ReadWrite.All |
+|Application | Sites.Read.All, Sites.ReadWrite.All, Sites.Manage.All |
+
+> **Note**: The application permission _Sites.Manage.All_ will be required if the SharePoint list has content approval settings turned on. Otherwise, Graph won't retrieve those list items that have an approval status other than Approved.
 
 ## HTTP request
 


### PR DESCRIPTION
Added a new application permission "Sites.Manage.All" that is required if the SharePoint list has content approval settings turned on. Otherwise, Graph won't retrieve those list items that have an approval status other than Approved. This permission won't be required if list items are retrieved using delegated permissions! I've also written a [blog post](https://www.devjhorst.com/2020/09/quick-tip-avoid-limitations-when.html) about this topic that might be useful during the review process since it contains more information about this issue!