### PR TITLE
Updating intune-devices-applogcollectionrequest.md

### DIFF
--- a/api-reference/beta/resources/intune-devices-applogcollectionrequest.md
+++ b/api-reference/beta/resources/intune-devices-applogcollectionrequest.md
@@ -20,11 +20,8 @@ AppLogCollectionRequest Entity.
 ## Methods
 |Method|Return Type|Description|
 |:---|:---|:---|
-|[List appLogCollectionRequests](../api/intune-devices-applogcollectionrequest-list.md)|[appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md) collection|List properties and relationships of the [appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md) objects.|
 |[Get appLogCollectionRequest](../api/intune-devices-applogcollectionrequest-get.md)|[appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md)|Read properties and relationships of the [appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md) object.|
 |[Create appLogCollectionRequest](../api/intune-devices-applogcollectionrequest-create.md)|[appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md)|Create a new [appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md) object.|
-|[Delete appLogCollectionRequest](../api/intune-devices-applogcollectionrequest-delete.md)|None|Deletes a [appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md).|
-|[Update appLogCollectionRequest](../api/intune-devices-applogcollectionrequest-update.md)|[appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md)|Update the properties of a [appLogCollectionRequest](../resources/intune-devices-applogcollectionrequest.md) object.|
 |[createDownloadUrl action](../api/intune-devices-applogcollectionrequest-createdownloadurl.md)|[appLogCollectionDownloadDetails](../resources/intune-devices-applogcollectiondownloaddetails.md)|Not yet documented|
 
 ## Properties


### PR DESCRIPTION
A current CRI brought to our teams attention: https://portal.microsofticm.com/imp/v3/incidents/details/230344847/home raised this issue that appLogCollectionRequest documentation needs to be revised. I will be removing documentation refering to appLogCollectionRequest: List, Delete and Update as these are not valid methods as show here: https://msazure.visualstudio.com/One/_git/Intune-Svc-DeviceFE?path=%2Fsrc%2FServices%2FDeviceFEService%2FSource%2FControllers%2FStatelessAppLogUploadRequestController.cs&_a=contents&version=GBdevelop

I will also be adding documentation refering to User Permissions for Create.