### PR TITLE
Skip attempting to create PRs for subsequent commits to the snippet branch

### DIFF
--- a/.github/workflows/snippet-generation-pr.yml
+++ b/.github/workflows/snippet-generation-pr.yml
@@ -19,6 +19,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 10 # number of commits to fetch so that we can query history
 
     # Create a pull request [0]
     - name: Create PR using the GitHub REST API via hub
@@ -31,8 +33,14 @@ jobs:
         ASSIGNEDTO: andrueastman
         BASE: master
       run: |
-        curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-        bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -a "$ASSIGNEDTO"
+        git fetch origin master
+        commitCount=`git rev-list origin/master.. --count`
+        if [ $commitCount == 1 ]; then
+          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+          bin/hub pull-request -b "$BASE" -h "$GITHUB_REF" -m "$MESSAGE_TITLE" -m "$MESSAGE_BODY" -r "$REVIEWERS" -a "$ASSIGNEDTO"
+        else
+          echo "this is a subsequent commit to the snippets branch, so ignoring PR generation request.."
+        fi
 
 # References
 # [0] https://hub.github.com/hub-pull-request.1.html


### PR DESCRIPTION
Fixes #11178

- Added a check on number of commits that the snippets branch is ahead of master. If the number of commits is 1, we generate the PR, otherwise we skip.

Tested the changes in my own fork.