### PR TITLE
Fix typos in permissions names for the setDeviceName action

### DIFF
--- a/api-reference/beta/api/intune-devices-manageddevice-setdevicename.md
+++ b/api-reference/beta/api/intune-devices-manageddevice-setdevicename.md
@@ -22,9 +22,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from most to least privileged)|
 |:---|:---|
-|Delegated (work or school account)|DeviceManagementManagedDevices.PriviligedOperation.All|
+|Delegated (work or school account)|DeviceManagementManagedDevices.PrivilegedOperation.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|DeviceManagementManagedDevices.PriviligedOperation.All|
+|Application|DeviceManagementManagedDevices.PrivilegedOperation.All|
 
 ## HTTP Request
 <!-- {

--- a/api-reference/beta/api/intune-devices-manageddevice-setdevicename.md
+++ b/api-reference/beta/api/intune-devices-manageddevice-setdevicename.md
@@ -22,9 +22,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from most to least privileged)|
 |:---|:---|
-|Delegated (work or school account)|DeviceManagementManagedDevices.PrivilegedOperation.All|
+|Delegated (work or school account)|DeviceManagementManagedDevices.PrivilegedOperations.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|DeviceManagementManagedDevices.PrivilegedOperation.All|
+|Application|DeviceManagementManagedDevices.PrivilegedOperations.All|
 
 ## HTTP Request
 <!-- {


### PR DESCRIPTION
There are typos in the permissions names.

DeviceManagementManagedDevices.PriviligedOperation.All
should be
DeviceManagementManagedDevices.Privil***e***gedOperation***s***.All

note the E in Privil***E***ged and the S in Operation***S***