### PR TITLE
Update POST responses to 201 Created

### DIFF
--- a/api-reference/beta/api/serviceprincipal-post-approleassignedto.md
+++ b/api-reference/beta/api/serviceprincipal-post-approleassignedto.md
@@ -113,7 +113,7 @@ Here is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 Content-length: 253
 

--- a/api-reference/beta/api/serviceprincipal-post-approleassignments.md
+++ b/api-reference/beta/api/serviceprincipal-post-approleassignments.md
@@ -116,7 +116,7 @@ Here is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 Content-length: 253
 

--- a/api-reference/beta/api/serviceprincipal-post-delegatedpermissionclassifications.md
+++ b/api-reference/beta/api/serviceprincipal-post-delegatedpermissionclassifications.md
@@ -101,7 +101,7 @@ The following is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 
 {

--- a/api-reference/v1.0/api/serviceprincipal-post-approleassignedto.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-approleassignedto.md
@@ -112,7 +112,7 @@ Here is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 Content-length: 253
 

--- a/api-reference/v1.0/api/serviceprincipal-post-approleassignments.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-approleassignments.md
@@ -115,7 +115,7 @@ Here is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 Content-length: 253
 

--- a/api-reference/v1.0/api/serviceprincipal-post-delegatedpermissionclassifications.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-delegatedpermissionclassifications.md
@@ -99,7 +99,7 @@ The following is an example of the response.
 } -->
 
 ```http
-HTTP/1.1 200 OK
+HTTP/1.1 201 Created
 Content-type: application/json
 
 {


### PR DESCRIPTION
Fix #10179 - The POST examples return a `201 Created`, not `200 OK`.