### PR TITLE
Fixing documentation for messaging and activity feed notifications

### DIFF
--- a/api-reference/beta/api/channel-post-message.md
+++ b/api-reference/beta/api/channel-post-message.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Create a new [chatMessage](../resources/chatmessage.md) in the specified [channel](../resources/channel.md).
 
-> **Note**: We don't recommend that you use this API for data migration. It does not have the throughput necessary for a typical migration.
-
 > **Note**: It is a violation of the [terms of use](/legal/microsoft-apis/terms-of-use) to use Microsoft Teams as a log file. Only send messages that people will read.
 
 ## Permissions
@@ -28,6 +26,8 @@ One of the following permissions is required to call this API. To learn more, in
 | Delegated (work or school account)     | ChannelMessage.Send, Group.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Teamwork.Migrate.All |
+
+> **Note**: Application permissions are *only* supported for [migration](/microsoftteams/platform/graph-api/import-messages/import-external-messages-to-teams).
 
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD001 -->

--- a/api-reference/beta/api/channel-post-messagereply.md
+++ b/api-reference/beta/api/channel-post-messagereply.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Create a new reply to a [chatMessage](../resources/chatmessage.md) in a specified [channel](../resources/channel.md).
 
-> **Note**: We don't recommend that you use this API for data migration. It does not have the throughput necessary for a typical migration.
-
 > **Note**: It is a violation of the [terms of use](/legal/microsoft-apis/terms-of-use) to use Microsoft Teams as a log file. Only send messages that people will read.
 <!-- markdownlint-disable MD024 -->
 <!-- markdownlint-disable MD022 -->
@@ -26,11 +24,13 @@ Create a new reply to a [chatMessage](../resources/chatmessage.md) in a specifie
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-|Permission type      | Permissions (from least to most privileged)              |
-|:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | ChannelMessage.Send, Group.ReadWrite.All |
-|Delegated (personal Microsoft account) | Not supported.    |
-|Application | Teamwork.Migrate.All |
+| Permission type                        | Permissions (from least to most privileged) |
+|:---------------------------------------|:--------------------------------------------|
+| Delegated (work or school account)     | ChannelMessage.Send, Group.ReadWrite.All |
+| Delegated (personal Microsoft account) | Not supported. |
+| Application                            | Teamwork.Migrate.All |
+
+> **Note**: Application permissions are *only* supported for [migration](/microsoftteams/platform/graph-api/import-messages/import-external-messages-to-teams).
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/team-post.md
+++ b/api-reference/beta/api/team-post.md
@@ -25,6 +25,8 @@ One of the following permissions is required to call this API. To learn more, in
 | Delegated (personal Microsoft account) | Not supported.                              |
 | Application                            | Team.Create, Teamwork.Migrate.All, Group.ReadWrite.All, Directory.ReadWrite.All |
 
+> **Note**: Teamwork.Migrate.All permission is *only* supported for [migration](/microsoftteams/platform/graph-api/import-messages/import-external-messages-to-teams).
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->
@@ -586,6 +588,8 @@ Content-Length: 0
 #### Request
 
 The following example shows how to create a team for imported messages.
