### PR TITLE
Clarifying 'iss' claim is the AAD ObjectId

### DIFF
--- a/concepts/application-rollkey-prooftoken.md
+++ b/concepts/application-rollkey-prooftoken.md
@@ -17,7 +17,7 @@ As part of the request validation for these methods, a proof of possession of an
 The token should contain the following claims:
 
 - `aud` - Audience needs to be `00000002-0000-0000-c000-000000000000`.
-- `iss` - Issuer needs to be the __id__  of the application that is making the call.
+- `iss` - Issuer needs to be the Azure AD __ObjectId__  of the application that is making the call (not the ApplicationId (a.k.a. ClientId)).
 - `nbf` - Not before time.
 - `exp` - Expiration time should be "nbf" + 10 mins.
 

--- a/concepts/application-rollkey-prooftoken.md
+++ b/concepts/application-rollkey-prooftoken.md
@@ -17,7 +17,7 @@ As part of the request validation for these methods, a proof of possession of an
 The token should contain the following claims:
 
 - `aud` - Audience needs to be `00000002-0000-0000-c000-000000000000`.
-- `iss` - Issuer needs to be the Azure AD __ObjectId__  of the application that is making the call (not the ApplicationId (a.k.a. ClientId)).
+- `iss` - Issuer needs to be the Azure AD __ObjectId__  of the application that is making the call (not the applicationId or clientId).
 - `nbf` - Not before time.
 - `exp` - Expiration time should be "nbf" + 10 mins.
 


### PR DESCRIPTION
Clarifying that it's the Azure AD ObjectId of the application, not the ApplicationId/ClientId.  For anyone encountering issues with the process, it's good to know for sure what it needs to be.