### PR TITLE
Update iteminsightssettings.md

### DIFF
--- a/api-reference/beta/resources/iteminsightssettings.md
+++ b/api-reference/beta/resources/iteminsightssettings.md
@@ -14,10 +14,10 @@ doc_type: resourcePageType
 Represents privacy settings for [itemInsights](iteminsights.md) and privacy setting for meeting hours insights. Use this API to disable/enable calculation and visibility of item insights and meeting hours insights. 
 
 - Item insights: Calculates relationship between users and items such as documents or sites in Microsoft 365.  
-- Meeting hours insights: Calculates a person's calendar meeting hours based on activities in Word, Excel, PowerPoint, email, and Outlook Calendar in Microsoft 365.
+- Meeting hours insights: Calculates a person's calendar meeting hours based on activities in Word, Excel, PowerPoint, email, and Outlook calendar in Microsoft 365.
 
 > [!NOTE]
-> As of November 2020, meeting hours insights are being rolled out to customers and are not yet generally available. 
+> Meeting hours insights are rolling out to customers starting November 2020. 
 
 ## Methods
 

--- a/api-reference/beta/resources/iteminsightssettings.md
+++ b/api-reference/beta/resources/iteminsightssettings.md
@@ -11,7 +11,13 @@ doc_type: resourcePageType
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents privacy settings for [itemInsights](iteminsights.md), which configure the visibility of insights derived from Microsoft Graph, between users and other items (such as documents or sites) in Microsoft 365.
+Represents privacy settings for [itemInsights](iteminsights.md) and privacy setting for meeting hours insights. Use this API to disable/enable calculation and visibility of item insights and meeting hours insights. 
+
+- Item insights: Calculates relationship between users and items such as documents or sites in Microsoft 365.  
+- Meeting hours insights: Calculates a person's calendar meeting hours based on activities in Word, Excel, PowerPoint, email, and Outlook Calendar in Microsoft 365.
+
+> [!NOTE]
+> As of November 2020, meeting hours insights are being rolled out to customers and are not yet generally available. 
 
 ## Methods
 


### PR DESCRIPTION
New info reflects that privacy setting also applies to the visibility of meeting hours insights.
Supporting docs: [Partner documentation](https://msfast.visualstudio.com/FAST/_wiki/wikis/FAST.wiki/2492/Consuming-Preferred-Meeting-Hours-from-MLAPI), [spec](https://microsofteur.sharepoint.com/:w:/t/fastpint/EY14t0ZYn4dOk8t-SLeE9ccBOz31FnqnvHEXz8bS7-M4dA?e=81TbN3), [work item](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/1771029). Engineering contact is Nir Netes (ninetes)
@elmakhmu FYI