+
+**Teams created in migration mode only support `standard` template.**
 
 ```http
 POST https://graph.microsoft.com/beta/teams

--- a/concepts/teams-changenotifications-chatmessage.md
+++ b/concepts/teams-changenotifications-chatmessage.md
@@ -254,11 +254,11 @@ Content-Type: application/json
 
 ## What should you expect in the notification
 
-Depending on your subscription, you can either get the notification with resource data, or without it. Subscribing with resource data allows you to get the message payload along with the notification, thus removing the need to call back and get the content.
+Depending on your subscription, you can either get the notification with resource data, or without it. Subscribing with resource data allows you to get the message payload along with the notification, removing the need to call back and get the content.
 
 ### Notifications with resource data
 
-For notifications with resource data, the payload looks like the following. The payload below is for a message sent in a chat
+For notifications with resource data, the payload looks like the following. This payload is for a message sent in a chat.
 
 ```json
 {
@@ -285,9 +285,9 @@ For notifications with resource data, the payload looks like the following. The 
 }
 ```
 
-For specifics on how to validate tokens and decrypt the payload, refer to [notifications with resource data documentation](webhooks-with-resource-data.md).
+For details about how to validate tokens and decrypt the payload, see [Set up change notifications that include resource data](webhooks-with-resource-data.md).
 
-The decrypted notification payload looks like the following. The payload abide by [chatMessage](/graph/api/resources/chatMessage?preserve-view=true) schema. The payload will be similar to to what one would get from GET APIs
+The decrypted notification payload looks like the following. The payload conforms to the [chatMessage](/graph/api/resources/chatMessage?preserve-view=true) schema. The payload is similar to that returned by GET operations.
 
 ```json
 {
@@ -331,9 +331,9 @@ The decrypted notification payload looks like the following. The payload abide b
 
 ### Notifications without resource data
 
-Notifications without resource data give you enough information to make call into GET APIs to get the message content. Subscriptions for notifications without resource data do not require encryption certificate (since actual resource data is not sent over).
+Notifications without resource data give you enough information to make gET calls to get the message content. Subscriptions for notifications without resource data do not require an encryption certificate (because actual resource data is not sent over).
 
-The payload looks like the following. The payload below is for a message sent in a channel
+The payload looks like the following. This payload is for a message sent in a channel.
 
 ```json
  {
@@ -351,7 +351,7 @@ The payload looks like the following. The payload below is for a message sent in
 }
 ```
 
-`resource` and `@odata.id` properties can be used to make call back into Microsoft Graph to get the payload for the message. GET APIs will always give the current state of the message. So if the message is changed between the notification being sent and message being retrieved, the APIs will give the current state.
+The **resource** and **@odata.id** properties can be used to make calls to Microsoft Graph to get the payload for the message. GET calls will always return the current state of the message. If the message is changed between when the notification is sent and when the message is retrieved, the operation will return the updated message.
 
 ## See also
 - [Microsoft Graph change notifications](webhooks.md)

--- a/concepts/teams-changenotifications-chatmessage.md
+++ b/concepts/teams-changenotifications-chatmessage.md
@@ -252,7 +252,7 @@ Content-Type: application/json
 }
 ```
 
-## What should you expect in the notification
+## Notification payloads
 
 Depending on your subscription, you can either get the notification with resource data, or without it. Subscribing with resource data allows you to get the message payload along with the notification, removing the need to call back and get the content.
 
@@ -331,7 +331,7 @@ The decrypted notification payload looks like the following. The payload conform
 
 ### Notifications without resource data
 
-Notifications without resource data give you enough information to make gET calls to get the message content. Subscriptions for notifications without resource data do not require an encryption certificate (because actual resource data is not sent over).
+Notifications without resource data give you enough information to make GET calls to get the message content. Subscriptions for notifications without resource data do not require an encryption certificate (because actual resource data is not sent over).
 
 The payload looks like the following. This payload is for a message sent in a channel.
 

--- a/concepts/teams-changenotifications-chatmessage.md
+++ b/concepts/teams-changenotifications-chatmessage.md
@@ -252,6 +252,107 @@ Content-Type: application/json
 }
 ```
 
