### PR TITLE
CloudPrinting: printerShare deprecated in v1.0

### DIFF
--- a/api-reference/v1.0/api/printershare-delete-alloweduser.md
+++ b/api-reference/v1.0/api/printershare-delete-alloweduser.md
@@ -29,7 +29,7 @@ To use the Universal Print service, the user or app's tenant must have an active
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-DELETE /print/printerShare/{printerShareId}/allowedUsers/{userId}/$ref
+DELETE /print/shares/{printerShareId}/allowedUsers/{userId}/$ref
 ```
 ## Request headers
 | Name          | Description   |
@@ -51,7 +51,7 @@ The following is an example of the request.
   "name": "delete_alloweduser"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/print/printerShare/{printerShareId}/allowedUsers/{userId}/$ref
+DELETE https://graph.microsoft.com/v1.0/print/shares/{printerShareId}/allowedUsers/{userId}/$ref
 ```
 
 ### Response

--- a/api-reference/v1.0/api/printershare-post-allowedgroups.md
+++ b/api-reference/v1.0/api/printershare-post-allowedgroups.md
@@ -32,7 +32,7 @@ To use the Universal Print service, the user or app's tenant must have an active
 }
 -->
 ``` http
-POST /print/printers/{printerShareId}/allowedGroups/$ref
+POST /print/printers/{printerId}/shares/{printerShareId}/allowedGroups/$ref
 ```
 
 ## Request headers


### PR DESCRIPTION
Rename printerShare to shares.