### PR TITLE
id of a WorkbookTableColumn object should be string

### DIFF
--- a/api-reference/beta/api/table-list-columns.md
+++ b/api-reference/beta/api/table-list-columns.md
@@ -90,7 +90,7 @@ Content-length: 126
 {
   "value": [
     {
-      "id": 99,
+      "id": "99",
       "name": "name-value",
       "index": 99,
       "values": "values-value"

--- a/api-reference/beta/api/table-post-columns.md
+++ b/api-reference/beta/api/table-post-columns.md
@@ -96,7 +96,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/api/table-post-columns.md
+++ b/api-reference/beta/api/table-post-columns.md
@@ -58,7 +58,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/api/tablecolumn-get.md
+++ b/api-reference/beta/api/tablecolumn-get.md
@@ -87,7 +87,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/api/tablecolumn-list.md
+++ b/api-reference/beta/api/tablecolumn-list.md
@@ -90,7 +90,7 @@ Content-length: 126
 {
   "value": [
     {
-      "id": 99,
+      "id": "99",
       "name": "name-value",
       "index": 99,
       "values": "values-value"

--- a/api-reference/beta/api/tablecolumn-update.md
+++ b/api-reference/beta/api/tablecolumn-update.md
@@ -99,7 +99,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/api/tablecolumncollection-add.md
+++ b/api-reference/beta/api/tablecolumncollection-add.md
@@ -104,7 +104,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/api/tablecolumncollection-itemat.md
+++ b/api-reference/beta/api/tablecolumncollection-itemat.md
@@ -91,7 +91,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/beta/resources/workbooktablecolumn.md
+++ b/api-reference/beta/resources/workbooktablecolumn.md
@@ -34,7 +34,7 @@ Represents a column in a table.
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|id|int|Returns a unique key that identifies the column within the table. Read-only.|
+|id|string|Returns a unique key that identifies the column within the table. Read-only.|
 |index|int|Returns the index number of the column within the columns collection of the table. Zero-indexed. Read-only.|
 |name|string|Returns the name of the table column.|
 |values|Json|Represents the raw values of the specified range. The data returned could be of type string, number, or a boolean. Cell that contain an error will return the error string.|
@@ -60,7 +60,7 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "id": 1024,
+  "id": "1024",
   "index": 1024,
   "name": "string",
   "values": "json"

--- a/api-reference/v1.0/api/table-list-columns.md
+++ b/api-reference/v1.0/api/table-list-columns.md
@@ -88,7 +88,7 @@ Content-length: 126
 {
   "value": [
     {
-      "id": 99,
+      "id": "99",
       "name": "name-value",
       "index": 99,
       "values": "values-value"

--- a/api-reference/v1.0/api/table-post-columns.md
+++ b/api-reference/v1.0/api/table-post-columns.md
@@ -56,7 +56,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/api/table-post-columns.md
+++ b/api-reference/v1.0/api/table-post-columns.md
@@ -94,7 +94,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/api/tablecolumn-get.md
+++ b/api-reference/v1.0/api/tablecolumn-get.md
@@ -85,7 +85,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/api/tablecolumn-list.md
+++ b/api-reference/v1.0/api/tablecolumn-list.md
@@ -88,7 +88,7 @@ Content-length: 126
 {
   "value": [
     {
-      "id": 99,
+      "id": "99",
       "name": "name-value",
       "index": 99,
       "values": "values-value"

--- a/api-reference/v1.0/api/tablecolumn-update.md
+++ b/api-reference/v1.0/api/tablecolumn-update.md
@@ -96,7 +96,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/api/tablecolumncollection-add.md
+++ b/api-reference/v1.0/api/tablecolumncollection-add.md
@@ -101,7 +101,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/api/tablecolumncollection-itemat.md
+++ b/api-reference/v1.0/api/tablecolumncollection-itemat.md
@@ -92,7 +92,7 @@ Content-type: application/json
 Content-length: 81
 
 {
-  "id": 99,
+  "id": "99",
   "name": "name-value",
   "index": 99,
   "values": "values-value"

--- a/api-reference/v1.0/resources/workbooktablecolumn.md
+++ b/api-reference/v1.0/resources/workbooktablecolumn.md
@@ -56,7 +56,7 @@ Here is a JSON representation of the resource.
 
 ```json
 {
-  "id": 1024,
+  "id": "1024",
   "index": 1024,
   "name": "string",
   "values": "json"


### PR DESCRIPTION
`workbookTableColumn` inherits `id` property from `entity` and `entity->id` is of type `string`.