### PR TITLE
Missing basetype causes issues for client library

### DIFF
--- a/api-reference/beta/resources/applicationserviceprincipal.md
+++ b/api-reference/beta/resources/applicationserviceprincipal.md
@@ -40,7 +40,6 @@ The following is a JSON representation of the resource.
 
   ],
   "@odata.type": "microsoft.graph.applicationServicePrincipal",
-  "baseType": "",
   "keyProperty": "id"
 }-->
 

--- a/api-reference/beta/resources/approvalsettings.md
+++ b/api-reference/beta/resources/approvalsettings.md
@@ -34,8 +34,7 @@ The following is a JSON representation of the request approval settings property
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.approvalSettings",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.approvalSettings"
 }-->
 
 ```json

--- a/api-reference/beta/resources/approvalstage.md
+++ b/api-reference/beta/resources/approvalstage.md
@@ -37,8 +37,7 @@ The following is a JSON representation of the request approval stage.
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.approvalStage",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.approvalStage"
 }-->
 
 ```json

--- a/api-reference/beta/resources/assignmentreviewsettings.md
+++ b/api-reference/beta/resources/assignmentreviewsettings.md
@@ -38,8 +38,7 @@ The following is a JSON representation of the access review settings property of
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.assignmentReviewSettings",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.assignmentReviewSettings"
 }-->
 
 ```json

--- a/api-reference/beta/resources/expirationpattern.md
+++ b/api-reference/beta/resources/expirationpattern.md
@@ -41,8 +41,7 @@ The following is a JSON representation of the resource.
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.expirationPattern",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.expirationPattern"
 }-->
 
 ```json

--- a/api-reference/beta/resources/externalitemcontent.md
+++ b/api-reference/beta/resources/externalitemcontent.md
@@ -37,8 +37,7 @@ The following is a JSON representation of the resource.
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.externalItemContent",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.externalItemContent"
 }-->
 
 ```json

--- a/api-reference/beta/resources/regionalformatoverrides.md
+++ b/api-reference/beta/resources/regionalformatoverrides.md
@@ -33,7 +33,6 @@ The following is a JSON definition of the resource.
 <!--{
   "blockType": "resource",
   "optionalProperties": [],
-  "baseType": "",
   "@odata.type": "microsoft.graph.regionalFormatOverrides"
 }-->
 

--- a/api-reference/beta/resources/requestorsettings.md
+++ b/api-reference/beta/resources/requestorsettings.md
@@ -44,8 +44,7 @@ The following is a JSON representation of the **requestorSettings** property of 
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.requestorSettings",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.requestorSettings"
 }-->
 
 ```json

--- a/api-reference/beta/resources/requestschedule.md
+++ b/api-reference/beta/resources/requestschedule.md
@@ -32,8 +32,7 @@ The following is a JSON representation of the resource.
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.requestSchedule",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.requestSchedule"
 }-->
 
 ```json

--- a/api-reference/beta/resources/termsexpiration.md
+++ b/api-reference/beta/resources/termsexpiration.md
@@ -33,7 +33,6 @@ The following is a JSON representation of this resource.
 
   ],
   "@odata.type": "microsoft.graph.termsExpiration",
-  "baseType": ""
 }-->
 
 ```json

--- a/api-reference/beta/resources/userset.md
+++ b/api-reference/beta/resources/userset.md
@@ -30,8 +30,7 @@ The following is a JSON representation of userSet.  Note that a userSet is an ab
   "optionalProperties": [
 
   ],
-  "@odata.type": "microsoft.graph.userSet",
-  "baseType": ""
+  "@odata.type": "microsoft.graph.userSet"
 }-->
 
 ```json


### PR DESCRIPTION
The base type gets set on the generated models. BaseType is set empty in the docs. This causes an issues in the tools that generate the client libraries. 

@snlraju-msft @jasonbro @markwahl-msft @raprakasMSFT @sureshja

Changes to be committed:
	modified:   api-reference/beta/resources/applicationserviceprincipal.md
	modified:   api-reference/beta/resources/approvalsettings.md
	modified:   api-reference/beta/resources/approvalstage.md
	modified:   api-reference/beta/resources/assignmentreviewsettings.md
	modified:   api-reference/beta/resources/expirationpattern.md
	modified:   api-reference/beta/resources/externalitemcontent.md
	modified:   api-reference/beta/resources/regionalformatoverrides.md
	modified:   api-reference/beta/resources/requestorsettings.md
	modified:   api-reference/beta/resources/requestschedule.md
	modified:   api-reference/beta/resources/termsexpiration.md
	modified:   api-reference/beta/resources/userset.md

@zengin This is something we could handle in ApiDoctor by ignoring empty base type.  