### PR TITLE
Update signin.md

### DIFF
--- a/api-reference/beta/resources/signin.md
+++ b/api-reference/beta/resources/signin.md
@@ -14,10 +14,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Provides details about user or application sign-in activity in your directory. 
-
->[!NOTE]
->You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
+Provides details about user or application sign-in activity in your directory. You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
 
 ## Methods
 

--- a/api-reference/beta/resources/signin.md
+++ b/api-reference/beta/resources/signin.md
@@ -16,6 +16,9 @@ Namespace: microsoft.graph
 
 Provides details about user or application sign-in activity in your directory. 
 
+>[!NOTE]
+>You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
+
 ## Methods
 
 | Method		   | Return Type	|Description|

--- a/api-reference/v1.0/resources/signin.md
+++ b/api-reference/v1.0/resources/signin.md
@@ -11,10 +11,7 @@ doc_type: resourcePageType
 
 Namespace: microsoft.graph
 
-Details user and application sign-in activity for a tenant (directory).
-
->[!NOTE]
->You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
+Details user and application sign-in activity for a tenant (directory). You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
 
 ## Methods
 

--- a/api-reference/v1.0/resources/signin.md
+++ b/api-reference/v1.0/resources/signin.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph
 Details user and application sign-in activity for a tenant (directory).
 
 >[!NOTE]
->You must have an Azure AD Premium P1 or P2 license to download sign-in logs using Graph API.
+>You must have an Azure AD Premium P1 or P2 license to download sign-in logs using the Microsoft Graph API.
 
 ## Methods
 

--- a/api-reference/v1.0/resources/signin.md
+++ b/api-reference/v1.0/resources/signin.md
@@ -13,6 +13,9 @@ Namespace: microsoft.graph
 
 Details user and application sign-in activity for a tenant (directory).
 
+>[!NOTE]
+>You must have an Azure AD Premium P1 or P2 license to download sign-in logs using Graph API.
+
 ## Methods
 
 | Method		   | Return Type	|Description|


### PR DESCRIPTION
Added Notes about license information in top section above Methods - "Note: You must have an Azure AD Premium P1 or P2 license to download sign-in logs using Graph API." As Developers are using this and facing "Authentication_RequestFromNonPremiumTenantOrB2CTenant".
UserVoice feedback reference - https://feedback.azure.com/forums/169401/suggestions/42160141