### PR TITLE
Clarifying what exactly 'key' needs

### DIFF
--- a/api-reference/v1.0/resources/keycredential.md
+++ b/api-reference/v1.0/resources/keycredential.md
@@ -23,7 +23,7 @@ Contains a key credential associated with an application <!--or a service princi
 |startDateTime|DateTimeOffset|The date and time at which the credential becomes valid.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |type|String|The type of key credential; for example, “Symmetric”.|
 |usage|String|A string that describes the purpose for which the key can be used; for example, “Verify”.|
-|key|Binary| Value for the key credential. Should be a base 64 encoded value. |
+|key|Binary| This is the certificate's raw data in byte array converted to Base64 string; for example, `[System.Convert]::ToBase64String($Cert.GetRawCertData())`. |
 
 ## JSON representation
 

--- a/api-reference/v1.0/resources/keycredential.md
+++ b/api-reference/v1.0/resources/keycredential.md
@@ -23,7 +23,7 @@ Contains a key credential associated with an application <!--or a service princi
 |startDateTime|DateTimeOffset|The date and time at which the credential becomes valid.The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: `'2014-01-01T00:00:00Z'`|
 |type|String|The type of key credential; for example, “Symmetric”.|
 |usage|String|A string that describes the purpose for which the key can be used; for example, “Verify”.|
-|key|Binary| This is the certificate's raw data in byte array converted to Base64 string; for example, `[System.Convert]::ToBase64String($Cert.GetRawCertData())`. |
+|key|Binary| The certificate's raw data in byte array converted to Base64 string; for example, `[System.Convert]::ToBase64String($Cert.GetRawCertData())`. |
 
 ## JSON representation
 


### PR DESCRIPTION
Added PowerShell / .NET example for how you would get the value to send for 'key'.

```powershell
[System.Convert]::ToBase64String($Cert.GetRawCertData())
```