### PR TITLE
Update get-a-count-endswith-java-snippets.md

### DIFF
--- a/api-reference/v1.0/includes/snippets/java/get-a-count-endswith-java-snippets.md
+++ b/api-reference/v1.0/includes/snippets/java/get-a-count-endswith-java-snippets.md
@@ -8,6 +8,7 @@ IGraphServiceClient graphClient = GraphServiceClient.builder().authenticationPro
 
 LinkedList<Option> requestOptions = new LinkedList<Option>();
 requestOptions.add(new HeaderOption("ConsistencyLevel", "eventual"));
+requestOptions.add(new QueryOption("$count", "true"));
 
 IUserCollectionPage users = graphClient.users()
 	.buildRequest( requestOptions )


### PR DESCRIPTION
In order to use advanced queries, you need to include the $count=true query parameter. See https://developer.microsoft.com/en-us/identity/blogs/microsoft-graph-advanced-queries-for-directory-objects-are-now-generally-available/ for more information.