### PR TITLE
Add support for up to 25 category descriptions on planner plan details

### DIFF
--- a/api-reference/beta/resources/plannerappliedcategories.md
+++ b/api-reference/beta/resources/plannerappliedcategories.md
@@ -1,6 +1,6 @@
 ---
 title: "plannerAppliedCategories resource type"
-description: "The **AppliedCategoriesCollection** resource represents the collection of categories (or labels) that have been applied to a task. It is part of the plannerTask object."
+description: "Represents the collection of categories (or labels) that have been applied to a task, which is part of the plannerTask object."
 localization_priority: Normal
 author: "TarkanSevilmis"
 ms.prod: "planner"
@@ -13,15 +13,24 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-The **AppliedCategoriesCollection** resource represents the collection of categories (or labels) that have been applied to a task. It is part of the [plannerTask](plannertask.md) object.
-There can be up to 25 categories applied to a task. Category descriptions, e.g. `category1`, `category2` etc., are part of the [plan details](plannerplandetails.md) object. This is an open type.
+Represents the collection of categories (or labels) that have been applied to a task, which is part of the [plannerTask](plannertask.md) object.
+Up to 25 categories can be applied to a task. Category descriptions, are part of the [plan details](plannerplandetails.md) object. This is an open type.
 
 ## Properties
-Properties of an Open Type can be defined by the client. In this case though, the client must provide `category1`, `category2`, `category3`, `category4`, `category5`, ... `category25` as properties with their values being the `true` boolean when the corresponding categories are applied on the task. Example is shown below. When they do not apply, properties are automatically removed by setting their values to the `false` boolean. 
+Properties of an open type can be defined by the client. In this case, the client must provide **category1**, **category2**, **category3**, **category4**, **category5**, and so on up to **category25** as properties with their values being `true` when the corresponding categories are applied on the task. When they do not apply, properties are automatically removed by setting their values to `false`, as shown in the following example.
+
+```json
+{
+  "category1": true,
+  "category3": true,
+  "category5": true,
+  "category21": true
+}
+```
 
 ## JSON representation
 
