### PR TITLE
Outlook task group sample URLs

### DIFF
--- a/api-reference/beta/api/outlooktask-complete.md
+++ b/api-reference/beta/api/outlooktask-complete.md
@@ -71,7 +71,7 @@ Here is an example of the request.
 }-->
 
 ```http
-POST https://graph.microsoft.com/beta/me/tasks('AAMkADA1MT15rfAAA=')/complete
+POST https://graph.microsoft.com/beta/me/outlook/tasks('AAMkADA1MT15rfAAA=')/complete
 Prefer: outlook.timezone="Pacific Standard Time"
 ```
 

--- a/api-reference/beta/api/outlooktaskfolder-post-tasks.md
+++ b/api-reference/beta/api/outlooktaskfolder-post-tasks.md
@@ -59,7 +59,7 @@ Here is an example of the request.
   "name": "create_outlooktask_from_outlooktaskfolder"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/me/taskfolders('AAMkADIyAAAhrbPXAAA=')/tasks
+POST https://graph.microsoft.com/beta/me/outlook/taskfolders('AAMkADIyAAAhrbPXAAA=')/tasks
 Content-type: application/json
 Content-length: 376
 

--- a/api-reference/beta/api/outlooktaskgroup-post-taskfolders.md
+++ b/api-reference/beta/api/outlooktaskgroup-post-taskfolders.md
@@ -48,13 +48,12 @@ If successful, this method returns `201 Created` response code and [outlookTaskF
 ##### Request
 The following example creates a task folder called `Cooking` in the specified task group.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "create_outlooktaskfolder_from_outlooktaskgroup"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/me/taskgroups/AAMkADIyAAAhrbe-AAA'/taskfolders
+POST https://graph.microsoft.com/beta/me/outlook/taskgroups/AAMkADIyAAAhrbe-AAA=/taskfolders
 Content-type: application/json
 Content-length: 131
 
@@ -62,11 +61,6 @@ Content-length: 131
   "name": "Cooking"
 }
 ```
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/create-outlooktaskfolder-from-outlooktaskgroup-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
----
 
 In the request body, supply a JSON representation of [outlookTaskFolder](../resources/outlooktaskfolder.md) object.
 ##### Response


### PR DESCRIPTION
Navigation is through me/outlook/task* instead of me/task*.