### PR TITLE
Messages Fixing: 'code-block-*', 'table-syntax-invalid'. Worse remain.

### DIFF
--- a/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-create.md
+++ b/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-create.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 
-``` http
+```http
 POST /deviceManagement/deviceConfigurations
 POST /deviceManagement/deviceConfigurations/{deviceConfigurationId}/microsoft.graph.windowsDomainJoinConfiguration/networkAccessConfigurations
 ```
@@ -105,8 +105,6 @@ The following table shows the properties that are required when you create the m
 |contentCachingKeepAwake|Boolean|Prevent the device from sleeping if content caching is enabled.|
 |contentCachingPort|Int32|Sets the port used for content caching. If the value is 0, a random available port will be selected. Valid values 0 to 65535|
 
-
-
 ## Response
 If successful, this method returns a `201 Created` response code and a [macOSDeviceFeaturesConfiguration](../resources/intune-deviceconfig-macosdevicefeaturesconfiguration.md) object in the response body.
 
@@ -115,7 +113,7 @@ If successful, this method returns a `201 Created` response code and a [macOSDev
 ### Request
 Here is an example of the request.
 
-``` http
+```http
 POST https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations
 Content-type: application/json
 Content-length: 5662
@@ -297,7 +295,7 @@ Content-length: 5662
 ### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
 
-``` http
+```http
 HTTP/1.1 201 Created
 Content-Type: application/json
 Content-Length: 5834
@@ -478,7 +476,3 @@ Content-Length: 5834
   "contentCachingPort": 2
 }
 ```
-
-
-
-

--- a/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-create.md
+++ b/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-create.md
@@ -31,12 +31,14 @@ One of the following permissions is required to call this API. To learn more, in
   "blockType": "ignored"
 }
 -->
+
 ``` http
 POST /deviceManagement/deviceConfigurations
 POST /deviceManagement/deviceConfigurations/{deviceConfigurationId}/microsoft.graph.windowsDomainJoinConfiguration/networkAccessConfigurations
 ```
 
 ## Request headers
+
 |Header|Value|
 |:---|:---|
 |Authorization|Bearer &lt;token&gt; Required.|
@@ -112,6 +114,7 @@ If successful, this method returns a `201 Created` response code and a [macOSDev
 
 ### Request
 Here is an example of the request.
+
 ``` http
 POST https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations
 Content-type: application/json
@@ -293,6 +296,7 @@ Content-length: 5662
 
 ### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+
 ``` http
 HTTP/1.1 201 Created
 Content-Type: application/json

--- a/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-update.md
+++ b/api-reference/beta/api/intune-deviceconfig-macosdevicefeaturesconfiguration-update.md
@@ -31,6 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
   "blockType": "ignored"
 }
 -->
+
 ``` http
 PATCH /deviceManagement/deviceConfigurations/{deviceConfigurationId}
 PATCH /deviceManagement/deviceConfigurations/{deviceConfigurationId}/groupAssignments/{deviceConfigurationGroupAssignmentId}/deviceConfiguration
@@ -38,6 +39,7 @@ PATCH /deviceManagement/deviceConfigurations/{deviceConfigurationId}/microsoft.g
 ```
 
 ## Request headers
+
 |Header|Value|
 |:---|:---|
 |Authorization|Bearer &lt;token&gt; Required.|
@@ -113,6 +115,7 @@ If successful, this method returns a `200 OK` response code and an updated [macO
 
 ### Request
 Here is an example of the request.
+
 ``` http
 PATCH https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations/{deviceConfigurationId}
 Content-type: application/json
@@ -294,6 +297,7 @@ Content-length: 5662
 
 ### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+
 ``` http
 HTTP/1.1 200 OK
 Content-Type: application/json

--- a/api-reference/beta/api/intune-shared-devicemanagementderivedcredentialsettings-get.md
+++ b/api-reference/beta/api/intune-shared-devicemanagementderivedcredentialsettings-get.md
@@ -35,6 +35,7 @@ One of the following permissions is required to call this API. To learn more, in
   "blockType": "ignored"
 }
 -->
