### PR TITLE
Update people-picker.md

### DIFF
--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -30,11 +30,9 @@ By default, the `mgt-people-picker` component fetches people from the `/me/peopl
 | group-type     | groupType      | The group type to search for. Available options are: `unified`, `security`, `mailenabledsecurity`, `distribution`, `any`. Default value is `any`. This attribute has no effect if the `type` property is set to `person`.                                                                           |
 |  selected-people  | selectedPeople     | An array of selected people. Set this value to select people programmatically.|
 | people   | people    | An array of people found and rendered in the search result |
-| placeholder   | placeholder    | A string representing input placeholder text. Default is "Start typing a name".
-| selection-mode   | selectionMode   | A string value that allows you to specify whether the component supports multiple selected people or just one. Default is `multiple`; `single` is the other option.
+| placeholder   | placeholder    | The default text that appears to explain how to use the component. Default value is `Start typing a name`.
 | default-selected-user-ids | defaultSelectedUserIds | When provided a string of comma-separated Microsoft Graph user IDs, the component renders the respective users as selected upon initialization.
-| selection-mode | selectionMode | Used to indicate whether to allow selecting multiple users or just a single user. Available options are: `single`, `multiple`. Default value is `multiple`.
-| placeholder | placeholder | The default text that appears to explain how to use the component. Default value is `Start typing a name`.
+| selection-mode | selectionMode | Used to indicate whether to allow selecting multiple items (users or groups) or just a single item. Available options are: `single`, `multiple`. Default value is `multiple`.
 
 The following is a `show-max` example.
 


### PR DESCRIPTION
removed duplicate "properties", and also changed selectionMode to say "items" instead of "users" because the person might be selecting a group