### PR TITLE
Fixes HTTP verbs for workbook range functions

### DIFF
--- a/api-reference/beta/api/workbookrange-columnsafter.md
+++ b/api-reference/beta/api/workbookrange-columnsafter.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=n)
 
 ```
 ## Function parameters
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_columnsafter"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
+GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md)]

--- a/api-reference/beta/api/workbookrange-columnsafter.md
+++ b/api-reference/beta/api/workbookrange-columnsafter.md
@@ -59,7 +59,7 @@ Here is an example of the request.
   "blockType": "request",
   "name": "workbookrange_columnsafter"
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/workbookrange-columnsbefore.md
+++ b/api-reference/beta/api/workbookrange-columnsbefore.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=n)
 
 ```
 
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_columnsbefore"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
+GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md)]

--- a/api-reference/beta/api/workbookrange-columnsbefore.md
+++ b/api-reference/beta/api/workbookrange-columnsbefore.md
@@ -59,7 +59,7 @@ Here is an example of the request.
   "blockType": "request",
   "name": "workbookrange_columnsbefore"
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/workbookrange-rowsabove.md
+++ b/api-reference/beta/api/workbookrange-rowsabove.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "blockType": "request",
   "name": "workbookrange_rowsAbove"
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/workbookrange-rowsabove.md
+++ b/api-reference/beta/api/workbookrange-rowsabove.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "name": "workbookrange_rowsAbove"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
+GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md)]

--- a/api-reference/beta/api/workbookrange-rowsbelow.md
+++ b/api-reference/beta/api/workbookrange-rowsbelow.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "blockType": "request",
   "name": "workbookrange_rowsBelow"
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/beta/api/workbookrange-rowsbelow.md
+++ b/api-reference/beta/api/workbookrange-rowsbelow.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "name": "workbookrange_rowsBelow"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
+GET https://graph.microsoft.com/beta/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md)]

