### PR TITLE
Update Directory Audit $filter Example to Reflect Valid Attribute

### DIFF
--- a/api-reference/beta/api/directoryaudit-list.md
+++ b/api-reference/beta/api/directoryaudit-list.md
@@ -40,7 +40,7 @@ This method supports the following OData query parameters to help customize the 
 
 |Parameter     |Description                            |Example|
 |:--------------------|----------------|------------------------------------------------------------------------|
-|[$filter](/graph/query-parameters#filter-parameter)|Filters results (rows). |`/auditLogs/directoryAudits?$filter=createdDateTime le 2018-01-24`<br>`/auditLogs/directoryAudits?$filter=targetResources/any(x: startswith(x/displayName, 'def'))` |
+|[$filter](/graph/query-parameters#filter-parameter)|Filters results (rows). |`/auditLogs/directoryAudits?$filter=activityDateTime le 2018-01-24`<br>`/auditLogs/directoryAudits?$filter=targetResources/any(x: startswith(x/displayName, 'def'))` |
 |[$top](/graph/query-parameters#top-parameter)|Sets the page size of results.|`/auditLogs/directoryAudits?$top=1`|
 |[$skiptoken](/graph/query-parameters#skiptoken-parameter)|Retrieves the next page of results from result sets that span multiple pages.|`/auditLogs/directoryAudits?$skiptoken=01fa0e77c60c2d3d63226c8e3294c860__1`|
 

--- a/api-reference/v1.0/api/directoryaudit-list.md
+++ b/api-reference/v1.0/api/directoryaudit-list.md
@@ -37,7 +37,7 @@ This method supports the following OData query parameters to help customize the 
 
 | Parameter                                                       | Description                                                                   | Example                                                                     |
 | :--------------------------------------------------------- | :---------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
-| [\$filter](/graph/query_parameters#filter-parameter)       | Filters results (rows).                                                       | `/auditLogs/directoryAudits?&$filter=createdDateTime le 2018-01-24`         |
+| [\$filter](/graph/query_parameters#filter-parameter)       | Filters results (rows).                                                       | `/auditLogs/directoryAudits?&$filter=activityDateTime le 2018-01-24`         |
 | [\$top](/graph/query_parameters#top-parameter)             | Sets the page size of results.                                                | `/auditLogs/directoryAudits?$top=1`                                         |
 | [\$skiptoken](/graph/query_parameters#skiptoken-parameter) | Retrieves the next page of results from result sets that span multiple pages. | `/auditLogs/directoryAudits?$skiptoken=01fa0e77c60c2d3d63226c8e3294c860__1` |
 


### PR DESCRIPTION
The filter example is using an attribute that doesn't exists in the directory audit logs. `createdDateTime` exists in the sign-in logs, but the equivalent in the directory audit logs is `activityDateTime`