### PR TITLE
Update team-post.md Application Permissions example

### DIFF
--- a/api-reference/v1.0/api/team-post.md
+++ b/api-reference/v1.0/api/team-post.md
@@ -121,17 +121,17 @@ POST https://graph.microsoft.com/v1.0/teams
 Content-Type: application/json
 
 {
-   "template@odata.bind":"https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
-   "displayName":"My Sample Team",
-   "description":"My Sample Team’s Description",
-   "members@odata.bind":[
-      {
-         "@odata.type":"#microsoft.graph.aadUserConversationMember",
-         "roles":[
-            "owner"
-         ],
-         "userId":"0040b377-61d8-43db-94f5-81374122dc7e"
-      }
+   "template@odata.bind": "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
+   "displayName": "My Sample Team",
+   "description": "My Sample Team’s Description",
+   "members": [
+       {
+           "@odata.type": "#microsoft.graph.aadUserConversationMember",
+           "roles": [
+               "owner"
+           ],
+           "userId": "0040b377-61d8-43db-94f5-81374122dc7e"
+       }
    ]
 }
 ```


### PR DESCRIPTION
The Application Permissions example (#2) is incorrect. I am proposing the change to one of the two working samples (changed line 127). There is another working sample:
{
    "template@odata.bind": "https://graph.microsoft.com/v1.0/teamsTemplates('standard')",
    "displayName": "My Sample Team",
    "description": "My Sample Team’s Description",
    "members": [
        {
            "@odata.type": "#microsoft.graph.aadUserConversationMember",
            "roles": [
                "owner"
            ],
            "user@odata.bind": "https://graph.microsoft.com/v1.0/users('userId')"
        }
    ]
}