### PR TITLE
Fix sample: Create Team with application permissions (example 2)

### DIFF
--- a/api-reference/beta/api/team-post.md
+++ b/api-reference/beta/api/team-post.md
@@ -135,7 +135,7 @@ Content-Type: application/json
          "roles":[
             "owner"
          ],
-         "userId":"0040b377-61d8-43db-94f5-81374122dc7e"
+         "user@odata.bind":"https://graph.microsoft.com/beta/users('0040b377-61d8-43db-94f5-81374122dc7e')"
       }
    ]
 }

--- a/api-reference/beta/includes/snippets/csharp/create-team-post-minimal-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/create-team-post-minimal-csharp-snippets.md
@@ -18,7 +18,10 @@ var team = new Team
 			{
 				"owner"
 			},
-			UserId = "0040b377-61d8-43db-94f5-81374122dc7e"
+			AdditionalData = new Dictionary<string, object>()
+			{
+				{"user@odata.bind", $"https://graph.microsoft.com/beta/users('0040b377-61d8-43db-94f5-81374122dc7e')"}
+			}
 		}
 	},
 	AdditionalData = new Dictionary<string, object>()

--- a/api-reference/beta/includes/snippets/javascript/create-team-post-minimal-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/create-team-post-minimal-javascript-snippets.md
@@ -20,7 +20,7 @@ const team = {
          roles:[
             "owner"
          ],
-         userId:"0040b377-61d8-43db-94f5-81374122dc7e"
+         user@odata.bind:"https://graph.microsoft.com/beta/users('0040b377-61d8-43db-94f5-81374122dc7e')"
       }
    ]
 };

--- a/api-reference/v1.0/api/team-post.md
+++ b/api-reference/v1.0/api/team-post.md
@@ -130,7 +130,7 @@ Content-Type: application/json
          "roles":[
             "owner"
          ],
-         "userId":"0040b377-61d8-43db-94f5-81374122dc7e"
+         "user@odata.bind":"https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')"
       }
    ]
 }

--- a/api-reference/v1.0/includes/snippets/csharp/create-team-post-minimal-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/create-team-post-minimal-csharp-snippets.md
@@ -18,7 +18,10 @@ var team = new Team
 			{
 				"owner"
 			},
-			UserId = "0040b377-61d8-43db-94f5-81374122dc7e"
+			AdditionalData = new Dictionary<string, object>()
+			{
+				{"user@odata.bind", $"https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')"}
+			}
 		}
 	},
 	AdditionalData = new Dictionary<string, object>()

--- a/api-reference/v1.0/includes/snippets/javascript/create-team-post-minimal-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/create-team-post-minimal-javascript-snippets.md
@@ -20,7 +20,7 @@ const team = {
          roles:[
             "owner"
          ],
-         userId:"0040b377-61d8-43db-94f5-81374122dc7e"
+         user@odata.bind:"https://graph.microsoft.com/v1.0/users('0040b377-61d8-43db-94f5-81374122dc7e')"
       }
    ]
 };


### PR DESCRIPTION
There seems to be an issue (again) with example 2 of the _Create Team_ documentation.
It was previously fixed with PR https://github.com/microsoftgraph/microsoft-graph-docs/pull/10221, but now fails again.
The error returned is:
`"message": "The navigation bind for the user was missing in request"`

I changed the documentation to have a working sample again.
Also fixed beta reference, javascript and C# samples.

The fix is to pass `user@odata.bind`, instead of `userId` in the POST body.