### PR TITLE
Update insights-customize-item-insights-privacy.md

### DIFF
--- a/concepts/insights-customize-item-insights-privacy.md
+++ b/concepts/insights-customize-item-insights-privacy.md
@@ -83,6 +83,8 @@ Some [trending](/graph/api/resources/insights-trending) or [used](/graph/api/res
 
 - The profile card of a user who has disabled item insights does not show their **used** documents. The same limitation applies to the profile result of Microsoft Search in Bing, where the **Recent Files** panel becomes empty. Furthermore, the precision of acronym-expansion in search is reduced.
 
+- Disabling item insights will stop [suggested meeting hours](https://support.microsoft.com/office/update-your-meeting-hours-using-the-profile-card-0613d113-d7c1-4faa-bb11-c8ba30a78ef1?ui=en-US&rs=en-US&ad=US) from being calculated and shown to the user on their profile card. 
+
 - In Delve, a user who has disabled item insights has their documents hidden. 
 
 - Any user who disables item insights has their activity removed from organization-wide analytics. Normally such analytics suggests assistive insights to the user's colleagues across a multitude of experiences, ranging from Outlook to OneDrive and SharePoint. The analytics is always anonymous regardless of settings, but when a user disables insights, the user's activity is excluded from improving the productivity of others.


### PR DESCRIPTION
Added info to Behavior changes in UI (specifically, that disabling item insights disables calculation and showing of suggested meeting hours on the profile card). 
Supporting docs: [partner documentation](https://msfast.visualstudio.com/FAST/_wiki/wikis/FAST.wiki/2492/Consuming-Preferred-Meeting-Hours-from-MLAPI), [spec](https://microsofteur.sharepoint.com/:w:/t/fastpint/EY14t0ZYn4dOk8t-SLeE9ccBOz31FnqnvHEXz8bS7-M4dA?e=81TbN3), [work item](https://o365exchange.visualstudio.com/O365%20Core/_workitems/edit/1771029) 
Engineering contact is Nir Netes (ninetes)
@elmakhmu FYI
