### PR TITLE
Update group-delete-members.md (Issue 10247)

### DIFF
--- a/api-reference/v1.0/api/group-delete-members.md
+++ b/api-reference/v1.0/api/group-delete-members.md
@@ -49,7 +49,7 @@ The following is an example of the request.
   "name": "delete_member_from_group"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/{group-id}/members/{directory-object-id}/$ref
+DELETE https://graph.microsoft.com/v1.0/groups/{group-id}/members/{directory-object-id}/$ref
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-member-from-group-csharp-snippets.md)]


### PR DESCRIPTION
Hi, 

I found a small mistake in the HTTP example in this article.
The `/groups/` part is missing from the URL.

**Current content:**
```
DELETE https://graph.microsoft.com/v1.0/{group-id}/members/{directory-object-id}/$ref
```

**Expected content:**
```
DELETE https://graph.microsoft.com/v1.0/groups/{group-id}/members/{directory-object-id}/$ref
```

Issue:
[/groups/ missing in HTTP example of Remove member](https://github.com/microsoftgraph/microsoft-graph-docs/issues/10247)