### PR TITLE
Modify description of the status property to reflect complex structure

### DIFF
--- a/api-reference/beta/resources/signin.md
+++ b/api-reference/beta/resources/signin.md
@@ -56,7 +56,7 @@ Provides details about user or application sign-in activity in your directory.
 |riskState|riskState|The risk state of a risky user, sign-in, or a risk event. Possible values: `none`, `confirmedSafe`, `remediated`, `dismissed`, `atRisk`, `confirmedCompromised`, or `unknownFutureValue`.|
 |servicePrincipalId|String|The application identifier used for sign-in. This field is populated when you are signing in using an application.|
 |servicePrincipalName|String|The application name used for sign-in. This field is populated when you are signing in using an application.|
-|status|[signInStatus](signinstatus.md)|The sign-in status. Possible values: `Success` or `Failure`.|
+|status|[signInStatus](signinstatus.md)|The sign-in status. Includes the error code and description of the error (in case of a sign-in failure).|
 |tokenIssuerName|String|The name of the identity provider. For example, `sts.microsoft.com`.|
 |tokenIssuerType|String|The type of identity provider. Possible values: `AzureAD`, `ADFederationServices`, or `UnknownFutureValue`.|
 |userAgent|String|The user agent information related to sign-in.|

--- a/api-reference/beta/resources/signinstatus.md
+++ b/api-reference/beta/resources/signinstatus.md
@@ -18,7 +18,7 @@ Provides the sign-in status (Success or Failure) of the sign-in
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |additionalDetails|String|Provides additional details on the sign-in activity|
-|errorCode|Int32|Provides the 5-6digit error code that's generated during a sign-in failure. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
+|errorCode|Int32|Provides the 5-6 digit error code that's generated during a sign-in failure. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
 |failureReason|String|Provides the error message or the reason for failure for the corresponding sign-in activity. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
 
 ## JSON representation

--- a/api-reference/beta/resources/signinstatus.md
+++ b/api-reference/beta/resources/signinstatus.md
@@ -35,9 +35,9 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "additionalDetails": "For more details, see https://login.microsoftonline.com/error",
-  "errorCode": 65001,
-  "failureReason": "The user or administrator has not consented to use the application with ID '{identifier}'{namePhrase}. Send an interactive authorization request for this user and resource."
+  "additionalDetails": "String",
+  "errorCode": 1024,
+  "failureReason": "String"
 }
 
 ```

--- a/api-reference/beta/resources/signinstatus.md
+++ b/api-reference/beta/resources/signinstatus.md
@@ -35,9 +35,9 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "additionalDetails": "String",
-  "errorCode": 1024,
-  "failureReason": "String"
+  "additionalDetails": "For more details, see https://login.microsoftonline.com/error",
+  "errorCode": 65001,
+  "failureReason": "The user or administrator has not consented to use the application with ID '{identifier}'{namePhrase}. Send an interactive authorization request for this user and resource."
 }
 
 ```

--- a/api-reference/v1.0/resources/signin.md
+++ b/api-reference/v1.0/resources/signin.md
@@ -43,7 +43,7 @@ Details user and application sign-in activity for a tenant (directory).
 |riskLevelAggregated|riskLevel|Aggregated risk level. The possible values are: `none`, `low`, `medium`, `high`, `hidden`, and `unknownFutureValue`. The value `hidden` means the user or sign-in was not enabled for Azure AD Identity Protection. **Note:** Details for this property are only available for Azure AD Premium P2 customers. All other customers will be returned `hidden`.|
 |riskLevelDuringSignIn|riskLevel|Risk level during sign-in. The possible values are: `none`, `low`, `medium`, `high`, `hidden`, and `unknownFutureValue`. The value `hidden` means the user or sign-in was not enabled for Azure AD Identity Protection. **Note:** Details for this property are only available for Azure AD Premium P2 customers. All other customers will be returned `hidden`.|
 |riskState|riskState|Reports status of the risky user, sign-in, or a risk event. The possible values are: `none`, `confirmedSafe`, `remediated`, `dismissed`, `atRisk`, `confirmedCompromised`, `unknownFutureValue`.|
-|status|[signInStatus](signinstatus.md)|Sign-in status. Possible values include `Success` and `Failure`.|
+|status|[signInStatus](signinstatus.md)|Sign-in status. Includes the error code and description of the error (in case of a sign-in failure).|
 |userDisplayName|String|Display name of the user that initiated the sign-in.|
 |userId|String|ID of the user that initiated the sign-in.|
 |userPrincipalName|String|User principal name of the user that initiated the sign-in.|

--- a/api-reference/v1.0/resources/signinstatus.md
+++ b/api-reference/v1.0/resources/signinstatus.md
@@ -18,7 +18,7 @@ Provides the sign-in status (Success or Failure) of the sign-in.
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |additionalDetails|String|Provides additional details on the sign-in activity|
-|errorCode|Int32|Provides the 5-6digit error code that's generated during a sign-in failure. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
+|errorCode|Int32|Provides the 5-6 digit error code that's generated during a sign-in failure. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
 |failureReason|String|Provides the error message or the reason for failure for the corresponding sign-in activity. Check out the [list of error codes and messages](/azure/active-directory/active-directory-reporting-activity-sign-ins-errors).|
 
 ## JSON representation

--- a/api-reference/v1.0/resources/signinstatus.md
+++ b/api-reference/v1.0/resources/signinstatus.md
@@ -35,9 +35,9 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "additionalDetails": "For more details, see https://login.microsoftonline.com/error",
-  "errorCode": 65001,
-  "failureReason": "The user or administrator has not consented to use the application with ID '{identifier}'{namePhrase}. Send an interactive authorization request for this user and resource."
+  "additionalDetails": "String",
+  "errorCode": 1024,
+  "failureReason": "String"
 }
 
 ```

--- a/api-reference/v1.0/resources/signinstatus.md
+++ b/api-reference/v1.0/resources/signinstatus.md
@@ -35,9 +35,9 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "additionalDetails": "String",
-  "errorCode": 1024,
-  "failureReason": "String"
+  "additionalDetails": "For more details, see https://login.microsoftonline.com/error",
+  "errorCode": 65001,
+  "failureReason": "The user or administrator has not consented to use the application with ID '{identifier}'{namePhrase}. Send an interactive authorization request for this user and resource."
 }
 
 ```


### PR DESCRIPTION
No simple `Success` or `Failure` values in the `status` property. The success or failure of the sign-in activity is identified by the values in 3 nested parameters: `errorCode`, `failureReason`, and `additionalDetails`.

Fixes #5798