### PR TITLE
add delivering as an assignmentState in accesspackageassignment

### DIFF
--- a/api-reference/beta/resources/accesspackageassignment.md
+++ b/api-reference/beta/resources/accesspackageassignment.md
@@ -29,8 +29,8 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |:-------------|:------------|:------------|
 |accessPackageId|String|The identifier of the access package. Read-only.|
 |assignmentPolicyId|String|The identifier of the access package assignment policy. Read-only.|
-|assignmentState|String|The state of the access package assignment. Possible values are `Delivering`, `Delivered` or `Expired`. Read-only.|
-|assignmentStatus|String|More information on the assignment lifecycle.  Possible values include `Delivering`, `Delivered`, `NearExpiry1DayNotificationTriggered` or `ExpiredNotificationTriggered`.  Read-only.|
+|assignmentState|String|The state of the access package assignment. Possible values are `Delivering`, `Delivered`, or `Expired`. Read-only.|
+|assignmentStatus|String|More information about the assignment lifecycle.  Possible values include `Delivering`, `Delivered`, `NearExpiry1DayNotificationTriggered`, or `ExpiredNotificationTriggered`.  Read-only.|
 |catalogId|String|The identifier of the catalog containing the access package. Read-only.|
 |expiredDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |id|String| Read-only.|

--- a/api-reference/beta/resources/accesspackageassignment.md
+++ b/api-reference/beta/resources/accesspackageassignment.md
@@ -29,8 +29,8 @@ In [Azure AD entitlement management](entitlementmanagement-root.md), an access p
 |:-------------|:------------|:------------|
 |accessPackageId|String|The identifier of the access package. Read-only.|
 |assignmentPolicyId|String|The identifier of the access package assignment policy. Read-only.|
-|assignmentState|String|The state of the access package. Possible values are `Delivered` or `Expired`. Read-only.|
-|assignmentStatus|String|Read-only.|
+|assignmentState|String|The state of the access package assignment. Possible values are `Delivering`, `Delivered` or `Expired`. Read-only.|
+|assignmentStatus|String|More information on the assignment lifecycle.  Possible values include `Delivering`, `Delivered`, `NearExpiry1DayNotificationTriggered` or `ExpiredNotificationTriggered`.  Read-only.|
 |catalogId|String|The identifier of the catalog containing the access package. Read-only.|
 |expiredDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |id|String| Read-only.|


### PR DESCRIPTION
In the entitlement management accesspackageassignment.md, add 'Delivering' to the values for `assignmentState`, and clarify that this is the state of the assignment not the state of the access package.