### PR TITLE
GroupMember.Read.All scope required for group filtering

### DIFF
--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -134,7 +134,7 @@ This component uses the following Microsoft Graph APIs and permissions.
 | [/me/people](/graph/api/user-list-people)                    | People.Read        |
 | [/users](/graph/api/user-list)  | User.ReadBasic.All |
 | [/groups](/group-list)  | Group.Read.All |
-| [/groups/\${groupId}/members](/graph/api/group-list-members) | User.ReadBasic.All        |
+| [/groups/\${groupId}/members](/graph/api/group-list-members) | GroupMember.Read.All        |
 | [/users/${userPrincipleName} ](/graph/api/user-get)  | User.Read |
 
 ## Authentication


### PR DESCRIPTION
According to the [current documentation](https://docs.microsoft.com/en-us/graph/toolkit/components/people-picker#microsoft-graph-permissions), the `Users.ReadBasic.All` scope is required for the `/groups/${groupId}/members` endpoint used to filter by group members. However, [the Microsoft Graph documentation ](https://docs.microsoft.com/en-us/graph/api/group-list-members?view=graph-rest-1.0&tabs=http#permissions) lists the `GroupMember.Read.All` scope as the minimum required to call that endpoint.