### PR TITLE
Data Sync: File name case warning

### DIFF
--- a/api-reference/beta/api/educationsynchronizationprofile-uploadurl.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-uploadurl.md
@@ -18,7 +18,8 @@ Retrieve a shared access signature (SAS) for uploading source files to Azure blo
 
 The upload URL is provided only for the [CSV data provider](../resources/educationcsvdataprovider.md).
 
-> [!WARNING]: All uploaded file names and extensions must be lower-cased (e.g. `student.csv` not `Student.csv`). Blobs are case-sensitive, and using mixed-cased file names will result in validation errors and synchronization failure.. 
+> [!WARNING]
+> All uploaded file names and extensions must be lowercase (for example, `student.csv` not `Student.csv`). Blobs are case-sensitive, and using mixed-cased file names will result in validation errors and synchronization failure.. 
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/educationsynchronizationprofile-uploadurl.md
+++ b/api-reference/beta/api/educationsynchronizationprofile-uploadurl.md
@@ -13,11 +13,12 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve a shared access signature (SAS) for uploading source files to Azure blob storage for a specific school data [synchronization profile](../resources/educationsynchronizationprofile.md) in the tenant. The SAS token has a validity of one hour.
+Retrieve a shared access signature (SAS) for uploading source files to Azure blob storage for a specific school data [synchronization profile](../resources/educationsynchronizationprofile.md) in the tenant. The SAS token has a validity of one hour. To access the blob storage with the SAS token, use the [Azure storage SDKs](https://github.com/search?q=org%3AAzure+azure-storage) or [AzCopy](/azure/storage/storage-use-azcopy).
+
 
 The upload URL is provided only for the [CSV data provider](../resources/educationcsvdataprovider.md).
 
-> **Note:** To access the blob storage with the SAS token, use the [Azure storage SDKs](https://github.com/search?q=org%3AAzure+azure-storage) or [AzCopy](/azure/storage/storage-use-azcopy).
+> [!WARNING]: All uploaded file names and extensions must be lower-cased (e.g. `student.csv` not `Student.csv`). Blobs are case-sensitive, and using mixed-cased file names will result in validation errors and synchronization failure.. 
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).


### PR DESCRIPTION
Adds warning that School Data Sync requires uploaded files to have lower-cased file names.