### PR TITLE
Typo on Access Review docs

### DIFF
--- a/api-reference/beta/api/accessreviewscheduledefinition-create.md
+++ b/api-reference/beta/api/accessreviewscheduledefinition-create.md
@@ -71,7 +71,7 @@ In the request body, supply a JSON representation of the [accessReviewScheduleDe
   "name": "create_accessReviewScheduleDefinition"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/accessReviews
+POST https://graph.microsoft.com/beta/identityGovernance/accessReviews/definitions
 Content-type: application/json
 
 {

--- a/api-reference/beta/resources/accessreviewsv2-root.md
+++ b/api-reference/beta/resources/accessreviewsv2-root.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
 >[!NOTE]
->This documentation applies to access reviews of Microsoft 365 groups. For access reviews for all other resource types, see [Access reviews (all resources)](accessreviews-root.md).
+>This documentation applies to access reviews of group memberships. For access reviews on all other supported resource types, see [Access reviews (all resources)](accessreviews-root.md).
 >
 >Currently, this API only supports access reviews of group memberships.
 


### PR DESCRIPTION
Note on docs says we only support M365 Groups when we support other group types as well. Fixed this.