+## What should you expect in the notification
+
+Depending on your subscription, you can either get the notification with resource data, or without it. Subscribing with resource data allows you to get the message payload along with the notification, thus removing the need to call back and get the content.
+
+### Notifications with resource data
+
+For notifications with resource data, the payload looks like the following. The payload below is for a message sent in a chat
+
+```json
+{
+    "value": [{
+        "subscriptionId": "10493aa0-4d29-4df5-bc0c-ef742cc6cd7f",
+        "changeType": "created",
+        "clientState": "<<--SpecifiedClientState-->>",
+        "subscriptionExpirationDateTime": "2021-02-02T10:30:34.9097561-08:00",
+        "resource": "chats('19:8ea0e38b-efb3-4757-924a-5f94061cf8c2_97f62344-57dc-409c-88ad-c4af14158ff5@unq.gbl.spaces')/messages('1612289765949')",
+        "resourceData": {
+            "id": "1612289765949",
+            "@odata.type": "#Microsoft.Graph.chatMessage",
+            "@odata.id": "chats('19:8ea0e38b-efb3-4757-924a-5f94061cf8c2_97f62344-57dc-409c-88ad-c4af14158ff5@unq.gbl.spaces')/messages('1612289765949')"
+        },
+        "encryptedContent": {
+            "data": "<<--EncryptedContent-->",
+            "dataKey": "<<--EnryptedDataKeyUsedForEncryptingContent-->>",
+            "encryptionCertificateId": "<<--IdOfTheCertificateUsedForEncryptingDataKey-->>",
+            "encryptionCertificateThumbprint": "<<--ThumbprintOfTheCertificateUsedForEncryptingDataKey-->>"
+        },
+        "tenantId": "<<--TenantForWhichNotificationWasSent-->>"
+    }],
+    "validationTokens": ["<<--ValidationTokens-->>"]
+}
+```
+
+For specifics on how to validate tokens and decrypt the payload, refer to [notifications with resource data documentation](webhooks-with-resource-data.md).
+
+The decrypted notification payload looks like the following. The payload abide by [chatMessage](/graph/api/resources/chatMessage?preserve-view=true) schema. The payload will be similar to to what one would get from GET APIs
+
+```json
+{
+  "id": "1612289992105",
+  "replyToId": null,
+  "etag": "1612289992105",
+  "messageType": "message",
+  "createdDateTime": "2021-02-02T18:19:52Z",
+  "lastModifiedDateTime": "2021-02-02T18:19:52.105Z",
+  "lastEditedDateTime": null,
+  "deletedDateTime": null,
+  "subject": null,
+  "summary": null,
+  "chatId": "19:8ea0e38b-efb3-4757-924a-5f94061cf8c2_97f62344-57dc-409c-88ad-c4af14158ff5@unq.gbl.spaces",
+  "importance": "normal",
+  "locale": "en-us",
+  "webUrl": null,
+  "from": {
+    "application": null,
+    "device": null,
+    "user": {
+      "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+      "displayName": "Ramjot Singh",
+      "userIdentityType": "aadUser"
+    },
+    "conversation": null
+  },
+  "body": {
+    "contentType": "text",
+    "content": "test"
+  },
+  "channelIdentity": null,
+  "attachments": [],
+  "mentions": [],
+  "policyViolation": null,
+  "reactions": [],
+  "replies": [],
+  "hostedContents": []
+}
+```
+
+### Notifications without resource data
+
+Notifications without resource data give you enough information to make call into GET APIs to get the message content. Subscriptions for notifications without resource data do not require encryption certificate (since actual resource data is not sent over).
+
+The payload looks like the following. The payload below is for a message sent in a channel
+
+```json
+ {
+  "subscriptionId": "9f9d1ed0-c9cc-42e7-8d80-a7fc4b0cda3c",
+  "changeType": "created",
+  "tenantId": "<<--TenantForWhichNotificationWasSent-->>",
+  "clientState": "<<--SpecifiedClientState-->>",
+  "subscriptionExpirationDateTime": "2021-02-02T11:26:41.0537895-08:00",
+  "resource": "teams('fbe2bf47-16c8-47cf-b4a5-4b9b187c508b')/channels('19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2')/messages('1612293113399')",
+  "resourceData": {
+    "id": "1612293113399",
+    "@odata.type": "#Microsoft.Graph.chatMessage",
+    "@odata.id": "teams('fbe2bf47-16c8-47cf-b4a5-4b9b187c508b')/channels('19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2')/messages('1612293113399')"
+  }
+}
+```
+
+`resource` and `@odata.id` properties can be used to make call back into Microsoft Graph to get the payload for the message. GET APIs will always give the current state of the message. So if the message is changed between the notification being sent and message being retrieved, the APIs will give the current state.
+
 ## See also
 - [Microsoft Graph change notifications](webhooks.md)
 - [Microsoft Teams API overview](teams-concept-overview.md)

--- a/concepts/teams-send-activityfeednotifications.md
+++ b/concepts/teams-send-activityfeednotifications.md
@@ -267,7 +267,7 @@ Target user must have the Teams app which is sending notifications installed.
 
 ##### Can a user send notifications to themselves?
 
-No, at the moment a user cannot send notifications to themselves. For scenario like these, please use application permissions.
+No, at the moment a user cannot send notifications to themselves. For scenarios like these, please use application permissions.
 
 ##### Can a Teams app control how the notifications are shown to user (banner, feed etc)
 
@@ -275,10 +275,10 @@ No, only users are allowed to change notification settings.
 
 ##### I installed my app, but I do not see notification settings under the user account
 
-The settings will appear once the first notification has been sent by the Teams app. This reduces the amount of settings users see and help in better management.
+The settings will appear once the first notification has been sent by the Teams app. This reduces the amount of settings that the users see and help in better management.
 
-##### I started getting a Conflict error, how do I resolve it
+##### I started getting a 409 (conflict) error, how do I resolve it
 
-The biggest reason for conflict errors is because multiple Teams apps installed in the scope (team, chat, user etc) have the same AzureAD appId being used in `webApplicationInfo` section of the manifest. When this happens you will get an error like `Found multiple applications with the same AAD App ID 'Your AzureAD AppId'.`. In such cases, ensure that you use unique AzureAD apps for unique Teams apps. However, having the same Teams app installed in multiple scopes (team + user for example) is not an issue.
+The biggest reason for `Conflict` errors is multiple Teams apps installed in the same scope (team, chat, user etc) have the same AzureAD appId being used in `webApplicationInfo` section of the manifest. When this happens, you will get an error like `Found multiple applications with the same AAD App ID 'Your AzureAD AppId'.`. In such cases, ensure that you use unique AzureAD apps for unique Teams apps. *Note, having the same Teams app installed in multiple scopes (team + user for example) is not an issue.*
 
 