-Here is a JSON representation of the resource
+The following is a JSON representation of the resource.
 
 <!-- {
   "blockType": "resource",
@@ -34,17 +43,6 @@ Here is a JSON representation of the resource
 ```json
 {
   "String-value": true
-}
-```
-
-Example: 
-
-```json
-{
-  "category1": true,
-  "category3": true,
-  "category5": true,
-  "category21": true
 }
 ```
 

--- a/api-reference/beta/resources/plannerappliedcategories.md
+++ b/api-reference/beta/resources/plannerappliedcategories.md
@@ -14,10 +14,10 @@ Namespace: microsoft.graph
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
 The **AppliedCategoriesCollection** resource represents the collection of categories (or labels) that have been applied to a task. It is part of the [plannerTask](plannertask.md) object.
-There can be up to 6 categories applied to a task. Category descriptions, e.g. `category1`, `category2` etc., are part of the [plan details](plannerplandetails.md) object. This is an open type.
+There can be up to 25 categories applied to a task. Category descriptions, e.g. `category1`, `category2` etc., are part of the [plan details](plannerplandetails.md) object. This is an open type.
 
 ## Properties
-Properties of an Open Type can be defined by the client. In this case though, the client must provide `category1`, `category2`, `category3`, `category4`, `category5` and/or `category6` as properties with their values being the `true` boolean when the corresponding categories are applied on the task. Example is shown below. When they do not apply, properties are automatically removed by setting their values to the `false` boolean. 
+Properties of an Open Type can be defined by the client. In this case though, the client must provide `category1`, `category2`, `category3`, `category4`, `category5`, ... `category25` as properties with their values being the `true` boolean when the corresponding categories are applied on the task. Example is shown below. When they do not apply, properties are automatically removed by setting their values to the `false` boolean. 
 
 ## JSON representation
 
@@ -43,7 +43,8 @@ Example:
 {
   "category1": true,
   "category3": true,
-  "category5": true
+  "category5": true,
+  "category21": true
 }
 ```
 

--- a/api-reference/beta/resources/plannercategorydescriptions.md
+++ b/api-reference/beta/resources/plannercategorydescriptions.md
@@ -2,7 +2,7 @@
 title: "plannerCategoryDescriptions resource type"
 description: "The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the plan details object. There can be up to 25 categories defined."
 localization_priority: Normal
-author: "TarkanSevilmis; AnubhavKumarSingh"
+author: "TarkanSevilmis"
 ms.prod: "planner"
 doc_type: resourcePageType
 ---

--- a/api-reference/beta/resources/plannercategorydescriptions.md
+++ b/api-reference/beta/resources/plannercategorydescriptions.md
@@ -48,6 +48,9 @@ The **plannerCategoryDescriptions** resource represents the descriptive labels f
 The following is a JSON representation of the resource.
 <!-- {
   "blockType": "resource",
+  "optionalProperties": [
+
+  ],
   "@odata.type": "microsoft.graph.plannerCategoryDescriptions"
 }-->
 

--- a/api-reference/beta/resources/plannercategorydescriptions.md
+++ b/api-reference/beta/resources/plannercategorydescriptions.md
@@ -1,8 +1,8 @@
 ---
 title: "plannerCategoryDescriptions resource type"
-description: "The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the plan details object. There can be up to 6 categories defined. "
+description: "The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the plan details object. There can be up to 25 categories defined."
 localization_priority: Normal
-author: "TarkanSevilmis"
+author: "TarkanSevilmis, AnubhavKumarSingh"
 ms.prod: "planner"
 doc_type: resourcePageType
 ---
@@ -13,38 +13,72 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the [plan details](plannerplandetails.md) object. There can be up to 6 categories defined. 
-
+The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the [plan details](plannerplandetails.md) object. There can be up to 25 categories defined. 
 
 ## Properties
-| Property	   | Type	|Description|
-|:---------------|:--------|:----------|
+|Property|Type|Description|
+|:---|:---|:---|
 |category1|String|The label associated with Category 1|
 |category2|String|The label associated with Category 2|
 |category3|String|The label associated with Category 3|
 |category4|String|The label associated with Category 4|
 |category5|String|The label associated with Category 5|
 |category6|String|The label associated with Category 6|
+|category7|String|The label associated with Category 7|
+|category8|String|The label associated with Category 8|
+|category9|String|The label associated with Category 9|
+|category10|String|The label associated with Category 10|
+|category11|String|The label associated with Category 11|
+|category12|String|The label associated with Category 12|
+|category13|String|The label associated with Category 13|
+|category14|String|The label associated with Category 14|
+|category15|String|The label associated with Category 15|
+|category16|String|The label associated with Category 16|
+|category17|String|The label associated with Category 17|
+|category18|String|The label associated with Category 18|
+|category19|String|The label associated with Category 19|
+|category20|String|The label associated with Category 20|
+|category21|String|The label associated with Category 21|
+|category22|String|The label associated with Category 22|
+|category23|String|The label associated with Category 23|
+|category24|String|The label associated with Category 24|
+|category25|String|The label associated with Category 25|
 
 ## JSON representation
-Here is a JSON representation of the resource.
-
+The following is a JSON representation of the resource.
 <!-- {
   "blockType": "resource",
-  "optionalProperties": [
-
-  ],
   "@odata.type": "microsoft.graph.plannerCategoryDescriptions"
 }-->
 
 ```json
 {
+  "@odata.type": "#microsoft.graph.plannerCategoryDescriptions",
   "category1": "String",
   "category2": "String",
   "category3": "String",
   "category4": "String",
   "category5": "String",
-  "category6": "String"
+  "category6": "String",
+  "category7": "String",
+  "category8": "String",
+  "category9": "String",
+  "category10": "String",
+  "category11": "String",
+  "category12": "String",
+  "category13": "String",
+  "category14": "String",
+  "category15": "String",
+  "category16": "String",
+  "category17": "String",
+  "category18": "String",
+  "category19": "String",
+  "category20": "String",
+  "category21": "String",
+  "category22": "String",
+  "category23": "String",
+  "category24": "String",
+  "category25": "String"
 }
 
 ```

--- a/api-reference/beta/resources/plannercategorydescriptions.md
+++ b/api-reference/beta/resources/plannercategorydescriptions.md
@@ -2,7 +2,7 @@
 title: "plannerCategoryDescriptions resource type"
 description: "The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the plan details object. There can be up to 25 categories defined."
 localization_priority: Normal
-author: "TarkanSevilmis, AnubhavKumarSingh"
+author: "TarkanSevilmis; AnubhavKumarSingh"
 ms.prod: "planner"
 doc_type: resourcePageType
 ---

--- a/api-reference/beta/resources/plannercategorydescriptions.md
+++ b/api-reference/beta/resources/plannercategorydescriptions.md
@@ -1,6 +1,6 @@
 ---
 title: "plannerCategoryDescriptions resource type"
-description: "The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the plan details object. There can be up to 25 categories defined."
+description: "Represents the descriptive labels for the categories that have been defined for a plan."
 localization_priority: Normal
 author: "TarkanSevilmis"
 ms.prod: "planner"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-The **plannerCategoryDescriptions** resource represents the descriptive labels for the categories that have been defined for a plan. It belongs to the [plan details](plannerplandetails.md) object. There can be up to 25 categories defined. 
+Represents the descriptive labels for the categories that have been defined for a plan. This resource is associated with the [plan details](plannerplandetails.md) object. Up to 25 categories can be defined. 
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/beta/resources/plannerplandetails.md
+++ b/api-reference/beta/resources/plannerplandetails.md
@@ -26,7 +26,7 @@ The **plannerPlanDetails** resource represents the additional information about 
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|categoryDescriptions|[plannerCategoryDescriptions](plannercategorydescriptions.md)|An object that specifies the descriptions of the six categories that can be associated with tasks in the plan|
+|categoryDescriptions|[plannerCategoryDescriptions](plannercategorydescriptions.md)|An object that specifies the descriptions of the 25 categories that can be associated with tasks in the plan|
 |id|String| Read-only. The ID of the plan details. It is 28 characters long and case-sensitive. [Format validation](tasks-identifiers-disclaimer.md) is done on the service.|
 |sharedWith|[plannerUserIds](planneruserids.md)|The set of user IDs that this plan is shared with. If you are using Microsoft 365 groups, use the groups API to manage group membership to share the [group's](group.md) plan. You can also add existing members of the group to this collection, although it is not required in order for them to access the plan owned by the group. |
 |contextDetails|[plannerPlanContextDetailsCollection](plannerplancontextdetailscollection.md)|Read-only. A collection of additional information associated with [plannerPlanContext](plannerplancontext.md) entries that are defined for the [plannerPlan](plannerplan.md) container. |

--- a/changelog/Microsoft.Office.Tasks.json
+++ b/changelog/Microsoft.Office.Tasks.json
@@ -1,430 +1,430 @@
 {
-    "changelog": [
-       {
-        "ChangeList": [
-          {
-            "Id": "a4350937-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Property",
-            "ChangedApiName": "creationSource",
-            "ChangeType": "Addition",
-            "Description": "Added the **creationSource** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannerTask?view=graph-rest-beta) resource.",
-            "Target": "plannerTask"
-          },
-          {
-            "Id": "a4376b5e-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Property",
-            "ChangedApiName": "container",
-            "ChangeType": "Addition",
-            "Description": "Added the **container** property to the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
-            "Target": "plannerPlan"
-          },
-          {
-            "Id": "a439cfbe-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Resource",
-            "ChangedApiName": "plannerPlanContainer",
-            "ChangeType": "Addition",
-            "Description": "Added the [plannerPlanContainer](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlanContainer?view=graph-rest-beta) resource,",
-            "Target": "plannerPlanContainer"
-          },
-          {
-            "Id": "a43c357f-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Resource",
-            "ChangedApiName": "plannerTaskCreation",
-            "ChangeType": "Addition",
-            "Description": "Added the [plannerTaskCreation](https://docs.microsoft.com/en-us/graph/api/resources/plannerTaskCreation?view=graph-rest-beta) resource.",
-            "Target": "plannerTaskCreation"
-          },
-          {
-            "Id": "a43e93b1-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Resource",
-            "ChangedApiName": "plannerTeamsPublicationInfo",
-            "ChangeType": "Addition",
-            "Description": "Added the [plannerTeamsPublicationInfo](https://docs.microsoft.com/en-us/graph/api/resources/plannerTeamsPublicationInfo?view=graph-rest-beta) resource.",
-            "Target": "plannerTeamsPublicationInfo"
-          },
-          {
-            "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Enum type",
-            "ChangedApiName": "plannerContainerType",
-            "ChangeType": "Addition",
-            "Description": "Added the **plannerContainerType** enumeration type.",
-            "Target": "plannerContainerType"
-          },
-          {
-            "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
-            "ApiChange": "Property",
-            "ChangedApiName": "owner",
-            "ChangeType": "Change",
-            "Description": "Deprecated the **owner** property on the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
-            "Target": "plannerPlan"
-          }
-        ],
-        "Id": "a432a5b2-340e-11eb-9836-6aeb5ee7dda6",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2020-01-13T19:51:45.390Z",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-            "ApiChange": "Resource",
-            "ChangedApiName": "todoTask,todoTaskList,linkedResource",
-            "ChangeType": "Addition",
-            "Description": "Introduced the To Do API. Added the [todoTask](https://docs.microsoft.com/en-us/graph/api/resources/todotask?view=graph-rest-beta), [todoTaskList](https://docs.microsoft.com/en-us/graph/api/resources/todotasklist?view=graph-rest-beta), and [linkedResource](https://docs.microsoft.com/en-us/graph/api/resources/linkedresource?view=graph-rest-beta) resources, and CRUD operations.",
-            "Target": "todoTask,todoTaskList,linkedResource"
-          },
-          {
-            "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-            "ApiChange": "method",
-            "ChangedApiName": "outlookTask,outlookTaskFolder,outlookTaskGroup",
-            "ChangeType": "Change",
-            "Description": "Deprecated the Outlook tasks API, including [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), and related operations and methods.",
-            "Target": "outlookTask,outlookTaskFolder,outlookTaskGroup"
-          }
-        ],
-        "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2020-08-01T00:00:00",
-        "WorkloadArea": "To-do tasks",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
-            "ApiChange": "Property",
-            "ChangedApiName": "priority",
-            "ChangeType": "Addition",
-            "Description": "Added the **priority** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) entity.",
-            "Target": "plannerTask"
-          }
-        ],
-        "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2019-08-01T00:00:00",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Resource",
-            "ChangedApiName": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection",
-            "ChangeType": "Addition",
-            "Description": "Added new complex types:, [plannerPlanContext](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontext?view=graph-rest-beta), [plannerPlanContextDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetails?view=graph-rest-beta), [plannerPlanContextCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextcollection?view=graph-rest-beta), [plannerPlanContextDetailsCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetailscollection?view=graph-rest-beta), [plannerFavoritePlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreference?view=graph-rest-beta), [plannerRecentPlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreference?view=graph-rest-beta), [plannerFavoritePlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreferencecollection?view=graph-rest-beta), [plannerRecentPlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreferencecollection?view=graph-rest-beta)",
-            "Target": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection"
-          },
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Property",
-            "ChangedApiName": "favoritePlanReferences,recentPlanReferences",
-            "ChangeType": "Addition",
-            "Description": "Added **favoritePlanReferences** and **recentPlanReferences** properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
-            "Target": "plannerUser"
-          },
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Property",
-            "ChangedApiName": "favoritePlans,recentPlans",
-            "ChangeType": "Addition",
-            "Description": "Added **favoritePlans** and **recentPlans** navigation properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
-            "Target": "plannerUser"
-          },
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Property",
-            "ChangedApiName": "contexts",
-            "ChangeType": "Addition",
-            "Description": "Added **contexts** property to [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) entity.",
-            "Target": "plannerPlan"
-          },
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Property",
-            "ChangedApiName": "contextDetails",
-            "ChangeType": "Addition",
-            "Description": "Added **contextDetails** property to [plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) entity.",
-            "Target": "plannerPlanDetails"
-          },
-          {
-            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-            "ApiChange": "Resource",
-            "ChangedApiName": "delta query",
-            "ChangeType": "Addition",
-            "Description": "Added Planner [delta query](https://docs.microsoft.com/en-us/graph/api/planneruser-list-delta?view=graph-rest-beta)",
-            "Target": "delta query"
-          }
-        ],
-        "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2018-02-01T00:00:00",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
-            "ApiChange": "Resource",
-            "ChangedApiName": "task,plan,bucket,taskDetails,planDetails,taskBoardTaskFormat,planTaskBoard",
-            "ChangeType": "Deletion",
-            "Description": "Removed the following entities:, **task**, **plan**, **bucket**, **taskDetails**, **planDetails**, **taskBoardTaskFormat**, **planTaskBoard**",
-            "Target": ""
-          }
-        ],
-        "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2017-05-01T00:00:00",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-            "ApiChange": "Property",
-            "ChangedApiName": "outlook",
-            "ChangeType": "Addition",
-            "Description": "New **outlook** navigation property added to [user](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-beta), to access Outlook tasks.",
-            "Target": "user"
-          },
-          {
-            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-            "ApiChange": "Resource",
-            "ChangedApiName": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask",
-            "ChangeType": "Addition",
-            "Description": "New entities - [outlookuser](https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), and [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta) - and their methods support organizing and accessing Outlook tasks.",
-            "Target": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask"
-          },
-          {
-            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-            "ApiChange": "Resource",
-            "ChangedApiName": "attachment,fileAttachment,itemAttachment,referenceAttachment",
-            "ChangeType": "Addition",
-            "Description": "Outlook tasks support attachments ([attachment](https://docs.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-beta), [fileAttachment](https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-beta), [itemAttachment](https://docs.microsoft.com/en-us/graph/api/resources/itemattachment?view=graph-rest-beta), and [referenceAttachment](https://docs.microsoft.com/en-us/graph/api/resources/referenceattachment?view=graph-rest-beta) resources).",
-            "Target": "attachment,fileAttachment,itemAttachment,referenceAttachment"
-          },
-          {
-            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-            "ApiChange": "Property",
-            "ChangedApiName": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty",
-            "ChangeType": "Addition",
-            "Description": "Outlook tasks support [extended properties](https://docs.microsoft.com/en-us/graph/api/resources/extended-properties-overview?view=graph-rest-beta) ([singleValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/singlevaluelegacyextendedproperty?view=graph-rest-beta) and [multiValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/multivaluelegacyextendedproperty?view=graph-rest-beta) resources).",
-            "Target": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty"
-          }
-        ],
-        "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2017-05-01T00:00:00",
-        "WorkloadArea": "To-do tasks",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
-            "ApiChange": "Resource",
-            "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
-            "ChangeType": "Addition",
-            "Description": "Added [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-1.0).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-1.0) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-1.0) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-1.0)",
-            "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
-          }
-        ],
-        "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
-        "Cloud": "prd",
-        "Version": "v1.0",
-        "CreatedDateTime": "2017-05-01T00:00:00",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-        "ChangeList": [
-          {
-            "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
-            "ApiChange": "Resource",
-            "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
-            "ChangeType": "Addition",
-            "Description": "Added new [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-beta) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-beta)",
-            "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
-          }
-        ],
-        "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
-        "Cloud": "prd",
-        "Version": "beta",
-        "CreatedDateTime": "2017-04-01T00:00:00",
-        "WorkloadArea": "Tasks and plans",
-        "SubArea": ""
-      },
-      {
-         "ChangeList":[
-              {
-                 "Id":"7f24040c-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category7",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category7** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f2666c5-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category8",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category8** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f28cbc3-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category9",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category9** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f2c3ba1-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category10",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category10** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f2e93ed-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category11",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category11** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f30f7d2-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category12",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category12** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f335ac0-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category13",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category13** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f35bdbc-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category14",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category14** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f382054-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category15",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category15** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f3a80b0-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category16",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category16** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f3ce3db-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category17",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category17** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f3f4972-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category18",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category18** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f41a8ba-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category19",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category19** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f440af3-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category20",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category20** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f466dd7-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category21",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category21** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f48cfc5-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category22",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category22** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f4b33b7-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category23",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category23** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f4d9595-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category24",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category24** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              },
-              {
-                 "Id":"7f4ff7be-6b0c-11eb-83a5-b441f1c9dab3",
-                 "ApiChange":"Property",
-                 "ChangedApiName":"category25",
-                 "ChangeType":"Addition",
-                 "Description":"Added the **category25** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-                 "Target":"plannerCategoryDescriptions"
-              }
-           ],
-           "Id":"7f21a1fd-6b0c-11eb-83a5-b441f1c9dab3",
-           "Cloud":"prd",
-           "Version":"beta",
-           "CreatedDateTime":"2021-02-09T19:24:58.162Z",
-           "WorkloadArea":"Tasks and plans",
-           "SubArea":""
-       }
-    ]
-  }
+  "changelog": [
+     {
+      "ChangeList": [
+        {
+          "Id": "a4350937-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Property",
+          "ChangedApiName": "creationSource",
+          "ChangeType": "Addition",
+          "Description": "Added the **creationSource** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannerTask?view=graph-rest-beta) resource.",
+          "Target": "plannerTask"
+        },
+        {
+          "Id": "a4376b5e-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Property",
+          "ChangedApiName": "container",
+          "ChangeType": "Addition",
+          "Description": "Added the **container** property to the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
+          "Target": "plannerPlan"
+        },
+        {
+          "Id": "a439cfbe-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Resource",
+          "ChangedApiName": "plannerPlanContainer",
+          "ChangeType": "Addition",
+          "Description": "Added the [plannerPlanContainer](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlanContainer?view=graph-rest-beta) resource,",
+          "Target": "plannerPlanContainer"
+        },
+        {
+          "Id": "a43c357f-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Resource",
+          "ChangedApiName": "plannerTaskCreation",
+          "ChangeType": "Addition",
+          "Description": "Added the [plannerTaskCreation](https://docs.microsoft.com/en-us/graph/api/resources/plannerTaskCreation?view=graph-rest-beta) resource.",
+          "Target": "plannerTaskCreation"
+        },
+        {
+          "Id": "a43e93b1-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Resource",
+          "ChangedApiName": "plannerTeamsPublicationInfo",
+          "ChangeType": "Addition",
+          "Description": "Added the [plannerTeamsPublicationInfo](https://docs.microsoft.com/en-us/graph/api/resources/plannerTeamsPublicationInfo?view=graph-rest-beta) resource.",
+          "Target": "plannerTeamsPublicationInfo"
+        },
+        {
+          "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Enum type",
+          "ChangedApiName": "plannerContainerType",
+          "ChangeType": "Addition",
+          "Description": "Added the **plannerContainerType** enumeration type.",
+          "Target": "plannerContainerType"
+        },
+        {
+          "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
+          "ApiChange": "Property",
+          "ChangedApiName": "owner",
+          "ChangeType": "Change",
+          "Description": "Deprecated the **owner** property on the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
+          "Target": "plannerPlan"
+        }
+      ],
+      "Id": "a432a5b2-340e-11eb-9836-6aeb5ee7dda6",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2020-01-13T19:51:45.390Z",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+          "ApiChange": "Resource",
+          "ChangedApiName": "todoTask,todoTaskList,linkedResource",
+          "ChangeType": "Addition",
+          "Description": "Introduced the To Do API. Added the [todoTask](https://docs.microsoft.com/en-us/graph/api/resources/todotask?view=graph-rest-beta), [todoTaskList](https://docs.microsoft.com/en-us/graph/api/resources/todotasklist?view=graph-rest-beta), and [linkedResource](https://docs.microsoft.com/en-us/graph/api/resources/linkedresource?view=graph-rest-beta) resources, and CRUD operations.",
+          "Target": "todoTask,todoTaskList,linkedResource"
+        },
+        {
+          "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+          "ApiChange": "method",
+          "ChangedApiName": "outlookTask,outlookTaskFolder,outlookTaskGroup",
+          "ChangeType": "Change",
+          "Description": "Deprecated the Outlook tasks API, including [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), and related operations and methods.",
+          "Target": "outlookTask,outlookTaskFolder,outlookTaskGroup"
+        }
+      ],
+      "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2020-08-01T00:00:00",
+      "WorkloadArea": "To-do tasks",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
+          "ApiChange": "Property",
+          "ChangedApiName": "priority",
+          "ChangeType": "Addition",
+          "Description": "Added the **priority** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) entity.",
+          "Target": "plannerTask"
+        }
+      ],
+      "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2019-08-01T00:00:00",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Resource",
+          "ChangedApiName": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection",
+          "ChangeType": "Addition",
+          "Description": "Added new complex types:, [plannerPlanContext](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontext?view=graph-rest-beta), [plannerPlanContextDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetails?view=graph-rest-beta), [plannerPlanContextCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextcollection?view=graph-rest-beta), [plannerPlanContextDetailsCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetailscollection?view=graph-rest-beta), [plannerFavoritePlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreference?view=graph-rest-beta), [plannerRecentPlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreference?view=graph-rest-beta), [plannerFavoritePlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreferencecollection?view=graph-rest-beta), [plannerRecentPlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreferencecollection?view=graph-rest-beta)",
+          "Target": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection"
+        },
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Property",
+          "ChangedApiName": "favoritePlanReferences,recentPlanReferences",
+          "ChangeType": "Addition",
+          "Description": "Added **favoritePlanReferences** and **recentPlanReferences** properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
+          "Target": "plannerUser"
+        },
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Property",
+          "ChangedApiName": "favoritePlans,recentPlans",
+          "ChangeType": "Addition",
+          "Description": "Added **favoritePlans** and **recentPlans** navigation properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
+          "Target": "plannerUser"
+        },
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Property",
+          "ChangedApiName": "contexts",
+          "ChangeType": "Addition",
+          "Description": "Added **contexts** property to [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) entity.",
+          "Target": "plannerPlan"
+        },
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Property",
+          "ChangedApiName": "contextDetails",
+          "ChangeType": "Addition",
+          "Description": "Added **contextDetails** property to [plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) entity.",
+          "Target": "plannerPlanDetails"
+        },
+        {
+          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+          "ApiChange": "Resource",
+          "ChangedApiName": "delta query",
+          "ChangeType": "Addition",
+          "Description": "Added Planner [delta query](https://docs.microsoft.com/en-us/graph/api/planneruser-list-delta?view=graph-rest-beta)",
+          "Target": "delta query"
+        }
+      ],
+      "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2018-02-01T00:00:00",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
+          "ApiChange": "Resource",
+          "ChangedApiName": "task,plan,bucket,taskDetails,planDetails,taskBoardTaskFormat,planTaskBoard",
+          "ChangeType": "Deletion",
+          "Description": "Removed the following entities:, **task**, **plan**, **bucket**, **taskDetails**, **planDetails**, **taskBoardTaskFormat**, **planTaskBoard**",
+          "Target": ""
+        }
+      ],
+      "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2017-05-01T00:00:00",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+          "ApiChange": "Property",
+          "ChangedApiName": "outlook",
+          "ChangeType": "Addition",
+          "Description": "New **outlook** navigation property added to [user](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-beta), to access Outlook tasks.",
+          "Target": "user"
+        },
+        {
+          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+          "ApiChange": "Resource",
+          "ChangedApiName": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask",
+          "ChangeType": "Addition",
+          "Description": "New entities - [outlookuser](https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), and [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta) - and their methods support organizing and accessing Outlook tasks.",
+          "Target": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask"
+        },
+        {
+          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+          "ApiChange": "Resource",
+          "ChangedApiName": "attachment,fileAttachment,itemAttachment,referenceAttachment",
+          "ChangeType": "Addition",
+          "Description": "Outlook tasks support attachments ([attachment](https://docs.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-beta), [fileAttachment](https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-beta), [itemAttachment](https://docs.microsoft.com/en-us/graph/api/resources/itemattachment?view=graph-rest-beta), and [referenceAttachment](https://docs.microsoft.com/en-us/graph/api/resources/referenceattachment?view=graph-rest-beta) resources).",
+          "Target": "attachment,fileAttachment,itemAttachment,referenceAttachment"
+        },
+        {
+          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+          "ApiChange": "Property",
+          "ChangedApiName": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty",
+          "ChangeType": "Addition",
+          "Description": "Outlook tasks support [extended properties](https://docs.microsoft.com/en-us/graph/api/resources/extended-properties-overview?view=graph-rest-beta) ([singleValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/singlevaluelegacyextendedproperty?view=graph-rest-beta) and [multiValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/multivaluelegacyextendedproperty?view=graph-rest-beta) resources).",
+          "Target": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty"
+        }
+      ],
+      "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2017-05-01T00:00:00",
+      "WorkloadArea": "To-do tasks",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
+          "ChangeType": "Addition",
+          "Description": "Added [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-1.0).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-1.0) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-1.0) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-1.0)",
+          "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
+        }
+      ],
+      "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
+      "Cloud": "prd",
+      "Version": "v1.0",
+      "CreatedDateTime": "2017-05-01T00:00:00",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
+          "ApiChange": "Resource",
+          "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
+          "ChangeType": "Addition",
+          "Description": "Added new [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-beta) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-beta)",
+          "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
+        }
+      ],
+      "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2017-04-01T00:00:00",
+      "WorkloadArea": "Tasks and plans",
+      "SubArea": ""
+    },
+	  {
+	    "ChangeList":[
+        {
+            "Id":"7f24040c-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category7",
+            "ChangeType":"Addition",
+            "Description":"Added the **category7** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f2666c5-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category8",
+            "ChangeType":"Addition",
+            "Description":"Added the **category8** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f28cbc3-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category9",
+            "ChangeType":"Addition",
+            "Description":"Added the **category9** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f2c3ba1-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category10",
+            "ChangeType":"Addition",
+            "Description":"Added the **category10** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f2e93ed-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category11",
+            "ChangeType":"Addition",
+            "Description":"Added the **category11** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f30f7d2-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category12",
+            "ChangeType":"Addition",
+            "Description":"Added the **category12** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f335ac0-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category13",
+            "ChangeType":"Addition",
+            "Description":"Added the **category13** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f35bdbc-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category14",
+            "ChangeType":"Addition",
+            "Description":"Added the **category14** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f382054-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category15",
+            "ChangeType":"Addition",
+            "Description":"Added the **category15** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f3a80b0-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category16",
+            "ChangeType":"Addition",
+            "Description":"Added the **category16** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f3ce3db-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category17",
+            "ChangeType":"Addition",
+            "Description":"Added the **category17** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f3f4972-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category18",
+            "ChangeType":"Addition",
+            "Description":"Added the **category18** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f41a8ba-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category19",
+            "ChangeType":"Addition",
+            "Description":"Added the **category19** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f440af3-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category20",
+            "ChangeType":"Addition",
+            "Description":"Added the **category20** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f466dd7-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category21",
+            "ChangeType":"Addition",
+            "Description":"Added the **category21** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f48cfc5-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category22",
+            "ChangeType":"Addition",
+            "Description":"Added the **category22** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f4b33b7-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category23",
+            "ChangeType":"Addition",
+            "Description":"Added the **category23** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f4d9595-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category24",
+            "ChangeType":"Addition",
+            "Description":"Added the **category24** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        },
+        {
+            "Id":"7f4ff7be-6b0c-11eb-83a5-b441f1c9dab3",
+            "ApiChange":"Property",
+            "ChangedApiName":"category25",
+            "ChangeType":"Addition",
+            "Description":"Added the **category25** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+            "Target":"plannerCategoryDescriptions"
+        }
+      ],
+      "Id":"7f21a1fd-6b0c-11eb-83a5-b441f1c9dab3",
+      "Cloud":"prd",
+      "Version":"beta",
+      "CreatedDateTime":"2021-02-09T19:24:58.162Z",
+      "WorkloadArea":"Tasks and plans",
+      "SubArea":""
+	  }
+  ]
+}

--- a/changelog/Microsoft.Office.Tasks.json
+++ b/changelog/Microsoft.Office.Tasks.json
@@ -1,268 +1,430 @@
 {
-  "changelog": [
-     {
-      "ChangeList": [
-        {
-          "Id": "a4350937-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Property",
-          "ChangedApiName": "creationSource",
-          "ChangeType": "Addition",
-          "Description": "Added the **creationSource** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannerTask?view=graph-rest-beta) resource.",
-          "Target": "plannerTask"
-        },
-        {
-          "Id": "a4376b5e-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Property",
-          "ChangedApiName": "container",
-          "ChangeType": "Addition",
-          "Description": "Added the **container** property to the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
-          "Target": "plannerPlan"
-        },
-        {
-          "Id": "a439cfbe-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Resource",
-          "ChangedApiName": "plannerPlanContainer",
-          "ChangeType": "Addition",
-          "Description": "Added the [plannerPlanContainer](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlanContainer?view=graph-rest-beta) resource,",
-          "Target": "plannerPlanContainer"
-        },
-        {
-          "Id": "a43c357f-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Resource",
-          "ChangedApiName": "plannerTaskCreation",
-          "ChangeType": "Addition",
-          "Description": "Added the [plannerTaskCreation](https://docs.microsoft.com/en-us/graph/api/resources/plannerTaskCreation?view=graph-rest-beta) resource.",
-          "Target": "plannerTaskCreation"
-        },
-        {
-          "Id": "a43e93b1-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Resource",
-          "ChangedApiName": "plannerTeamsPublicationInfo",
-          "ChangeType": "Addition",
-          "Description": "Added the [plannerTeamsPublicationInfo](https://docs.microsoft.com/en-us/graph/api/resources/plannerTeamsPublicationInfo?view=graph-rest-beta) resource.",
-          "Target": "plannerTeamsPublicationInfo"
-        },
-        {
-          "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Enum type",
-          "ChangedApiName": "plannerContainerType",
-          "ChangeType": "Addition",
-          "Description": "Added the **plannerContainerType** enumeration type.",
-          "Target": "plannerContainerType"
-        },
-        {
-          "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
-          "ApiChange": "Property",
-          "ChangedApiName": "owner",
-          "ChangeType": "Change",
-          "Description": "Deprecated the **owner** property on the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
-          "Target": "plannerPlan"
-        }
-      ],
-      "Id": "a432a5b2-340e-11eb-9836-6aeb5ee7dda6",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2020-01-13T19:51:45.390Z",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-          "ApiChange": "Resource",
-          "ChangedApiName": "todoTask,todoTaskList,linkedResource",
-          "ChangeType": "Addition",
-          "Description": "Introduced the To Do API. Added the [todoTask](https://docs.microsoft.com/en-us/graph/api/resources/todotask?view=graph-rest-beta), [todoTaskList](https://docs.microsoft.com/en-us/graph/api/resources/todotasklist?view=graph-rest-beta), and [linkedResource](https://docs.microsoft.com/en-us/graph/api/resources/linkedresource?view=graph-rest-beta) resources, and CRUD operations.",
-          "Target": "todoTask,todoTaskList,linkedResource"
-        },
-        {
-          "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-          "ApiChange": "method",
-          "ChangedApiName": "outlookTask,outlookTaskFolder,outlookTaskGroup",
-          "ChangeType": "Change",
-          "Description": "Deprecated the Outlook tasks API, including [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), and related operations and methods.",
-          "Target": "outlookTask,outlookTaskFolder,outlookTaskGroup"
-        }
-      ],
-      "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2020-08-01T00:00:00",
-      "WorkloadArea": "To-do tasks",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
-          "ApiChange": "Property",
-          "ChangedApiName": "priority",
-          "ChangeType": "Addition",
-          "Description": "Added the **priority** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) entity.",
-          "Target": "plannerTask"
-        }
-      ],
-      "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2019-08-01T00:00:00",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Resource",
-          "ChangedApiName": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection",
-          "ChangeType": "Addition",
-          "Description": "Added new complex types:, [plannerPlanContext](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontext?view=graph-rest-beta), [plannerPlanContextDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetails?view=graph-rest-beta), [plannerPlanContextCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextcollection?view=graph-rest-beta), [plannerPlanContextDetailsCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetailscollection?view=graph-rest-beta), [plannerFavoritePlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreference?view=graph-rest-beta), [plannerRecentPlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreference?view=graph-rest-beta), [plannerFavoritePlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreferencecollection?view=graph-rest-beta), [plannerRecentPlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreferencecollection?view=graph-rest-beta)",
-          "Target": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection"
-        },
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Property",
-          "ChangedApiName": "favoritePlanReferences,recentPlanReferences",
-          "ChangeType": "Addition",
-          "Description": "Added **favoritePlanReferences** and **recentPlanReferences** properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
-          "Target": "plannerUser"
-        },
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Property",
-          "ChangedApiName": "favoritePlans,recentPlans",
-          "ChangeType": "Addition",
-          "Description": "Added **favoritePlans** and **recentPlans** navigation properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
-          "Target": "plannerUser"
-        },
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Property",
-          "ChangedApiName": "contexts",
-          "ChangeType": "Addition",
-          "Description": "Added **contexts** property to [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) entity.",
-          "Target": "plannerPlan"
-        },
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Property",
-          "ChangedApiName": "contextDetails",
-          "ChangeType": "Addition",
-          "Description": "Added **contextDetails** property to [plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) entity.",
-          "Target": "plannerPlanDetails"
-        },
-        {
-          "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-          "ApiChange": "Resource",
-          "ChangedApiName": "delta query",
-          "ChangeType": "Addition",
-          "Description": "Added Planner [delta query](https://docs.microsoft.com/en-us/graph/api/planneruser-list-delta?view=graph-rest-beta)",
-          "Target": "delta query"
-        }
-      ],
-      "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2018-02-01T00:00:00",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
-          "ApiChange": "Resource",
-          "ChangedApiName": "task,plan,bucket,taskDetails,planDetails,taskBoardTaskFormat,planTaskBoard",
-          "ChangeType": "Deletion",
-          "Description": "Removed the following entities:, **task**, **plan**, **bucket**, **taskDetails**, **planDetails**, **taskBoardTaskFormat**, **planTaskBoard**",
-          "Target": ""
-        }
-      ],
-      "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2017-05-01T00:00:00",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-          "ApiChange": "Property",
-          "ChangedApiName": "outlook",
-          "ChangeType": "Addition",
-          "Description": "New **outlook** navigation property added to [user](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-beta), to access Outlook tasks.",
-          "Target": "user"
-        },
-        {
-          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-          "ApiChange": "Resource",
-          "ChangedApiName": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask",
-          "ChangeType": "Addition",
-          "Description": "New entities - [outlookuser](https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), and [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta) - and their methods support organizing and accessing Outlook tasks.",
-          "Target": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask"
-        },
-        {
-          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-          "ApiChange": "Resource",
-          "ChangedApiName": "attachment,fileAttachment,itemAttachment,referenceAttachment",
-          "ChangeType": "Addition",
-          "Description": "Outlook tasks support attachments ([attachment](https://docs.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-beta), [fileAttachment](https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-beta), [itemAttachment](https://docs.microsoft.com/en-us/graph/api/resources/itemattachment?view=graph-rest-beta), and [referenceAttachment](https://docs.microsoft.com/en-us/graph/api/resources/referenceattachment?view=graph-rest-beta) resources).",
-          "Target": "attachment,fileAttachment,itemAttachment,referenceAttachment"
-        },
-        {
-          "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-          "ApiChange": "Property",
-          "ChangedApiName": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty",
-          "ChangeType": "Addition",
-          "Description": "Outlook tasks support [extended properties](https://docs.microsoft.com/en-us/graph/api/resources/extended-properties-overview?view=graph-rest-beta) ([singleValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/singlevaluelegacyextendedproperty?view=graph-rest-beta) and [multiValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/multivaluelegacyextendedproperty?view=graph-rest-beta) resources).",
-          "Target": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty"
-        }
-      ],
-      "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2017-05-01T00:00:00",
-      "WorkloadArea": "To-do tasks",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
-          "ApiChange": "Resource",
-          "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
-          "ChangeType": "Addition",
-          "Description": "Added [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-1.0).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-1.0) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-1.0) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-1.0)",
-          "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
-        }
-      ],
-      "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
-      "Cloud": "prd",
-      "Version": "v1.0",
-      "CreatedDateTime": "2017-05-01T00:00:00",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
-          "ApiChange": "Resource",
-          "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
-          "ChangeType": "Addition",
-          "Description": "Added new [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-beta) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-beta)",
-          "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
-        }
-      ],
-      "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2017-04-01T00:00:00",
-      "WorkloadArea": "Tasks and plans",
-      "SubArea": ""
-    }
-  ]
-}
+    "changelog": [
+       {
+        "ChangeList": [
+          {
+            "Id": "a4350937-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Property",
+            "ChangedApiName": "creationSource",
+            "ChangeType": "Addition",
+            "Description": "Added the **creationSource** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannerTask?view=graph-rest-beta) resource.",
+            "Target": "plannerTask"
+          },
+          {
+            "Id": "a4376b5e-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Property",
+            "ChangedApiName": "container",
+            "ChangeType": "Addition",
+            "Description": "Added the **container** property to the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
+            "Target": "plannerPlan"
+          },
+          {
+            "Id": "a439cfbe-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Resource",
+            "ChangedApiName": "plannerPlanContainer",
+            "ChangeType": "Addition",
+            "Description": "Added the [plannerPlanContainer](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlanContainer?view=graph-rest-beta) resource,",
+            "Target": "plannerPlanContainer"
+          },
+          {
+            "Id": "a43c357f-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Resource",
+            "ChangedApiName": "plannerTaskCreation",
+            "ChangeType": "Addition",
+            "Description": "Added the [plannerTaskCreation](https://docs.microsoft.com/en-us/graph/api/resources/plannerTaskCreation?view=graph-rest-beta) resource.",
+            "Target": "plannerTaskCreation"
+          },
+          {
+            "Id": "a43e93b1-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Resource",
+            "ChangedApiName": "plannerTeamsPublicationInfo",
+            "ChangeType": "Addition",
+            "Description": "Added the [plannerTeamsPublicationInfo](https://docs.microsoft.com/en-us/graph/api/resources/plannerTeamsPublicationInfo?view=graph-rest-beta) resource.",
+            "Target": "plannerTeamsPublicationInfo"
+          },
+          {
+            "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Enum type",
+            "ChangedApiName": "plannerContainerType",
+            "ChangeType": "Addition",
+            "Description": "Added the **plannerContainerType** enumeration type.",
+            "Target": "plannerContainerType"
+          },
+          {
+            "Id": "a440f891-340e-11eb-9836-6aeb5ee7dda6",
+            "ApiChange": "Property",
+            "ChangedApiName": "owner",
+            "ChangeType": "Change",
+            "Description": "Deprecated the **owner** property on the [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerPlan?view=graph-rest-beta) resource.",
+            "Target": "plannerPlan"
+          }
+        ],
+        "Id": "a432a5b2-340e-11eb-9836-6aeb5ee7dda6",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2020-01-13T19:51:45.390Z",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+            "ApiChange": "Resource",
+            "ChangedApiName": "todoTask,todoTaskList,linkedResource",
+            "ChangeType": "Addition",
+            "Description": "Introduced the To Do API. Added the [todoTask](https://docs.microsoft.com/en-us/graph/api/resources/todotask?view=graph-rest-beta), [todoTaskList](https://docs.microsoft.com/en-us/graph/api/resources/todotasklist?view=graph-rest-beta), and [linkedResource](https://docs.microsoft.com/en-us/graph/api/resources/linkedresource?view=graph-rest-beta) resources, and CRUD operations.",
+            "Target": "todoTask,todoTaskList,linkedResource"
+          },
+          {
+            "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+            "ApiChange": "method",
+            "ChangedApiName": "outlookTask,outlookTaskFolder,outlookTaskGroup",
+            "ChangeType": "Change",
+            "Description": "Deprecated the Outlook tasks API, including [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), and related operations and methods.",
+            "Target": "outlookTask,outlookTaskFolder,outlookTaskGroup"
+          }
+        ],
+        "Id": "3a22446c-e65a-43dc-aca4-999146a95ca8",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2020-08-01T00:00:00",
+        "WorkloadArea": "To-do tasks",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
+            "ApiChange": "Property",
+            "ChangedApiName": "priority",
+            "ChangeType": "Addition",
+            "Description": "Added the **priority** property to the [plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) entity.",
+            "Target": "plannerTask"
+          }
+        ],
+        "Id": "d09e8b60-aacb-45e7-9691-253940c1b408",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2019-08-01T00:00:00",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Resource",
+            "ChangedApiName": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection",
+            "ChangeType": "Addition",
+            "Description": "Added new complex types:, [plannerPlanContext](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontext?view=graph-rest-beta), [plannerPlanContextDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetails?view=graph-rest-beta), [plannerPlanContextCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextcollection?view=graph-rest-beta), [plannerPlanContextDetailsCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerplancontextdetailscollection?view=graph-rest-beta), [plannerFavoritePlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreference?view=graph-rest-beta), [plannerRecentPlanReference](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreference?view=graph-rest-beta), [plannerFavoritePlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerfavoriteplanreferencecollection?view=graph-rest-beta), [plannerRecentPlanReferenceCollection](https://docs.microsoft.com/en-us/graph/api/resources/plannerrecentplanreferencecollection?view=graph-rest-beta)",
+            "Target": "plannerPlanContext,plannerPlanContextDetails,plannerPlanContextCollection,plannerPlanContextDetailsCollection,plannerFavoritePlanReference,plannerRecentPlanReference,plannerFavoritePlanReferenceCollection,plannerRecentPlanReferenceCollection"
+          },
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Property",
+            "ChangedApiName": "favoritePlanReferences,recentPlanReferences",
+            "ChangeType": "Addition",
+            "Description": "Added **favoritePlanReferences** and **recentPlanReferences** properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
+            "Target": "plannerUser"
+          },
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Property",
+            "ChangedApiName": "favoritePlans,recentPlans",
+            "ChangeType": "Addition",
+            "Description": "Added **favoritePlans** and **recentPlans** navigation properties to [plannerUser](https://docs.microsoft.com/en-us/graph/api/resources/planneruser?view=graph-rest-beta) entity.",
+            "Target": "plannerUser"
+          },
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Property",
+            "ChangedApiName": "contexts",
+            "ChangeType": "Addition",
+            "Description": "Added **contexts** property to [plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) entity.",
+            "Target": "plannerPlan"
+          },
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Property",
+            "ChangedApiName": "contextDetails",
+            "ChangeType": "Addition",
+            "Description": "Added **contextDetails** property to [plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) entity.",
+            "Target": "plannerPlanDetails"
+          },
+          {
+            "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+            "ApiChange": "Resource",
+            "ChangedApiName": "delta query",
+            "ChangeType": "Addition",
+            "Description": "Added Planner [delta query](https://docs.microsoft.com/en-us/graph/api/planneruser-list-delta?view=graph-rest-beta)",
+            "Target": "delta query"
+          }
+        ],
+        "Id": "a760876c-d24c-46c8-9842-37295b5b7216",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2018-02-01T00:00:00",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
+            "ApiChange": "Resource",
+            "ChangedApiName": "task,plan,bucket,taskDetails,planDetails,taskBoardTaskFormat,planTaskBoard",
+            "ChangeType": "Deletion",
+            "Description": "Removed the following entities:, **task**, **plan**, **bucket**, **taskDetails**, **planDetails**, **taskBoardTaskFormat**, **planTaskBoard**",
+            "Target": ""
+          }
+        ],
+        "Id": "46f0da80-1dbc-4931-8d66-f8c1a1b6d6b2",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2017-05-01T00:00:00",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+            "ApiChange": "Property",
+            "ChangedApiName": "outlook",
+            "ChangeType": "Addition",
+            "Description": "New **outlook** navigation property added to [user](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-beta), to access Outlook tasks.",
+            "Target": "user"
+          },
+          {
+            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+            "ApiChange": "Resource",
+            "ChangedApiName": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask",
+            "ChangeType": "Addition",
+            "Description": "New entities - [outlookuser](https://docs.microsoft.com/en-us/graph/api/resources/outlookuser?view=graph-rest-beta), [outlookTaskGroup](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskgroup?view=graph-rest-beta), [outlookTaskFolder](https://docs.microsoft.com/en-us/graph/api/resources/outlooktaskfolder?view=graph-rest-beta), and [outlookTask](https://docs.microsoft.com/en-us/graph/api/resources/outlooktask?view=graph-rest-beta) - and their methods support organizing and accessing Outlook tasks.",
+            "Target": "outlookuser,outlookTaskGroup,outlookTaskFolder,outlookTask"
+          },
+          {
+            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+            "ApiChange": "Resource",
+            "ChangedApiName": "attachment,fileAttachment,itemAttachment,referenceAttachment",
+            "ChangeType": "Addition",
+            "Description": "Outlook tasks support attachments ([attachment](https://docs.microsoft.com/en-us/graph/api/resources/attachment?view=graph-rest-beta), [fileAttachment](https://docs.microsoft.com/en-us/graph/api/resources/fileattachment?view=graph-rest-beta), [itemAttachment](https://docs.microsoft.com/en-us/graph/api/resources/itemattachment?view=graph-rest-beta), and [referenceAttachment](https://docs.microsoft.com/en-us/graph/api/resources/referenceattachment?view=graph-rest-beta) resources).",
+            "Target": "attachment,fileAttachment,itemAttachment,referenceAttachment"
+          },
+          {
+            "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+            "ApiChange": "Property",
+            "ChangedApiName": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty",
+            "ChangeType": "Addition",
+            "Description": "Outlook tasks support [extended properties](https://docs.microsoft.com/en-us/graph/api/resources/extended-properties-overview?view=graph-rest-beta) ([singleValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/singlevaluelegacyextendedproperty?view=graph-rest-beta) and [multiValueLegacyExtendedProperty](https://docs.microsoft.com/en-us/graph/api/resources/multivaluelegacyextendedproperty?view=graph-rest-beta) resources).",
+            "Target": "extended properties,singleValueLegacyExtendedProperty,multiValueLegacyExtendedProperty"
+          }
+        ],
+        "Id": "97c3d22e-a50e-4f31-946b-239acfafb174",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2017-05-01T00:00:00",
+        "WorkloadArea": "To-do tasks",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
+            "ApiChange": "Resource",
+            "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
+            "ChangeType": "Addition",
+            "Description": "Added [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-1.0).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-1.0) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-1.0) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-1.0) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-1.0)",
+            "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
+          }
+        ],
+        "Id": "30092d1a-95ae-4207-b2a6-59245ab06159",
+        "Cloud": "prd",
+        "Version": "v1.0",
+        "CreatedDateTime": "2017-05-01T00:00:00",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+        "ChangeList": [
+          {
+            "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
+            "ApiChange": "Resource",
+            "ChangedApiName": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat",
+            "ChangeType": "Addition",
+            "Description": "Added new [Planner API](https://docs.microsoft.com/en-us/graph/api/resources/planner-overview?view=graph-rest-beta).\u003Cbr /\u003ENew resources:\u003Cbr /\u003E[plannerPlan](https://docs.microsoft.com/en-us/graph/api/resources/plannerplan?view=graph-rest-beta) \u003Cbr /\u003E[plannerTask](https://docs.microsoft.com/en-us/graph/api/resources/plannertask?view=graph-rest-beta) \u003Cbr /\u003E[plannerPlanDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannerplandetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerTaskDetails](https://docs.microsoft.com/en-us/graph/api/resources/plannertaskdetails?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucket](https://docs.microsoft.com/en-us/graph/api/resources/plannerbucket?view=graph-rest-beta) \u003Cbr /\u003E[plannerAssignedToTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerassignedtotaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerBucketTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerbuckettaskboardtaskformat?view=graph-rest-beta) \u003Cbr /\u003E[plannerProgressTaskBoardTaskFormat](https://docs.microsoft.com/en-us/graph/api/resources/plannerprogresstaskboardtaskformat?view=graph-rest-beta)",
+            "Target": "Planner API,plannerPlan,plannerTask,plannerPlanDetails,plannerTaskDetails,plannerBucket,plannerAssignedToTaskBoardTaskFormat,plannerBucketTaskBoardTaskFormat,plannerProgressTaskBoardTaskFormat"
+          }
+        ],
+        "Id": "b5842b87-9a53-423a-b3a2-215bb3585996",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2017-04-01T00:00:00",
+        "WorkloadArea": "Tasks and plans",
+        "SubArea": ""
+      },
+      {
+         "ChangeList":[
+              {
+                 "Id":"7f24040c-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category7",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category7** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f2666c5-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category8",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category8** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f28cbc3-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category9",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category9** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f2c3ba1-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category10",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category10** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f2e93ed-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category11",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category11** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f30f7d2-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category12",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category12** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f335ac0-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category13",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category13** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f35bdbc-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category14",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category14** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f382054-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category15",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category15** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f3a80b0-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category16",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category16** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f3ce3db-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category17",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category17** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f3f4972-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category18",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category18** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f41a8ba-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category19",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category19** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f440af3-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category20",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category20** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f466dd7-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category21",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category21** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f48cfc5-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category22",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category22** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f4b33b7-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category23",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category23** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f4d9595-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category24",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category24** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              },
+              {
+                 "Id":"7f4ff7be-6b0c-11eb-83a5-b441f1c9dab3",
+                 "ApiChange":"Property",
+                 "ChangedApiName":"category25",
+                 "ChangeType":"Addition",
+                 "Description":"Added the **category25** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+                 "Target":"plannerCategoryDescriptions"
+              }
+           ],
+           "Id":"7f21a1fd-6b0c-11eb-83a5-b441f1c9dab3",
+           "Cloud":"prd",
+           "Version":"beta",
+           "CreatedDateTime":"2021-02-09T19:24:58.162Z",
+           "WorkloadArea":"Tasks and plans",
+           "SubArea":""
+       }
+    ]
+  }

--- a/changelog/Microsoft.Office.Tasks.json
+++ b/changelog/Microsoft.Office.Tasks.json
@@ -422,7 +422,7 @@
       "Id":"7f21a1fd-6b0c-11eb-83a5-b441f1c9dab3",
       "Cloud":"prd",
       "Version":"beta",
-      "CreatedDateTime":"2021-02-09T19:24:58.162Z",
+      "CreatedDateTime":"2021-02-10T19:24:58.162Z",
       "WorkloadArea":"Tasks and plans",
       "SubArea":""
     }

--- a/changelog/Microsoft.Office.Tasks.json
+++ b/changelog/Microsoft.Office.Tasks.json
@@ -264,159 +264,159 @@
       "WorkloadArea": "Tasks and plans",
       "SubArea": ""
     },
-	  {
-	    "ChangeList":[
+    {
+	  "ChangeList":[
         {
-            "Id":"7f24040c-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category7",
-            "ChangeType":"Addition",
-            "Description":"Added the **category7** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f24040c-6b0c-11eb-83a5-b441f1c9dab3",
+		  "ApiChange":"Property",
+		  "ChangedApiName":"category7",
+		  "ChangeType":"Addition",
+		  "Description":"Added the **category7** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+		  "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f2666c5-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category8",
-            "ChangeType":"Addition",
-            "Description":"Added the **category8** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f2666c5-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category8",
+          "ChangeType":"Addition",
+          "Description":"Added the **category8** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f28cbc3-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category9",
-            "ChangeType":"Addition",
-            "Description":"Added the **category9** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f28cbc3-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category9",
+          "ChangeType":"Addition",
+          "Description":"Added the **category9** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f2c3ba1-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category10",
-            "ChangeType":"Addition",
-            "Description":"Added the **category10** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f2c3ba1-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category10",
+          "ChangeType":"Addition",
+          "Description":"Added the **category10** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f2e93ed-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category11",
-            "ChangeType":"Addition",
-            "Description":"Added the **category11** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f2e93ed-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category11",
+          "ChangeType":"Addition",
+          "Description":"Added the **category11** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f30f7d2-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category12",
-            "ChangeType":"Addition",
-            "Description":"Added the **category12** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f30f7d2-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category12",
+          "ChangeType":"Addition",
+          "Description":"Added the **category12** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f335ac0-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category13",
-            "ChangeType":"Addition",
-            "Description":"Added the **category13** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f335ac0-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category13",
+          "ChangeType":"Addition",
+          "Description":"Added the **category13** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f35bdbc-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category14",
-            "ChangeType":"Addition",
-            "Description":"Added the **category14** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f35bdbc-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category14",
+          "ChangeType":"Addition",
+          "Description":"Added the **category14** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f382054-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category15",
-            "ChangeType":"Addition",
-            "Description":"Added the **category15** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f382054-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category15",
+          "ChangeType":"Addition",
+          "Description":"Added the **category15** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f3a80b0-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category16",
-            "ChangeType":"Addition",
-            "Description":"Added the **category16** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f3a80b0-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category16",
+          "ChangeType":"Addition",
+          "Description":"Added the **category16** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f3ce3db-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category17",
-            "ChangeType":"Addition",
-            "Description":"Added the **category17** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f3ce3db-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category17",
+          "ChangeType":"Addition",
+          "Description":"Added the **category17** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f3f4972-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category18",
-            "ChangeType":"Addition",
-            "Description":"Added the **category18** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f3f4972-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category18",
+          "ChangeType":"Addition",
+          "Description":"Added the **category18** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f41a8ba-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category19",
-            "ChangeType":"Addition",
-            "Description":"Added the **category19** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f41a8ba-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category19",
+          "ChangeType":"Addition",
+          "Description":"Added the **category19** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f440af3-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category20",
-            "ChangeType":"Addition",
-            "Description":"Added the **category20** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f440af3-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category20",
+          "ChangeType":"Addition",
+          "Description":"Added the **category20** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f466dd7-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category21",
-            "ChangeType":"Addition",
-            "Description":"Added the **category21** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f466dd7-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category21",
+          "ChangeType":"Addition",
+          "Description":"Added the **category21** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f48cfc5-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category22",
-            "ChangeType":"Addition",
-            "Description":"Added the **category22** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f48cfc5-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category22",
+          "ChangeType":"Addition",
+          "Description":"Added the **category22** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f4b33b7-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category23",
-            "ChangeType":"Addition",
-            "Description":"Added the **category23** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f4b33b7-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category23",
+          "ChangeType":"Addition",
+          "Description":"Added the **category23** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f4d9595-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category24",
-            "ChangeType":"Addition",
-            "Description":"Added the **category24** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f4d9595-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category24",
+          "ChangeType":"Addition",
+          "Description":"Added the **category24** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         },
         {
-            "Id":"7f4ff7be-6b0c-11eb-83a5-b441f1c9dab3",
-            "ApiChange":"Property",
-            "ChangedApiName":"category25",
-            "ChangeType":"Addition",
-            "Description":"Added the **category25** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
-            "Target":"plannerCategoryDescriptions"
+          "Id":"7f4ff7be-6b0c-11eb-83a5-b441f1c9dab3",
+          "ApiChange":"Property",
+          "ChangedApiName":"category25",
+          "ChangeType":"Addition",
+          "Description":"Added the **category25** property to [plannerCategoryDescriptions](https://docs.microsoft.com/en-us/graph/api/resources/plannerCategoryDescriptions?view=graph-rest-beta) resource",
+          "Target":"plannerCategoryDescriptions"
         }
       ],
       "Id":"7f21a1fd-6b0c-11eb-83a5-b441f1c9dab3",
@@ -425,6 +425,6 @@
       "CreatedDateTime":"2021-02-09T19:24:58.162Z",
       "WorkloadArea":"Tasks and plans",
       "SubArea":""
-	  }
+    }
   ]
 }


### PR DESCRIPTION
Documentation update for increasing the available category descriptions on planner plan details from 6 to 25