### PR TITLE
Update teamstab.md

### DIFF
--- a/api-reference/beta/resources/teamstab.md
+++ b/api-reference/beta/resources/teamstab.md
@@ -33,7 +33,7 @@ A teamsTab is a [tab](../resources/teamstab.md) that's pinned (attached) to a [c
 |  id              |   string                  |  Identifier that uniquely identifies a specific instance of a channel tab. Read only.     |
 |  displayName            |   string                  |  Name of the tab.     |
 |  name            |   string                  |  (Deprecated) Name of the tab.     |
-|  teamsAppId           |   string             |  App definition identifier of the tab. This value cannot be changed after tab creation.     |
+|  teamsAppId           |   string             |  (Deprecated) App definition identifier of the tab. This value cannot be changed after tab creation. Since this property is deprecated, consider expanding teamsApp to retrieve the application that is linked to the tab. |
 |  sortOrderIndex  |   string                  |  Index of the order used for sorting tabs.     |
 |  webUrl          |   string                  |  Deep link URL of the tab instance. Read only.     |
 |  configuration        |   [teamsTabConfiguration](teamstabconfiguration.md) |  Container for custom settings applied to a tab. The tab is considered configured only once this property is set.     |

--- a/api-reference/beta/resources/teamstab.md
+++ b/api-reference/beta/resources/teamstab.md
@@ -32,8 +32,8 @@ A teamsTab is a [tab](../resources/teamstab.md) that's pinned (attached) to a [c
 |:---------------|:--------|:----------|
 |  id              |   string                  |  Identifier that uniquely identifies a specific instance of a channel tab. Read only.     |
 |  displayName            |   string                  |  Name of the tab.     |
-|  name            |   string                  |  (Deprecated) Name of the tab.     |
-|  teamsAppId           |   string             |  (Deprecated) App definition identifier of the tab. This value cannot be changed after tab creation. Since this property is deprecated, consider expanding teamsApp to retrieve the application that is linked to the tab. |
+|  name (deprecated)      |   string                  |  Name of the tab.     |
+|  teamsAppId (deprecated)|   string             |  App definition identifier of the tab. This value cannot be changed after tab creation. Since this property is deprecated, consider expanding teamsApp to retrieve the application that is linked to the tab. |
 |  sortOrderIndex  |   string                  |  Index of the order used for sorting tabs.     |
 |  webUrl          |   string                  |  Deep link URL of the tab instance. Read only.     |
 |  configuration        |   [teamsTabConfiguration](teamstabconfiguration.md) |  Container for custom settings applied to a tab. The tab is considered configured only once this property is set.     |

--- a/api-reference/beta/resources/teamstab.md
+++ b/api-reference/beta/resources/teamstab.md
@@ -33,7 +33,7 @@ A teamsTab is a [tab](../resources/teamstab.md) that's pinned (attached) to a [c
 |  id              |   string                  |  Identifier that uniquely identifies a specific instance of a channel tab. Read only.     |
 |  displayName            |   string                  |  Name of the tab.     |
 |  name (deprecated)      |   string                  |  Name of the tab.     |
-|  teamsAppId (deprecated)|   string             |  App definition identifier of the tab. This value cannot be changed after tab creation. Since this property is deprecated, consider expanding teamsApp to retrieve the application that is linked to the tab. |
+|  teamsAppId (deprecated)|   string             |  App definition identifier of the tab. This value cannot be changed after tab creation. Because this property is deprecated, we recommend expanding **teamsApp** to retrieve the application that is linked to the tab. |
 |  sortOrderIndex  |   string                  |  Index of the order used for sorting tabs.     |
 |  webUrl          |   string                  |  Deep link URL of the tab instance. Read only.     |
 |  configuration        |   [teamsTabConfiguration](teamstabconfiguration.md) |  Container for custom settings applied to a tab. The tab is considered configured only once this property is set.     |


### PR DESCRIPTION
The Graph API /teams/{id}/channels/{id}/tabs started to return the teamsAppId with a value of null. Previously, it was possible to get the Teams App ID such as http://com.microsoft.teamspace.tab.wiki/ as part of the response. Since this property is deprecated, it might be helpful to provide developers with some guidance about the new approach.