--- a/concepts/teams-send-activityfeednotifications.md
+++ b/concepts/teams-send-activityfeednotifications.md
@@ -258,3 +258,27 @@ Microsoft Teams users can customize the notifications they see in their feed, as
 Users can click **Edit** next to an app and customize the notifications, as shown in the following example. The `description` field in the Teams app manifest is displayed.
 
 ![Screenshot showing notifications customized to Banner and feed for a Teams app](images/teams-activityfeednotifications/applevelnotificationsettings.png)
+
+## FAQs
+
+##### Who needs the Teams app to be installed?
+
+Target user must have the Teams app which is sending notifications installed.
+
+##### Can a user send notifications to themselves?
+
+No, at the moment a user cannot send notifications to themselves. For scenario like these, please use application permissions.
+
+##### Can a Teams app control how the notifications are shown to user (banner, feed etc)
+
+No, only users are allowed to change notification settings.
+
+##### I installed my app, but I do not see notification settings under the user account
+
+The settings will appear once the first notification has been sent by the Teams app. This reduces the amount of settings users see and help in better management.
+
+##### I started getting a Conflict error, how do I resolve it
+
+The biggest reason for conflict errors is because multiple Teams apps installed in the scope (team, chat, user etc) have the same AzureAD appId being used in `webApplicationInfo` section of the manifest. When this happens you will get an error like `Found multiple applications with the same AAD App ID 'Your AzureAD AppId'.`. In such cases, ensure that you use unique AzureAD apps for unique Teams apps. However, having the same Teams app installed in multiple scopes (team + user for example) is not an issue.
+
+

--- a/concepts/teams-send-activityfeednotifications.md
+++ b/concepts/teams-send-activityfeednotifications.md
@@ -261,24 +261,24 @@ Users can click **Edit** next to an app and customize the notifications, as show
 
 ## FAQs
 
-##### Who needs the Teams app to be installed?
+### Who needs to install the Teams app?
 
-Target user must have the Teams app which is sending notifications installed.
+The target user must have the Teams app that is sending notifications installed.
 
-##### Can a user send notifications to themselves?
+### Can a user send notifications to themselves?
 
-No, at the moment a user cannot send notifications to themselves. For scenarios like these, please use application permissions.
+No, a user cannot send notifications to themselves. For this scenario, use application permissions.
 
-##### Can a Teams app control how the notifications are shown to user (banner, feed etc)
+### Can a Teams app control how the notifications are shown to the user?
 
 No, only users are allowed to change notification settings.
 
-##### I installed my app, but I do not see notification settings under the user account
+### I installed my app, why don't I see notification settings under the user account?
 
-The settings will appear once the first notification has been sent by the Teams app. This reduces the amount of settings that the users see and help in better management.
+The settings will appear after the first notification is sent by the Teams app. This reduces the number of settings that users see.
 
-##### I started getting a 409 (conflict) error, how do I resolve it
+### I started getting a 409 (conflict) error, how do I resolve it?
 
-The biggest reason for `Conflict` errors is multiple Teams apps installed in the same scope (team, chat, user etc) have the same AzureAD appId being used in `webApplicationInfo` section of the manifest. When this happens, you will get an error like `Found multiple applications with the same AAD App ID 'Your AzureAD AppId'.`. In such cases, ensure that you use unique AzureAD apps for unique Teams apps. *Note, having the same Teams app installed in multiple scopes (team + user for example) is not an issue.*
+`Conflict` errors primarily occur when multiple Teams apps installed in the same scope (team, chat, user, and so on) have the same Azure AD appId in the `webApplicationInfo` section of the manifest. When this happens, you will get an error such as `Found multiple applications with the same Azure AD App ID 'Your AzureAD AppId'.`. Make sure that you use unique Azure AD apps for unique Teams apps. Note that you can have the same Teams app installed in multiple scopes (team + user for example).
 
 


### PR DESCRIPTION
Following changes have been made

- Making it clear that Teamwork.Migrate.All is only supported for migration purposes (messaging and teams)
- Adding note specifying that only standard template is supported for migration team
- Adding sample payloads to messaging change notifications
- Adding FAQs to activity feed notifications doc

Fixes #11498 