### PR TITLE
1797650: Remove '?view=azure-cli-latest' link syntax

### DIFF
--- a/concepts/change-notifications-delivery.md
+++ b/concepts/change-notifications-delivery.md
@@ -30,7 +30,7 @@ This section will walk you through the setup of required Azure services.
 
 #### Option 1: Using the Azure CLI
 
-The [Azure CLI](/cli/azure/what-is-azure-cli?view=azure-cli-latest) allows you to script and automate adminstrative tasks in Azure. The CLI can be [installed on your local computer](/cli/azure/install-azure-cli?view=azure-cli-latest) or run directly from the [Azure Cloud Shell](/azure/cloud-shell/quickstart).
+The [Azure CLI](/cli/azure/what-is-azure-cli) allows you to script and automate adminstrative tasks in Azure. The CLI can be [installed on your local computer](/cli/azure/install-azure-cli) or run directly from the [Azure Cloud Shell](/azure/cloud-shell/quickstart).
 
 ```shell
 # --------------


### PR DESCRIPTION
No code or content changes. Part of an effort to remove unnecessary versioning link syntax.

See user story [1797650](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1797650) for more information.