### PR TITLE
Fix typo "use" -> "user"

### DIFF
--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -104,7 +104,7 @@ GET https://graph.microsoft.com/v1.0/me/photo/$value
 ##### Response
 Contains the binary data of the requested photo. The HTTP response code is 200.
 
-### Example 2: Get the 48x48 photo for the signed-in use
+### Example 2: Get the 48x48 photo for the signed-in user
 ##### Request
 <!-- {
   "blockType": "ignored"


### PR DESCRIPTION
Get photo fix:
"Example 2: Get the 48x48 photo for the signed-in use"
To:
"Example 2: Get the 48x48 photo for the signed-in user"