--- a/api-reference/beta/includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.ColumnsAfter(null)
+	.ColumnsAfter(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/beta/includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.ColumnsBefore(null)
+	.ColumnsBefore(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/beta/includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.RowsAbove(null)
+	.RowsAbove(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/beta/includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md
+++ b/api-reference/beta/includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.RowsBelow(null)
+	.RowsBelow(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/beta/includes/snippets/java/workbookrange-columnsafter-java-snippets.md
+++ b/api-reference/beta/includes/snippets/java/workbookrange-columnsafter-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.drive().root().workbook().worksheets("{id}")
 	.range()
-	.columnsAfter(null)
+	.columnsAfter(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/java/workbookrange-columnsbefore-java-snippets.md
+++ b/api-reference/beta/includes/snippets/java/workbookrange-columnsbefore-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.drive().root().workbook().worksheets("{id}")
 	.range()
-	.columnsBefore(null)
+	.columnsBefore(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/java/workbookrange-rowsabove-java-snippets.md
+++ b/api-reference/beta/includes/snippets/java/workbookrange-rowsabove-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.drive().root().workbook().worksheets("{id}")
 	.range()
-	.rowsAbove(null)
+	.rowsAbove(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/java/workbookrange-rowsbelow-java-snippets.md
+++ b/api-reference/beta/includes/snippets/java/workbookrange-rowsbelow-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.drive().root().workbook().worksheets("{id}")
 	.range()
-	.rowsBelow(null)
+	.rowsBelow(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/javascript/workbookrange-columnsafter-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/workbookrange-columnsafter-javascript-snippets.md
@@ -12,6 +12,6 @@ const client = Client.init(options);
 
 let res = await client.api('/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)')
 	.version('beta')
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/javascript/workbookrange-columnsbefore-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/workbookrange-columnsbefore-javascript-snippets.md
@@ -12,6 +12,6 @@ const client = Client.init(options);
 
 let res = await client.api('/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)')
 	.version('beta')
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/javascript/workbookrange-rowsabove-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/workbookrange-rowsabove-javascript-snippets.md
@@ -12,6 +12,6 @@ const client = Client.init(options);
 
 let res = await client.api('/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)')
 	.version('beta')
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/javascript/workbookrange-rowsbelow-javascript-snippets.md
+++ b/api-reference/beta/includes/snippets/javascript/workbookrange-rowsbelow-javascript-snippets.md
@@ -12,6 +12,6 @@ const client = Client.init(options);
 
 let res = await client.api('/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)')
 	.version('beta')
-	.post();
+	.get();
 
 ```

--- a/api-reference/beta/includes/snippets/objc/workbookrange-columnsafter-objc-snippets.md
+++ b/api-reference/beta/includes/snippets/objc/workbookrange-columnsafter-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/beta/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/beta/includes/snippets/objc/workbookrange-columnsbefore-objc-snippets.md
+++ b/api-reference/beta/includes/snippets/objc/workbookrange-columnsbefore-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/beta/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/beta/includes/snippets/objc/workbookrange-rowsabove-objc-snippets.md
+++ b/api-reference/beta/includes/snippets/objc/workbookrange-rowsabove-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/beta/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/beta/includes/snippets/objc/workbookrange-rowsbelow-objc-snippets.md
+++ b/api-reference/beta/includes/snippets/objc/workbookrange-rowsbelow-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/beta/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/v1.0/api/workbookrange-columnsafter.md
+++ b/api-reference/v1.0/api/workbookrange-columnsafter.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "idempotent": true
 }-->
 ```http
-POST https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
+GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookrange-columnsafter.md
+++ b/api-reference/v1.0/api/workbookrange-columnsafter.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_columnsafter",
   "idempotent": true
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/workbookrange-columnsbefore.md
+++ b/api-reference/v1.0/api/workbookrange-columnsbefore.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_columnsbefore",
   "idempotent": true
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/workbookrange-columnsbefore.md
+++ b/api-reference/v1.0/api/workbookrange-columnsbefore.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "idempotent": true
 }-->
 ```http
-POST https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
+GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookrange-rowsabove.md
+++ b/api-reference/v1.0/api/workbookrange-rowsabove.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "idempotent": true
 }-->
 ```http
-POST https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
+GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md)]
@@ -117,7 +117,7 @@ If called without the optional `count` parameter, this function returns the sing
   "idempotent": true
 }-->
 ```http
-POST https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove
+GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-rowsabove-nocount-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookrange-rowsabove.md
+++ b/api-reference/v1.0/api/workbookrange-rowsabove.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_rowsAbove",
   "idempotent": true
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)
 ```
 # [C#](#tab/csharp)
@@ -116,7 +116,7 @@ If called without the optional `count` parameter, this function returns the sing
   "name": "workbookrange_rowsAbove_nocount",
   "idempotent": true
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsAbove
 ```
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/workbookrange-rowsbelow.md
+++ b/api-reference/v1.0/api/workbookrange-rowsbelow.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 <!-- { "blockType": "ignored" } -->
 ```http
-POST /me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=n)
+GET /me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=n)
 
 ```
 
@@ -61,7 +61,7 @@ Here is an example of the request.
   "idempotent": true
 }-->
 ```http
-POST https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
+GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md)]

--- a/api-reference/v1.0/api/workbookrange-rowsbelow.md
+++ b/api-reference/v1.0/api/workbookrange-rowsbelow.md
@@ -60,7 +60,7 @@ Here is an example of the request.
   "name": "workbookrange_rowsBelow",
   "idempotent": true
 }-->
-```http
+```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)
 ```
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/workbookrange-columnsafter-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.ColumnsAfter(null)
+	.ColumnsAfter(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/v1.0/includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/workbookrange-columnsbefore-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.ColumnsBefore(null)
+	.ColumnsBefore(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsabove-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.RowsAbove(null)
+	.RowsAbove(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsabove-nocount-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsabove-nocount-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
 	.RowsAbove()
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/workbookrange-rowsbelow-csharp-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
-await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
+var workbookRange = await graphClient.Me.Drive.Root.Workbook.Worksheets["{id}"]
 	.Range()
-	.RowsBelow(null)
+	.RowsBelow(2)
 	.Request()
-	.PostAsync();
+	.GetAsync();
 
 ```

--- a/api-reference/v1.0/includes/snippets/java/workbookrange-columnsafter-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/workbookrange-columnsafter-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.me().drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.me().drive().root().workbook().worksheets("{id}")
 	.range()
