### PR TITLE
Adding new columns to getSharePointSiteUsageDetail api

### DIFF
--- a/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
+++ b/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
@@ -81,6 +81,10 @@ The CSV file has the following headers for columns:
 - Active File Count
 - Page View Count
 - Visited Page Count
+- Anonymous Link Count
+- Company Link Count
+- Secure Link For Guest Count
+- Secure Link For Member Count
 - Storage Used (Byte)
 - Storage Allocated (Byte)
 - Root Web Template

--- a/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
+++ b/api-reference/beta/api/reportroot-getsharepointsiteusagedetail.md
@@ -73,6 +73,10 @@ The CSV file has the following headers for columns:
 - Owner Display Name
 - Is Deleted
 - Last Activity Date
+- Site Sensitivity Label Id
+- External Sharing
+- Unmanaged Device Policy
+- Geo Location
 - File Count
 - Active File Count
 - Page View Count
@@ -134,7 +138,7 @@ Follow the 302 redirection and the CSV file that downloads will have the followi
 HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 
-Report Refresh Date,Site Id,Site URL,Owner Display Name,Is Deleted,Last Activity Date,File Count,Active File Count,Page View Count,Visited Page Count,Storage Used (Byte),Storage Allocated (Byte),Root Web Template,Owner Principal Name,Report Period
+Report Refresh Date,Site Id,Site URL,Owner Display Name,Is Deleted,Last Activity Date,Site Sensitivity Label Id,External Sharing,Unmanaged Device Policy,Geo Location,File Count,Active File Count,Page View Count,Visited Page Count,Anonymous Link Count,Company Link Count,Secure Link For Guest Count,Secure Link For Member Count,Storage Used (Byte),Storage Allocated (Byte),Root Web Template,Owner Principal Name,Report Period
 ```
 
 ### JSON
@@ -184,10 +188,18 @@ Content-Length: 484
       "ownerPrincipalName": "ownerPrincipalName-value", 
       "isDeleted": false, 
       "lastActivityDate": "2017-09-01", 
+      "SiteSensitivityLabelId": "SiteSensitivityLabelId-value",
+      "ExternalSharing": false,
+      "UnmanagedDevicePolicy": "UnmanagedDevicePolicy-value",
+      "GeoLocation": "GeoLocation-value",
       "fileCount": 170, 
       "activeFileCount": 25, 
       "pageViewCount": 7, 
       "visitedPageCount": 3, 
+      "AnonymousLinkCount": 5,
+      "CompanyLinkCount": 8,
+      "SecureLinkForGuestCount": 13,
+      "SecureLinkForMemberCount": 11,
       "storageUsedInBytes": 63442116, 
       "storageAllocatedInBytes": 2748779094400, 
       "rootWebTemplate": "Publishing Site", 

--- a/api-reference/beta/resources/sharepointsiteusagedetail.md
+++ b/api-reference/beta/resources/sharepointsiteusagedetail.md
@@ -59,7 +59,7 @@ The following is a JSON representation of the resource.
   "lastActivityDate": "Date",
   "lastActivityDate": "2017-09-01", 
   "SiteSensitivityLabelId": "String",
-  "ExternalSharing": false,
+  "ExternalSharing": true,
   "UnmanagedDevicePolicy": "String",
   "GeoLocation": "String",
   "fileCount": 1024,

--- a/api-reference/beta/resources/sharepointsiteusagedetail.md
+++ b/api-reference/beta/resources/sharepointsiteusagedetail.md
@@ -23,7 +23,7 @@ Namespace: microsoft.graph
 | isDeleted               | Boolean |
 | lastActivityDate        | Date    |
 | SiteSensitivityLabelId  | String  |
-| ExternalSharing         | String  |
+| ExternalSharing         | Boolean |
 | UnmanagedDevicePolicy   | String  |
 | GeoLocation             | String  |
 | fileCount               | Int64   |

--- a/api-reference/beta/resources/sharepointsiteusagedetail.md
+++ b/api-reference/beta/resources/sharepointsiteusagedetail.md
@@ -22,10 +22,18 @@ Namespace: microsoft.graph
 | ownerPrincipalName      | String  |
 | isDeleted               | Boolean |
 | lastActivityDate        | Date    |
+| SiteSensitivityLabelId  | String  |
+| ExternalSharing         | String  |
+| UnmanagedDevicePolicy   | String  |
+| GeoLocation             | String  |
 | fileCount               | Int64   |
 | activeFileCount         | Int64   |
 | pageViewCount           | Int64   |
 | visitedPageCount        | Int64   |
+| AnonymousLinkCount      | Int64   |
+| CompanyLinkCount        | Int64   |
+| SecureLinkForGuestCount | Int64   |
+| SecureLinkForMemberCount| Int64   |
 | storageUsedInBytes      | Int64   |
 | storageAllocatedInBytes | Int64   |
 | rootWebTemplate         | String  |
@@ -49,10 +57,19 @@ The following is a JSON representation of the resource.
   "ownerPrincipalName": "String",
   "isDeleted": true,
   "lastActivityDate": "Date",
+  "lastActivityDate": "2017-09-01", 
+  "SiteSensitivityLabelId": "String",
+  "ExternalSharing": false,
+  "UnmanagedDevicePolicy": "String",
+  "GeoLocation": "String",
   "fileCount": 1024,
   "activeFileCount": 1024,
   "pageViewCount": 1024,
   "visitedPageCount": 1024,
+  "AnonymousLinkCount": 5,
+  "CompanyLinkCount": 8,
+  "SecureLinkForGuestCount": 13,
+  "SecureLinkForMemberCount": 11,
   "storageUsedInBytes": 1024,
   "storageAllocatedInBytes": 1024,
   "rootWebTemplate": "String",

--- a/changelog/Microsoft.O365Reporting.json
+++ b/changelog/Microsoft.O365Reporting.json
@@ -1,0 +1,78 @@
+{
+  "changelog": [
+    {
+      "ChangeList": [
+        {
+          "Id": "e793c5e3-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "siteSensitivityLabelId",
+          "ChangeType": "Addition",
+          "Description": "Added the **siteSensitivityLabelId** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e79628b9-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "externalSharing",
+          "ChangeType": "Addition",
+          "Description": "Added the **externalSharing** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e7988a6d-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "unmanagedDevicePolicy",
+          "ChangeType": "Addition",
+          "Description": "Added the **unmanagedDevicePolicy** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e79aecbf-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "geolocation",
+          "ChangeType": "Addition",
+          "Description": "Added the **geolocation** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e79d5001-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "anonymousLinkCount",
+          "ChangeType": "Addition",
+          "Description": "Added the **anonymousLinkCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e79fb1a8-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "companyLinkCount",
+          "ChangeType": "Addition",
+          "Description": "Added the **companyLinkCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e7a2132c-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "secureLinkForGuestCount",
+          "ChangeType": "Addition",
+          "Description": "Added the **secureLinkForGuestCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        },
+        {
+          "Id": "e7a48071-5c97-11eb-8de9-f7f8b8b7f046",
+          "ApiChange": "Property",
+          "ChangedApiName": "secureLinkForMemberCount",
+          "ChangeType": "Addition",
+          "Description": "Added the **secureLinkForMemberCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Target": "sharePointSiteUsageDetail"
+        }
+      ],
+      "Id": "e7916352-5c97-11eb-8de9-f7f8b8b7f046",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2021-01-22T09:55:05.981Z",
+      "WorkloadArea": "Reports and audit",
+      "SubArea": "Microsoft 365 usage reports"
+    }
+  ]
+}

--- a/changelog/Microsoft.O365Reporting.json
+++ b/changelog/Microsoft.O365Reporting.json
@@ -71,7 +71,7 @@
       "Cloud": "prd",
       "Version": "beta",
       "CreatedDateTime": "2021-01-22T09:55:05.981Z",
-      "WorkloadArea": "Reports and audit",
+      "WorkloadArea": "Reports",
       "SubArea": "Microsoft 365 usage reports"
     }
   ]

--- a/changelog/Microsoft.O365Reporting.json
+++ b/changelog/Microsoft.O365Reporting.json
@@ -7,7 +7,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "siteSensitivityLabelId",
           "ChangeType": "Addition",
-          "Description": "Added the **siteSensitivityLabelId** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **siteSensitivityLabelId** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -15,7 +15,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "externalSharing",
           "ChangeType": "Addition",
-          "Description": "Added the **externalSharing** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **externalSharing** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -23,7 +23,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "unmanagedDevicePolicy",
           "ChangeType": "Addition",
-          "Description": "Added the **unmanagedDevicePolicy** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **unmanagedDevicePolicy** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -31,7 +31,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "geolocation",
           "ChangeType": "Addition",
-          "Description": "Added the **geolocation** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **geolocation** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -39,7 +39,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "anonymousLinkCount",
           "ChangeType": "Addition",
-          "Description": "Added the **anonymousLinkCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **anonymousLinkCount** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -47,7 +47,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "companyLinkCount",
           "ChangeType": "Addition",
-          "Description": "Added the **companyLinkCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **companyLinkCount** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -55,7 +55,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "secureLinkForGuestCount",
           "ChangeType": "Addition",
-          "Description": "Added the **secureLinkForGuestCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **secureLinkForGuestCount** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         },
         {
@@ -63,14 +63,14 @@
           "ApiChange": "Property",
           "ChangedApiName": "secureLinkForMemberCount",
           "ChangeType": "Addition",
-          "Description": "Added the **secureLinkForMemberCount** property to [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource",
+          "Description": "Added the **secureLinkForMemberCount** property to the [sharePointSiteUsageDetail](https://docs.microsoft.com/en-us/graph/api/resources/sharePointSiteUsageDetail?view=graph-rest-beta) resource.",
           "Target": "sharePointSiteUsageDetail"
         }
       ],
       "Id": "e7916352-5c97-11eb-8de9-f7f8b8b7f046",
       "Cloud": "prd",
       "Version": "beta",
-      "CreatedDateTime": "2021-01-22T09:55:05.981Z",
+      "CreatedDateTime": "2021-02-04T09:55:05.981Z",
       "WorkloadArea": "Reports",
       "SubArea": "Microsoft 365 usage reports"
     }


### PR DESCRIPTION
Publishing date - Feb 2nd week.
Adding below columns to the existing api
     
-       siteSensitivityLabelId Edm.String
-       externalSharing Edm.Boolean
-       unmanagedDevicePolicy Edm.String
-       geolocation Edm.String
-       anonymousLinkCount Edm.Int64
-       companyLinkCount Edm.Int64
-       secureLinkForGuestCount Edm.Int64
-       secureLinkForMemberCount Edm.Int64

graph api approval - Completed

https://microsoftgraph.visualstudio.com/onboarding/_git/onboarding/pullrequest/6385?_a=files

Schema approval - Active

https://microsoftgraph.visualstudio.com/onboarding/_git/AGS-OnboardingAutomationPipeline/pullrequest/7114