### PR TITLE
create-team-csharp-snippets.md

### DIFF
--- a/api-reference/v1.0/includes/snippets/csharp/create-team-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/create-team-csharp-snippets.md
@@ -11,18 +11,22 @@ var team = new Team
 	MemberSettings = new TeamMemberSettings
 	{
 		AllowCreatePrivateChannels = true,
-		AllowCreateUpdateChannels = true
+		AllowCreateUpdateChannels = true,
+		ODataType = null
 	},
 	MessagingSettings = new TeamMessagingSettings
 	{
 		AllowUserEditMessages = true,
-		AllowUserDeleteMessages = true
+		AllowUserDeleteMessages = true,
+		ODataType = null
 	},
 	FunSettings = new TeamFunSettings
 	{
 		AllowGiphy = true,
-		GiphyContentRating = GiphyRatingType.Strict
-	}
+		GiphyContentRating = GiphyRatingType.Strict,
+		ODataType = null
+	},
+	ODataType = null
 };
 
 await graphClient.Groups["{id}"].Team


### PR DESCRIPTION
Added required ODataType =  null statements; command fails with "Message: Could not find member '@odata.type' on object of type..." without ODataType switch.