### PR TITLE
Changed lambda declaration to avoid CS0136 compiler error

### DIFF
--- a/concepts/sdks/large-file-upload.md
+++ b/concepts/sdks/large-file-upload.md
@@ -39,8 +39,8 @@ using (var fileStream = System.IO.File.OpenRead(filePath))
         new LargeFileUploadTask<DriveItem>(uploadSession, fileStream, maxSliceSize);
 
     // Create a callback that is invoked after each slice is uploaded
-    IProgress<long> progress = new Progress<long>(progress => {
-        Console.WriteLine($"Uploaded {progress} bytes of {fileStream.Length} bytes");
+    IProgress<long> progress = new Progress<long>(prog => {
+        Console.WriteLine($"Uploaded {prog} bytes of {fileStream.Length} bytes");
     });
 
     try

--- a/concepts/sdks/large-file-upload.md
+++ b/concepts/sdks/large-file-upload.md
@@ -7,7 +7,7 @@ author: DarrelMiller
 
 # Upload large files using the Microsoft Graph SDKs
 
-A number of entities in Microsoft Graph support [resumable file uploads](/graph/api/driveitem-createuploadsession?view=graph-rest-1.0) to make it easier to upload large files. Instead of trying to upload the entire file in a single request, the file is sliced into smaller pieces and a request is used to upload a single slice. In order to simplify this process, the Microsoft Graph SDKs implement a large file upload task that manages the uploading of the slices.
+A number of entities in Microsoft Graph support [resumable file uploads](/graph/api/driveitem-createuploadsession?view=graph-rest-1.0&preserve-view=true) to make it easier to upload large files. Instead of trying to upload the entire file in a single request, the file is sliced into smaller pieces and a request is used to upload a single slice. In order to simplify this process, the Microsoft Graph SDKs implement a large file upload task that manages the uploading of the slices.
 
 ## [C#](#tab/csharp)
 
@@ -153,7 +153,7 @@ chunkedUploadProvider.upload(callback, customConfig);
 
 ## Resuming a file upload
 
-The Microsoft Graph SDKs support [resuming in-progress uploads](/graph/api/driveitem-createuploadsession?view=graph-rest-1.0#resuming-an-in-progress-upload). If your application encounters a connection interruption or a 5.x.x HTTP status during upload, you can resume the upload.
+The Microsoft Graph SDKs support [resuming in-progress uploads](/graph/api/driveitem-createuploadsession?view=graph-rest-1.0&preserve-view=true#resuming-an-in-progress-upload). If your application encounters a connection interruption or a 5.x.x HTTP status during upload, you can resume the upload.
 
 <!-- markdownlint-disable MD024 -->
 ### [C#](#tab/csharp)


### PR DESCRIPTION
.NET Framework errors because `progress` was already declared. Interestingly enough, .NET Core did not complain about this.

Fixes #11132