### PR TITLE
Labeling new access review api documentation as Preview

### DIFF
--- a/api-reference/beta/resources/accessreviews-root.md
+++ b/api-reference/beta/resources/accessreviews-root.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure AD access reviews"
+title: "Azure AD access reviews (all resources)"
 description: "You can use Azure AD access reviews to configure one-time or recurring access reviews for attestation of user's access rights. This documentation serves the legacy APIs."
 localization_priority: Normal
 author: "markwahl-msft"
@@ -7,14 +7,14 @@ ms.prod: "microsoft-identity-platform"
 doc_type: conceptualPageType
 ---
 
-# Azure AD access reviews
+# Azure AD access reviews (all resources)
 
 Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
 >[!NOTE]
->A newer version of Access Review APIs can be found [here](accessreviewsv2-root.md). This new version only supports reviews of group membership at this time. For reviews of all other resources, please use the legacy APIs.
+>For access review APIs that apply to group memeberships, see [Access Reviews (group memberships)](accessreviewsv2-root.md). These access review APIs apply to all other resource types.
 
 You can use [Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) to configure one-time or recurring access reviews for attestation of user's access rights.
 

--- a/api-reference/beta/resources/accessreviews-root.md
+++ b/api-reference/beta/resources/accessreviews-root.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure AD access reviews - Legacy"
+title: "Azure AD access reviews"
 description: "You can use Azure AD access reviews to configure one-time or recurring access reviews for attestation of user's access rights. This documentation serves the legacy APIs."
 localization_priority: Normal
 author: "markwahl-msft"
@@ -7,7 +7,7 @@ ms.prod: "microsoft-identity-platform"
 doc_type: conceptualPageType
 ---
 
-# Azure AD access reviews (Legacy)
+# Azure AD access reviews
 
 Namespace: microsoft.graph
 

--- a/api-reference/beta/resources/accessreviewsv2-root.md
+++ b/api-reference/beta/resources/accessreviewsv2-root.md
@@ -14,9 +14,9 @@ Namespace: microsoft.graph
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
 >[!NOTE]
->This documentation contains the latest supported version of access reviews APIs for reviews on Microsoft 365 Groups. For reviews on other resources, see [access reviews APIs](accessreviews-root.md).
+>This documentation applies to access reviews of Microsoft 365 groups. For access reviews for all other resource types, see [Access reviews (all resources)](accessreviews-root.md).
 >
->Currently, the Microsoft Graph APIs only supports access reviews of group membership.
+>Currently, this API only supports access reviews of group memberships.
 
 You can use [Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) to configure one-time or recurring access reviews for attestation of user's access rights.
 

--- a/api-reference/beta/resources/accessreviewsv2-root.md
+++ b/api-reference/beta/resources/accessreviewsv2-root.md
@@ -7,7 +7,7 @@ ms.prod: "microsoft-identity-platform"
 doc_type: conceptualPageType
 ---
 
-# Azure AD access reviews
+# Azure AD access reviews (Preview)
 
 Namespace: microsoft.graph
 

--- a/api-reference/beta/resources/accessreviewsv2-root.md
+++ b/api-reference/beta/resources/accessreviewsv2-root.md
@@ -1,5 +1,5 @@
 ---
-title: "Azure AD access reviews - beta update"
+title: "Azure AD access reviews - group memberships"
 description: "You can use Azure AD access reviews to configure one-time or recurring access reviews for attestation of user's access rights. This documentation serves the 2nd version of the APIs."
 localization_priority: Normal
 author: "isabelleatmsft"
@@ -7,7 +7,7 @@ ms.prod: "microsoft-identity-platform"
 doc_type: conceptualPageType
 ---
 
-# Azure AD access reviews (Preview)
+# Azure AD access reviews (Group memberships)
 
 Namespace: microsoft.graph
 

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -10521,7 +10521,7 @@ items:
                href: api/identityuserflowattribute-delete.md
       - name: Governance
         items:
-        - name: Access reviews
+        - name: Access reviews (Preview)
           href: resources/accessreviewsv2-root.md
           items:
           - name: Access review schedule definition

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -10521,7 +10521,7 @@ items:
                href: api/identityuserflowattribute-delete.md
       - name: Governance
         items:
-        - name: Access reviews (Preview)
+        - name: Access reviews (groups)
           href: resources/accessreviewsv2-root.md
           items:
           - name: Access review schedule definition
@@ -10537,14 +10537,6 @@ items:
               href: api/accessreviewscheduledefinition-delete.md 
             - name: Update
               href: api/accessreviewscheduledefinition-update.md
-          - name: Access review schedule settings
-            href: resources/accessreviewschedulesettings.md
-          - name: Access review apply action
-            href: resources/accessreviewapplyaction.md
-          - name: Access review scope
-            href: resources/accessreviewscope.md
-          - name: Access review reviewer scope
-            href: resources/accessreviewreviewerscope.md
           - name: Access review instance
             href: resources/accessreviewinstance.md
             items:
@@ -10571,13 +10563,7 @@ items:
               href: api/accessreviewinstancedecisionitem-listpendingapproval.md
             - name: Update
               href: api/accessreviewinstancedecisionitem-update.md
-          - name: Access review instance decision item target
-            href: resources/accessreviewinstancedecisionitemtarget.md
-          - name: Access review instance decision item user target
-            href: resources/accessreviewinstancedecisionitemusertarget.md
-          - name: Access review instance decision item service principal target
-            href: resources/accessreviewinstancedecisionitemserviceprincipaltarget.md
-        - name: Access reviews
+        - name: Access reviews (all resources)
           href: resources/accessreviews-root.md
           items:
           - name: Access review


### PR DESCRIPTION
- removing "Legacy" from old access review apis
- labeling new access review apis as "Preview"