### PR TITLE
Add a Github Action to create PRs for generated snippets

### DIFF
--- a/.github/workflows/snippet-generation-pr.yml
+++ b/.github/workflows/snippet-generation-pr.yml
@@ -1,0 +1,39 @@
+# This action will automatically create a pull request against master if the pushed branch
+# has a branch path spec like snippet-generation/*.
+
+name: "Snippet Generation Pull Request"
+
+# Controls when the action will run. Triggers the workflow on push
+# events but only for branches with the following branch spec: "snippet-generation/*"
+on:
+  push:
+    branches:
+      - "snippet-generation/*"
+
+jobs:
+  create-pull-request:
+    # GitHub Actions don't support skip ci yet like Azure Pipelines so this check will do the same. 
+    if: github.event_name == 'push' && !contains(toJson(github.event.commits), 'NO_CI') && !contains(toJson(github.event.commits), '[ci skip]') && !contains(toJson(github.event.commits), '[skip ci]')
+
+    runs-on: ubuntu-latest # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
+
+    steps:
+    - uses: actions/checkout@v2
+
+    # Create a pull request [0]
+    - name: Create PR using the GitHub REST API via hub
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MESSAGE_TITLE: "Snippets Update"
+        MESSAGE_BODY: "Scheduled snippets update"
+        REVIEWERS: andrueastman
+        ASSIGNEDTO: andrueastman
+        BASE: master
+      run: |
+        curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -a "$ASSIGNEDTO"
+
+# References
+# [0] https://hub.github.com/hub-pull-request.1.html
+# https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token


### PR DESCRIPTION
Automatically creates a pull request once snippet generation pipeline finishes.

It limits the check by the branch naming: `snippet-generation/*`. The same pattern exists in the snippet generation pipeline. The PR that introduces the new generation pipeline can be found here:
https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/339

The action follows the same template as our Github Actions for the SDK PRs, e.g. https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/.github/workflows/create-v1.0-pull-request.yml

Related work items:
[AB#6093](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/6093)
[AB#6094](https://microsoftgraph.visualstudio.com/0985d294-5762-4bc2-a565-161ef349ca3e/_workitems/edit/6094)