### PR TITLE
Update EM requestorSettings with new scopeType

### DIFF
--- a/api-reference/beta/resources/requestorsettings.md
+++ b/api-reference/beta/resources/requestorsettings.md
@@ -30,7 +30,7 @@ Used for the **requestorSettings** property of an [access package assignment pol
 
 | Property                     | Type                      | Description |
 | :--------------------------- | :------------------------ | :---------- |
-| scopeType |String |Who can request. One of `NoSubjects`, `SpecificDirectorySubjects`, `SpecificConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects` or `AllExternalSubjects`.  |
+| scopeType |String |Who can request. One of `NoSubjects`, `SpecificDirectorySubjects`, `SpecificConnectedOrganizationSubjects`, `AllConfiguredConnectedOrganizationSubjects`, `AllExistingConnectedOrganizationSubjects`, `AllExistingDirectoryMemberUsers`, `AllExistingDirectorySubjects` or `AllExternalSubjects`.  |
 | acceptRequests | Boolean | Indicates whether new requests are accepted on this policy. |
 | allowedRequestors | [userSet](userset.md) collection| The users who are allowed to request on this policy, which can be [singleUser](singleuser.md), [groupMembers](groupmembers.md), and [connectedOrganizationMembers](connectedorganizationmembers.md). |
 


### PR DESCRIPTION
Added a new allowable value of the scopeType property of the requestorSettings type.  This type is used within Azure AD entitlement management accessPackageAssignmentPolicy.  The new value is `AllConfiguredConnectedOrganizationSubjects`.