+
 ``` http
 GET /deviceManagement/derivedCredentials/{deviceManagementDerivedCredentialSettingsId}
 GET /deviceManagement/deviceConfigurations/{deviceConfigurationId}/derivedCredentialSettings
@@ -48,6 +49,7 @@ GET /deviceManagement/deviceConfigurations/{deviceConfigurationId}/microsoft.gra
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
 
 ## Request headers
+
 |Header|Value|
 |:---|:---|
 |Authorization|Bearer &lt;token&gt; Required.|
@@ -63,12 +65,14 @@ If successful, this method returns a `200 OK` response code and [deviceManagemen
 
 ### Request
 Here is an example of the request.
+
 ``` http
 GET https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations/{deviceConfigurationId}/derivedCredentialSettings
 ```
 
 ### Response
 Here is an example of the response. Note: The response object shown here may be truncated for brevity. All of the properties will be returned from an actual call.
+
 ``` http
 HTTP/1.1 200 OK
 Content-Type: application/json
@@ -80,8 +84,4 @@ Content-Length: 155
     "id": "bc650741-0741-bc65-4107-65bc410765bc"
   }
 }
-
-
-
-
-
+```

--- a/api-reference/beta/api/profilephoto-get.md
+++ b/api-reference/beta/api/profilephoto-get.md
@@ -194,23 +194,23 @@ Content-type: application/json
 
 When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. The following JavaScript example shows how to create an array that you can pass as the value of the `Attachments` parameter of an [Outlook message](user-post-messages.md).
 
-      ```javascript
-      const attachments = [{
-        '@odata.type': '#microsoft.graph.fileAttachment',
-        ContentBytes: file.toString('base64'),
-        Name: 'mypic.jpg'
-      }];
-      ```
+```javascript
+const attachments = [{
+  '@odata.type': '#microsoft.graph.fileAttachment',
+  ContentBytes: file.toString('base64'),
+  Name: 'mypic.jpg'
+}];
+```
 
 See the [Microsoft Graph Connect Sample for Node.js](https://github.com/microsoftgraph/nodejs-connect-rest-sample) for an implementation of this example.
 
 If you want to display the image on a web page, create an in-memory object from the image and make that object the source of an image element. Here is an example in JavaScript of this operation.
 
-    ```javascript
-    const url = window.URL || window.webkitURL;
-    const blobUrl = url.createObjectURL(image.data);
-    document.getElementById(imageElement).setAttribute("src", blobUrl);
-    ```
+```javascript
+const url = window.URL || window.webkitURL;
+const blobUrl = url.createObjectURL(image.data);
+document.getElementById(imageElement).setAttribute("src", blobUrl);
+```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/profilephoto-get.md
+++ b/api-reference/beta/api/profilephoto-get.md
@@ -42,6 +42,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ### Get the photo
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photo/$value
 GET /users/{id | userPrincipalName}/photo/$value
@@ -51,8 +52,10 @@ GET /users/{id | userPrincipalName}/contacts/{id}/photo/$value
 GET /me/contactfolders/{contactFolderId}/contacts/{id}/photo/$value
 GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photo/$value
 ```
+
 ### Get the metadata of the photo
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photo
 GET /users/{id | userPrincipalName}/photo