-	.columnsAfter(null)
+	.columnsAfter(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/java/workbookrange-columnsbefore-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/workbookrange-columnsbefore-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.me().drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.me().drive().root().workbook().worksheets("{id}")
 	.range()
-	.columnsBefore(null)
+	.columnsBefore(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/java/workbookrange-rowsabove-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/workbookrange-rowsabove-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.me().drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.me().drive().root().workbook().worksheets("{id}")
 	.range()
-	.rowsAbove(null)
+	.rowsAbove(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/java/workbookrange-rowsabove-nocount-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/workbookrange-rowsabove-nocount-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.me().drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.me().drive().root().workbook().worksheets("{id}")
 	.range()
 	.rowsAbove()
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/java/workbookrange-rowsbelow-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/workbookrange-rowsbelow-java-snippets.md
@@ -6,10 +6,10 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationProvider( authProvider ).buildClient();
 
-graphClient.me().drive().root().workbook().worksheets("{id}")
+WorkbookRange workbookRange = graphClient.me().drive().root().workbook().worksheets("{id}")
 	.range()
-	.rowsBelow(null)
+	.rowsBelow(2)
 	.buildRequest()
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/javascript/workbookrange-columnsafter-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/workbookrange-columnsafter-javascript-snippets.md
@@ -11,6 +11,6 @@ const options = {
 const client = Client.init(options);
 
 let res = await client.api('/me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)')
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/javascript/workbookrange-columnsbefore-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/workbookrange-columnsbefore-javascript-snippets.md
@@ -11,6 +11,6 @@ const options = {
 const client = Client.init(options);
 
 let res = await client.api('/me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)')
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsabove-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsabove-javascript-snippets.md
@@ -11,6 +11,6 @@ const options = {
 const client = Client.init(options);
 
 let res = await client.api('/me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)')
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsabove-nocount-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsabove-nocount-javascript-snippets.md
@@ -11,6 +11,6 @@ const options = {
 const client = Client.init(options);
 
 let res = await client.api('/me/drive/root/workbook/worksheets/{id}/range/rowsAbove')
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsbelow-javascript-snippets.md
+++ b/api-reference/v1.0/includes/snippets/javascript/workbookrange-rowsbelow-javascript-snippets.md
@@ -11,6 +11,6 @@ const options = {
 const client = Client.init(options);
 
 let res = await client.api('/me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)')
-	.post();
+	.get();
 
 ```

--- a/api-reference/v1.0/includes/snippets/objc/workbookrange-columnsafter-objc-snippets.md
+++ b/api-reference/v1.0/includes/snippets/objc/workbookrange-columnsafter-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/v1.0/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/me/drive/root/workbook/worksheets/{id}/range/columnsAfter(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/v1.0/includes/snippets/objc/workbookrange-columnsbefore-objc-snippets.md
+++ b/api-reference/v1.0/includes/snippets/objc/workbookrange-columnsbefore-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/v1.0/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/me/drive/root/workbook/worksheets/{id}/range/columnsBefore(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsabove-nocount-objc-snippets.md
+++ b/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsabove-nocount-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/v1.0/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/me/drive/root/workbook/worksheets/{id}/range/rowsAbove"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsabove-objc-snippets.md
+++ b/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsabove-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/v1.0/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/me/drive/root/workbook/worksheets/{id}/range/rowsAbove(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 

--- a/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsbelow-objc-snippets.md
+++ b/api-reference/v1.0/includes/snippets/objc/workbookrange-rowsbelow-objc-snippets.md
@@ -8,12 +8,12 @@ MSHTTPClient *httpClient = [MSClientFactory createHTTPClientWithAuthenticationPr
 
 NSString *MSGraphBaseURL = @"https://graph.microsoft.com/v1.0/";
 NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:[MSGraphBaseURL stringByAppendingString:@"/me/drive/root/workbook/worksheets/{id}/range/rowsBelow(count=2)"]]];
-[urlRequest setHTTPMethod:@"POST"];
+[urlRequest setHTTPMethod:@"GET"];
 
 MSURLSessionDataTask *meDataTask = [httpClient dataTaskWithRequest:urlRequest 
 	completionHandler: ^(NSData *data, NSURLResponse *response, NSError *nserror) {
 
-		//Request Completed
+		MSGraphWorkbookRange *workbookRange = [[MSGraphWorkbookRange alloc] initWithData:data error:&nserror];
 
 }];
 


### PR DESCRIPTION
- Fixed workbook range functions to use GET to get ranges.
- Regenerated language snippets

- This fixes 4 Beta and 4 V1 C# tests for Raptor.