### PR TITLE
Updated StackOverflow link

### DIFF
--- a/api-reference/beta/overview.md
+++ b/api-reference/beta/overview.md
@@ -12,7 +12,7 @@ author: "angelgolfer-ms"
 The reference content in this section documents the Microsoft Graph beta endpoint. The beta endpoint includes APIs that are currently in preview and are not yet generally available. We invite you to try these APIs and provide your feedback via the following channels:
 
 - [GitHub](https://github.com/OfficeDev/microsoft-graph-docs/issues) - For feedback on the Preview APIs. Tag with `beta`.
-- [StackOverflow](https://stackoverflow.com/questions/tagged/microsoftgraph) - For questions or help with your code. Tag with `microsoftgraph`.
+- [StackOverflow](https://stackoverflow.com/questions/tagged/microsoft-graph-api) - For questions or help with your code. Tag with `microsoft-graph-api`.
 
 > **Note:** The APIs in the beta endpoint are subject to change. We don't recommend that you use them in your production apps. 
 


### PR DESCRIPTION
The StackOverflow link targeted the `microsoftgraph` tag, but that is a synonym of `microsoft-graph-api`. It's better to link to the canonical tag.