@@ -65,6 +68,7 @@ GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{i
 
 ### Get the metadata for a specific photo size
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photos/{size}
 GET /users/{id | userPrincipalName}/photos/{size}
@@ -103,6 +107,7 @@ If successful, this method returns a `200 OK` response code and a [profilePhoto]
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/beta/me/photo/$value
 Content-Type: image/jpg
@@ -117,6 +122,7 @@ Contains the binary data of the requested photo. The HTTP response code is 200.
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/beta/me/photos/48x48/$value
 Content-Type: image/jpg
@@ -132,6 +138,7 @@ Contains the binary data of the requested 48x48 photo. The HTTP response code is
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/beta/me/photo
 ```
@@ -144,6 +151,7 @@ The following response data shows the photo metadata.
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
@@ -166,6 +174,7 @@ The following response data shows the contents of a response when a photo hasn't
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
@@ -180,23 +189,28 @@ Content-type: application/json
     "height": 1
 }
 ```
+
 ## Using the binary data of the requested photo
 
 When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. The following JavaScript example shows how to create an array that you can pass as the value of the `Attachments` parameter of an [Outlook message](user-post-messages.md).
 
+      ```javascript
       const attachments = [{
         '@odata.type': '#microsoft.graph.fileAttachment',
         ContentBytes: file.toString('base64'),
         Name: 'mypic.jpg'
       }];
+      ```
 
 See the [Microsoft Graph Connect Sample for Node.js](https://github.com/microsoftgraph/nodejs-connect-rest-sample) for an implementation of this example.
 
 If you want to display the image on a web page, create an in-memory object from the image and make that object the source of an image element. Here is an example in JavaScript of this operation.
 
+    ```javascript
     const url = window.URL || window.webkitURL;
     const blobUrl = url.createObjectURL(image.data);
     document.getElementById(imageElement).setAttribute("src", blobUrl);
+    ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/resources/azure-ad-overview.md
+++ b/api-reference/beta/resources/azure-ad-overview.md
@@ -56,7 +56,7 @@ The following table lists some common use cases for Azure AD resources.
 | Invite external (guest) users to an organization. | [invitation](../resources/invitation.md) | [What is Azure AD B2B collaboration?](https://docs.microsoft.com/azure/active-directory/active-directory-b2b-what-is-azure-ad-b2b)|
 | Manage branding for the sign-in experience of an organization. | [organizationalbranding](../resources/organizationalbrandingproperties.md) | [Add branding to your organization's Azure Active Directory sign-in page](https://docs.microsoft.com/azure/active-directory/fundamentals/customize-branding)|
 | **Access reviews** | | |
-| Ensure group memberships and application access rights are correct with access reviews | [access reviews API](../resources/accessreviews-root.md) |[Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) |
+| Ensure group memberships and application access rights are correct with access reviews. | [access reviews API](../resources/accessreviews-root.md) |[Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) |
 
 ## What's new
 Find out about the [latest new features and updates](/graph/whats-new-overview) for this API set.

--- a/api-reference/beta/resources/azure-ad-overview.md
+++ b/api-reference/beta/resources/azure-ad-overview.md
@@ -55,9 +55,7 @@ The following table lists some common use cases for Azure AD resources.
 | Get information about the service SKUs that a company is subscribed to. | [subscribedSku](../resources/subscribedsku.md) | N/A |
 | Invite external (guest) users to an organization. | [invitation](../resources/invitation.md) | [What is Azure AD B2B collaboration?](https://docs.microsoft.com/azure/active-directory/active-directory-b2b-what-is-azure-ad-b2b)|
 | Manage branding for the sign-in experience of an organization. | [organizationalbranding](../resources/organizationalbrandingproperties.md) | [Add branding to your organization's Azure Active Directory sign-in page](https://docs.microsoft.com/azure/active-directory/fundamentals/customize-branding)|
-
-| **Access reviews** | Link 1 | Link 2 |
-| :----------------- | :----- | :----- |
+| **Access reviews** | | |
 | Ensure group memberships and application access rights are correct with access reviews | [access reviews API](../resources/accessreviews-root.md) |[Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) |
 
 ## What's new

--- a/api-reference/beta/resources/azure-ad-overview.md
+++ b/api-reference/beta/resources/azure-ad-overview.md
@@ -56,7 +56,8 @@ The following table lists some common use cases for Azure AD resources.
 | Invite external (guest) users to an organization. | [invitation](../resources/invitation.md) | [What is Azure AD B2B collaboration?](https://docs.microsoft.com/azure/active-directory/active-directory-b2b-what-is-azure-ad-b2b)|
 | Manage branding for the sign-in experience of an organization. | [organizationalbranding](../resources/organizationalbrandingproperties.md) | [Add branding to your organization's Azure Active Directory sign-in page](https://docs.microsoft.com/azure/active-directory/fundamentals/customize-branding)|
 
-| **Access reviews** | | |
+| **Access reviews** | Link 1 | Link 2 |
+| :----------------- | :----- | :----- |
 | Ensure group memberships and application access rights are correct with access reviews | [access reviews API](../resources/accessreviews-root.md) |[Azure AD access reviews](/azure/active-directory/active-directory-azure-ad-controls-access-reviews-overview) |
 
 ## What's new

--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -38,6 +38,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ### Get the photo
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photo/$value
 GET /users/{id | userPrincipalName}/photo/$value
@@ -47,8 +48,10 @@ GET /users/{id | userPrincipalName}/contacts/{id}/photo/$value
 GET /me/contactfolders/{contactFolderId}/contacts/{id}/photo/$value
 GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{id}/photo/$value
 ```
+
 ### Get the metadata of the photo
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photo
 GET /me/photos
@@ -62,6 +65,7 @@ GET /users/{id | userPrincipalName}/contactfolders/{contactFolderId}/contacts/{i
 
 ### Get the metadata for a specific photo size
 <!-- { "blockType": "ignored" } -->
+
 ```http
 GET /me/photos/{size}
 GET /users/{id | userPrincipalName}/photos/{size}
@@ -78,6 +82,7 @@ GET /groups/{id}/photos/{size}
 This method supports the [OData query parameters](/graph/query-parameters) to help customize the response.
 
 ## Request headers
+
 | Name       | Type | Description|
 |:-----------|:------|:----------|
 | Authorization  | string  | Bearer {token}. Required. |
@@ -97,6 +102,7 @@ If successful, this method returns a `200 OK` response code and [profilePhoto](.
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/v1.0/me/photo/$value
 ```
@@ -109,6 +115,7 @@ Contains the binary data of the requested photo. The HTTP response code is 200.
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/v1.0/me/photos/48x48/$value
 Content-Type: image/jpg
@@ -122,6 +129,7 @@ Contains the binary data of the requested 48x48 photo. The HTTP response code is
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 GET https://graph.microsoft.com/v1.0/me/photo
 ```
@@ -134,6 +142,7 @@ The following response data shows the photo metadata.
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
@@ -156,6 +165,7 @@ The following response data shows the contents of a response when a photo hasn't
 <!-- {
   "blockType": "ignored"
 }-->
+
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
@@ -170,23 +180,28 @@ Content-type: application/json
     "height": 1
 }
 ```
+
 ## Using the binary data of the requested photo
 
 When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. Here is an example in JavaScript of how to create an array that you can pass as the value of the `Attachments` parameter of an [Outlook Message](user-post-messages.md).
 
+      ```java
       const attachments = [{
         '@odata.type': '#microsoft.graph.fileAttachment',
         ContentBytes: file.toString('base64'),
         Name: 'mypic.jpg'
       }];
+     ```
 
 See the [Microsoft Graph Connect Sample for Node.js](https://github.com/microsoftgraph/nodejs-connect-rest-sample) for an implementation of this example.
 
 If you want to display the image on a web page, create an in-memory object from the image and make that object the source of an image element. Here is an example in JavaScript of this operation.
 
+    ```javascript
     const url = window.URL || window.webkitURL;
     const blobUrl = url.createObjectURL(image.data);
     document.getElementById(imageElement).setAttribute("src", blobUrl);
+    ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -185,23 +185,23 @@ Content-type: application/json
 
 When you use the `/photo/$value` endpoint to get the binary data for a profile photo, you'll need to convert the data into a base-64 string in order to add it as an email attachment. Here is an example in JavaScript of how to create an array that you can pass as the value of the `Attachments` parameter of an [Outlook Message](user-post-messages.md).
 
-      ```java
-      const attachments = [{
-        '@odata.type': '#microsoft.graph.fileAttachment',
-        ContentBytes: file.toString('base64'),
-        Name: 'mypic.jpg'
-      }];
-     ```
+```java
+const attachments = [{
+  '@odata.type': '#microsoft.graph.fileAttachment',
+  ContentBytes: file.toString('base64'),
+  Name: 'mypic.jpg'
+}];
+```
 
 See the [Microsoft Graph Connect Sample for Node.js](https://github.com/microsoftgraph/nodejs-connect-rest-sample) for an implementation of this example.
 
 If you want to display the image on a web page, create an in-memory object from the image and make that object the source of an image element. Here is an example in JavaScript of this operation.
 
-    ```javascript
-    const url = window.URL || window.webkitURL;
-    const blobUrl = url.createObjectURL(image.data);
-    document.getElementById(imageElement).setAttribute("src", blobUrl);
-    ```
+```javascript
+const url = window.URL || window.webkitURL;
+const blobUrl = url.createObjectURL(image.data);
+document.getElementById(imageElement).setAttribute("src", blobUrl);
+```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->


### PR DESCRIPTION
Messages Fixing: 'code-block-*', 'table-syntax-invalid'. Worse remain.

I am just helping the Microsoft Graph team by fixing some of there messages for them.

At a minimum, the following types of Suggestion/Warning messages remain to be fixed by `MsGraphDocsVTeam`:

- bookmark-not-found
- invalid-tab-group
- link-out-of-scope
- moniker-range-undefined
- redirect-url-invalid

GeneMi (= MightyPen)
