### PR TITLE
fix: Invalid trailing comma in JSON

### DIFF
--- a/api-reference/beta/resources/printdocument.md
+++ b/api-reference/beta/resources/printdocument.md
@@ -57,7 +57,7 @@ The following is a JSON representation of the resource.
     "orientation": "String",
     "duplexConfiguration": "String",
     "copies": 123456,
-    "colorConfiguration": "String",
+    "colorConfiguration": "String"
   }
 }
 


### PR DESCRIPTION
JSON representation of the resource had a trailing comma causing an invalid JSON error when copied directly from docs.