### PR TITLE
Fix extra lines in http blocks

### DIFF
--- a/api-reference/beta/api/calendargroup-post-calendars.md
+++ b/api-reference/beta/api/calendargroup-post-calendars.md
@@ -74,7 +74,6 @@ Here is an example of the request.
 
 ```http
 POST https://graph.microsoft.com/beta/me/calendargroups/AAMkADYAAAR9NR5AAA=/calendars
-
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/connector-post-memberof.md
+++ b/api-reference/beta/api/connector-post-memberof.md
@@ -52,7 +52,6 @@ Here is an example of the request.
 }-->
 ```http
 POST https://graph.microsoft.com/beta/onPremisesPublishingProfiles/applicationProxy/connectors/{id}/memberOf/$ref
-
 Content-type: application/json
 Content-length: 99
 

--- a/api-reference/beta/api/connectorgroup-post-applications.md
+++ b/api-reference/beta/api/connectorgroup-post-applications.md
@@ -53,7 +53,6 @@ The following is an example of the request.
 }-->
 ```http
 PUT https://graph.microsoft.com/beta/applications/{id}/connectorGroup/$ref
-
 Content-type: application/json
 Content-length: 30
 

--- a/api-reference/beta/api/featurerolloutpolicy-update.md
+++ b/api-reference/beta/api/featurerolloutpolicy-update.md
@@ -66,7 +66,6 @@ The following is an example of the request.
 
 ```http
 PATCH https://graph.microsoft.com/v1.0/directory/featureRolloutPolicies/d7ab4886-d7f0-441b-a5e6-e62d7328d18a
-
 Content-type: application/json
 
 {

--- a/api-reference/beta/api/identityuserflowattributeassignment-setorder.md
+++ b/api-reference/beta/api/identityuserflowattributeassignment-setorder.md
@@ -70,7 +70,6 @@ If successful, this action returns a `204 No Content` response code.
 
 ``` http
 POST https://graph.microsoft.com/beta/identity/b2cUserFlows/{id}/userAttributeAssignments/setOrder
-
 Content-Type: application/json
 Content-length: 90
 

--- a/api-reference/beta/api/permission-revokegrants.md
+++ b/api-reference/beta/api/permission-revokegrants.md
@@ -75,7 +75,6 @@ If successful, this action returns a `200 OK` response code and a [permission](.
 -->
 ``` http
 POST /me/drive/items/{item-id}/permissions/{perm-id}/revokeGrants
-
 Content-Type: application/json
 Content-length: 95
 

--- a/api-reference/beta/api/synchronization-synchronizationjob-provision-on-demand.md
+++ b/api-reference/beta/api/synchronization-synchronizationjob-provision-on-demand.md
@@ -65,7 +65,6 @@ If successful, this method returns a `200 OK` response code and a stringKeyStrin
 -->
 ``` http
 POST https://graph.microsoft.com/beta/servicePrincipals/{servicePrincipalsId}/synchronization/jobs/{synchronizationJobId}/provisionOnDemand
-
 Content-Type: application/json
 Content-length: 122
 

--- a/api-reference/beta/api/userteamwork-sendactivitynotification.md
+++ b/api-reference/beta/api/userteamwork-sendactivitynotification.md
@@ -136,7 +136,6 @@ If you want to link an aspect that is not represented by Microsoft Graph, or you
 -->
 ``` http
 POST https://graph.microsoft.com/beta/users/{userId}/teamwork/sendActivityNotification
-
 Content-Type: application/json
 
 {

--- a/api-reference/beta/api/userteamwork-sendactivitynotification.md
+++ b/api-reference/beta/api/userteamwork-sendactivitynotification.md
@@ -128,7 +128,6 @@ If you want to link an aspect that is not represented by Microsoft Graph, or you
 
 #### Request
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "team_sendactivitynotification"
@@ -156,11 +155,6 @@ Content-Type: application/json
     ]
 }
 ```
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/team-sendactivitynotification-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
----
 
 
 #### Response

--- a/api-reference/v1.0/api/calendargroup-post-calendars.md
+++ b/api-reference/v1.0/api/calendargroup-post-calendars.md
@@ -72,7 +72,6 @@ Here is an example of the request.
 
 ```http
 POST https://graph.microsoft.com/v1.0/me/calendargroups/AAMkADYAAAR9NR5AAA=/calendars
-
 Content-type: application/json
 
 {

--- a/api-reference/v1.0/api/directoryobject-getavailableextensionproperties.md
+++ b/api-reference/v1.0/api/directoryobject-getavailableextensionproperties.md
@@ -63,7 +63,6 @@ If successful, this action returns a `200 OK` response code and an [extensionPro
 -->
 ``` http
 POST https://graph.microsoft.com/v1.0/directoryObjects/getAvailableExtensionProperties
-
 Content-Type: application/json
 Content-length: 43
 

--- a/api-reference/v1.0/api/riskyuser-confirmcompromised.md
+++ b/api-reference/v1.0/api/riskyuser-confirmcompromised.md
@@ -64,7 +64,6 @@ If successful, this action returns a `204 No Content` response code.
 -->
 ``` http
 POST https://graph.microsoft.com/v1.0/identityProtection/riskyUsers/confirmCompromised
-
 Content-Type: application/json
 Content-length: 39
 

--- a/api-reference/v1.0/api/riskyuser-dismiss.md
+++ b/api-reference/v1.0/api/riskyuser-dismiss.md
@@ -64,7 +64,6 @@ If successful, this action returns a `204 No Content` response code.
 -->
 ``` http
 POST https://graph.microsoft.com/v1.0/identityProtection/riskyUsers/dismiss
-
 Content-Type: application/json
 Content-length: 39
 


### PR DESCRIPTION
This PR fixes some http examples with extra newlines after the startline.

The http headers should appear immediately after the startline (second line) and an empty line used to separate the headers section and the body section. More info [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages#HTTP_Requests).

This fix will also prevent the breaking of the master branch on future versions of ApiDoctor and it will also enable snippet generation for the affected bodies.