### PR TITLE
Added note that date range cannot exceed 90 days

### DIFF
--- a/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
+++ b/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
@@ -47,7 +47,7 @@ The following table shows the parameters that can be used with this function.
 |toDateTime|DateTimeOffset|End of time range to query. UTC, inclusive.|
 
 > [!IMPORTANT]
-> \* The fromDateTime and toDateTime values cannot be more than a date range of 90 days.
+> \* The **fromDateTime** and **toDateTime** values cannot be more than a date range of 90 days.
 
 ## Request headers
 

--- a/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
+++ b/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
@@ -46,6 +46,9 @@ The following table shows the parameters that can be used with this function.
 |fromDateTime|DateTimeOffset|Start of time range to query. UTC, inclusive.<br/>Time range is based on the call start time.|
 |toDateTime|DateTimeOffset|End of time range to query. UTC, inclusive.|
 
+> [!IMPORTANT]
+> \* The fromDateTime and toDateTime values cannot be more than a date range of 90 days.
+
 ## Request headers
 
 |Name|Description|


### PR DESCRIPTION
There is nothing in the documentation to suggest this, but you cannot exceed 90 days between the startDateTime and endDateTime. Doing so, will result in a response code 406 from Graph.