### PR TITLE
Add note on filtering on the `identities` property in Beta docs from 1.0 docs

### DIFF
--- a/api-reference/beta/resources/objectidentity.md
+++ b/api-reference/beta/resources/objectidentity.md
@@ -25,6 +25,8 @@ The **identities** property of the [user](user.md) resource is an **objectIdenti
 |issuer|string|Specifies the issuer of the identity, for example `facebook.com`.<br>For local accounts (where **signInType** is not `federated`), this property is the local B2C tenant default domain name, for example `contoso.onmicrosoft.com`.<br>For external users from other Azure AD organization, this will be the domain of the federated organization, for example `contoso.com`.<br><br>Supports `$filter`. 512 character limit.|
 |issuerAssignedId|string|Specifies the unique identifier assigned to the user by the issuer. The combination of **issuer** and **issuerAssignedId** must be unique within the organization. Represents the sign-in name for the user, when **signInType** is set to `emailAddress` or `userName` (also known as local accounts).<br>When **signInType** is set to: <ul><li>`emailAddress`, (or starts with `emailAddress` like `emailAddress1`) **issuerAssignedId** must be a valid email address</li><li>`userName`, **issuerAssignedId** must be a valid [local part of an email address](https://tools.ietf.org/html/rfc3696#section-3)</li></ul>Supports `$filter`. 512 character limit.|
 
+>**Note:** When filtering on the **identities** property, you must supply both **issuer** and **issuerAssignedId**.
+
 ## JSON representation
 
 The following is a JSON representation of the resource.


### PR DESCRIPTION
This is just a copy of what was added in the `1.0` docs with this PR - https://github.com/microsoftgraph/microsoft-graph-docs/pull/7917 based on this issue https://github.com/microsoftgraph/microsoft-graph-docs/issues/7282

I just wanted to make sure this important note propagates to the Beta docs as I got stuck on it reading the Beta docs, when the note clearly exists in the 1.0 docs.