### PR TITLE
Camel case fixes for compilable snippets

### DIFF
--- a/api-reference/beta/api/administrativeunit-delta.md
+++ b/api-reference/beta/api/administrativeunit-delta.md
@@ -89,7 +89,7 @@ For details and an example, see [Using delta query](/graph/delta-query-overview)
   "name": "administrativeunit_delta"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/administrativeunits/delta
+GET https://graph.microsoft.com/beta/administrativeUnits/delta
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/administrativeunit-delta-csharp-snippets.md)]

--- a/api-reference/beta/api/directoryrole-delete-member.md
+++ b/api-reference/beta/api/directoryrole-delete-member.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-DELETE /directoryroles/{id}/members/{id}/$ref
+DELETE /directoryRoles/{id}/members/{id}/$ref
 ```
 
 ## Request headers
@@ -61,7 +61,7 @@ Here is an example of the request.
 }-->
 
 ```http
-DELETE https://graph.microsoft.com/beta/directoryroles/{id}/members/{id}/$ref
+DELETE https://graph.microsoft.com/beta/directoryRoles/{id}/members/{id}/$ref
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-directoryobject-from-directoryrole-csharp-snippets.md)]

--- a/api-reference/beta/api/informationprotectionlabel-evaluateapplication.md
+++ b/api-reference/beta/api/informationprotectionlabel-evaluateapplication.md
@@ -48,7 +48,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST me/informationprotection/policy/labels/evaluateApplication
+POST me/informationProtection/policy/labels/evaluateApplication
 POST /users/{id}/informationProtection/policy/labels/evaluateApplication
 ```
 
@@ -88,7 +88,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/informationprotection/policy/labels/evaluateApplication
+POST https://graph.microsoft.com/beta/informationProtection/policy/labels/evaluateApplication
 Content-type: application/json
 User-agent: ContosoLOBApp/1.0
 

--- a/api-reference/beta/api/informationprotectionlabel-evaluateclassificationresults.md
+++ b/api-reference/beta/api/informationprotectionlabel-evaluateclassificationresults.md
@@ -48,7 +48,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /informationprotection/policy/labels/{id}/evaluateClassificationResults
+POST /informationProtection/policy/labels/{id}/evaluateClassificationResults
 ```
 
 ## Request headers
@@ -87,7 +87,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/informationprotection/policy/labels/evaluateClassificationResults
+POST https://graph.microsoft.com/beta/informationProtection/policy/labels/evaluateClassificationResults
 Content-type: application/json
 User-agent: ContosoLOBApp/1.0
 

--- a/api-reference/beta/api/informationprotectionlabel-evaluateremoval.md
+++ b/api-reference/beta/api/informationprotectionlabel-evaluateremoval.md
@@ -39,7 +39,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-POST /informationprotection/policy/labels/evaluateRemoval
+POST /informationProtection/policy/labels/evaluateRemoval
 ```
 
 ## Request headers
@@ -79,7 +79,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/informationprotection/policy/labels/evaluateRemoval
+POST https://graph.microsoft.com/beta/informationProtection/policy/labels/evaluateRemoval
 Content-type: application/json
 User-agent: ContosoLOBApp/1.0
 

--- a/api-reference/beta/api/informationprotectionlabel-extractlabel.md
+++ b/api-reference/beta/api/informationprotectionlabel-extractlabel.md
@@ -71,7 +71,7 @@ The following is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/informationprotection/policy/labels/extractLabel
+POST https://graph.microsoft.com/beta/informationProtection/policy/labels/extractLabel
 Content-type: application/json
 User-agent: ContosoLOBApp/1.0
 

--- a/api-reference/beta/api/oauth2permissiongrant-delta.md
+++ b/api-reference/beta/api/oauth2permissiongrant-delta.md
@@ -32,7 +32,7 @@ To begin tracking changes, you make a request including the delta function on th
 
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /oauth2permissionGrants/delta
+GET /oauth2PermissionGrants/delta
 ```
 
 ## Query parameters
@@ -85,7 +85,7 @@ For details, see [Using delta query](/graph/delta-query-overview). For example r
   "name": "oauth2permissiongrant_delta"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/oauth2permissionGrants/delta
+GET https://graph.microsoft.com/beta/oauth2PermissionGrants/delta
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/oauth2permissiongrant-delta-csharp-snippets.md)]

--- a/api-reference/beta/api/oauth2permissiongrant-delta.md
+++ b/api-reference/beta/api/oauth2permissiongrant-delta.md
@@ -32,7 +32,7 @@ To begin tracking changes, you make a request including the delta function on th
 
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /oauth2permissiongrants/delta
+GET /oauth2permissionGrants/delta
 ```
 
 ## Query parameters
@@ -85,7 +85,7 @@ For details, see [Using delta query](/graph/delta-query-overview). For example r
   "name": "oauth2permissiongrant_delta"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/oauth2permissiongrants/delta
+GET https://graph.microsoft.com/beta/oauth2permissionGrants/delta
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/oauth2permissiongrant-delta-csharp-snippets.md)]

--- a/api-reference/beta/api/place-update.md
+++ b/api-reference/beta/api/place-update.md
@@ -181,7 +181,7 @@ PATCH https://graph.microsoft.com/beta/places/Building1RroomList@contoso.onmicro
 Content-type: application/json
 
 {
-  "@odata.type": "microsoft.graph.roomlist",
+  "@odata.type": "microsoft.graph.roomList",
   "displayName": "Building 1",
   "phone":"555-555-0100",
   "address": {

--- a/api-reference/v1.0/api/oauth2permissiongrant-delta.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-delta.md
@@ -29,7 +29,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /oauth2permissiongrants/delta
+GET /oauth2permissionGrants/delta
 ```
 
 ## Query parameters
@@ -81,7 +81,7 @@ For details, see [Using delta query](/graph/delta-query-overview). For example r
   "name": "oauth2permissiongrant_delta"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/oauth2permissiongrants/delta
+GET https://graph.microsoft.com/v1.0/oauth2permissionGrants/delta
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/oauth2permissiongrant-delta-csharp-snippets.md)]

--- a/api-reference/v1.0/api/oauth2permissiongrant-delta.md
+++ b/api-reference/v1.0/api/oauth2permissiongrant-delta.md
@@ -29,7 +29,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /oauth2permissionGrants/delta
+GET /oauth2PermissionGrants/delta
 ```
 
 ## Query parameters
@@ -81,7 +81,7 @@ For details, see [Using delta query](/graph/delta-query-overview). For example r
   "name": "oauth2permissiongrant_delta"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/oauth2permissionGrants/delta
+GET https://graph.microsoft.com/v1.0/oauth2PermissionGrants/delta
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/oauth2permissiongrant-delta-csharp-snippets.md)]


### PR DESCRIPTION
Wrong casing causes compilation issues for C# and Java snippets because snippet generation process relies on the casing provided in the HTTP snippets. This PR fixes 9 of those instances.

cc: @pixieofhugs 