### PR TITLE
Updates instructions to use MGT with SPFx

### DIFF
--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -573,6 +573,8 @@ items:
                 href: toolkit/get-started/overview.md
               - name: Toolkit for React
                 href: toolkit/get-started/mgt-react.md
+              - name: Toolkit for SPFx
+                href: toolkit/get-started/mgt-spfx.md
           - name: Build your first app
             items:
               - name: Register an Azure Active Directory app

--- a/concepts/toolkit/get-started/build-a-sharepoint-web-part.md
+++ b/concepts/toolkit/get-started/build-a-sharepoint-web-part.md
@@ -10,35 +10,18 @@ author: elisenyang
 This topic covers how to use Microsoft Graph Toolkit components in a [SharePoint client-side web part](/sharepoint/dev/spfx/web-parts/overview-client-side-web-parts). Getting started involves the following steps:
 
 1. Set up your development environment and create a web part.
-2. Update TypeScript in your project.
-3. Add the Microsoft Graph Toolkit.
-4. Add the SharePoint Provider.
-5. Add components.
-6. Configure permissions.
-7. Build and deploy your web part.
-8. Test your web part.
+1. Add the Microsoft Graph Toolkit.
+1. Add the Microsoft Graph Toolkit SharePoint Framework package.
+1. Add the SharePoint Provider.
+1. Add components.
+1. Configure permissions.
+1. Deploy the Microsoft Graph Toolkit SharePoint Framework package.
+1. Build and deploy your web part.
+1. Test your web part.
 
 ## Set up your SharePoint Framework development environment and create a new web part
 
 Follow the steps to [Set up your SharePoint Framework development environment](/sharepoint/dev/spfx/set-up-your-development-environment) and then [create a new web part](/sharepoint/dev/spfx/web-parts/get-started/build-a-hello-world-web-part).
-
-## Update TypeScript in your project
-
-The Microsoft Graph Toolkit requires Typescript 3.x. Before adding the Toolkit to your project, make sure you're using a [supported version of Typescript](https://github.com/SharePoint/sp-dev-docs/wiki/SharePoint-Framework-v1.8-release-notes#support-for-typescript-27-29-and-3x). For example, to add Typescript 3.7, use the following command:
-
-```bash
-npm install @microsoft/rush-stack-compiler-3.7 --save-dev
-```
-Then, locate the `tsconfig.json` file in your project folder, open the file, and look for this line:
-
-```json
-"extends": "./node_modules/@microsoft/rush-stack-compiler-3.3/includes/tsconfig-web.json",
-```
-Replace the line with:
-
-```json
-"extends": "./node_modules/@microsoft/rush-stack-compiler-3.7/includes/tsconfig-web.json",
-```
 
 ## Add the Microsoft Graph Toolkit
 
@@ -94,6 +77,18 @@ import 'core-js/es/regexp';
 import '@webcomponents/webcomponentsjs/webcomponents-bundle.js';
 ```
 
+## Add the Microsoft Graph Toolkit SharePoint Framework package
+
+To prevent multiple SharePoint Framework components from registering their own set of Microsoft Graph Toolkit components on the page, you should deploy the Microsoft Graph Toolkit SharePoint Framework package to your tenant and reference Microsoft Graph Toolkit components that you use in your solution from this package.
+
+The Microsoft Graph Toolkit SharePoint Framework package contains a SharePoint Framework library that registers a single instance of Microsoft Graph Toolkit components in SharePoint.
+
+Install the Microsoft Graph Toolkit SharePoint Framework npm package using the following command:
+
+```bash
+npm install @microsoft/mgt-spfx
+```
+
 ## Add the SharePoint Provider
 
 The Microsoft Graph Toolkit providers enable authentication and access to Microsoft Graph for the components. To learn more, see [Using the providers](../providers/providers.md). SharePoint web parts always exist in an authenticated context because the user has already had to sign in in order to get to the page that hosts your web part. Use this context to initialize the [SharePoint provider](../providers/sharepoint.md).
@@ -101,14 +96,16 @@ The Microsoft Graph Toolkit providers enable authentication and access to Micros
 First, add the provider to your web part. Locate the `src\webparts\<your-project>\<your-web-part>.ts` file in your project folder, and add the following line to the top of your file, right below the existing `import` statements:
 
 ```ts
-import { Providers, SharePointProvider } from '@microsoft/mgt';
+import { Providers, SharePointProvider } from '@microsoft/mgt-spfx';
 ```
 
 Next, you need to initialize the provider with the authenticated context inside the `onInit()` method of your web part. In the same file, add the following code right before the `public render(): void {` line:
 
 ```ts
 protected async onInit() {
-    Providers.globalProvider = new SharePointProvider(this.context)
+  if (!Providers.globalProvider) {
+    Providers.globalProvider = new SharePointProvider(this.context);
+  }
 }
 ```
 
@@ -154,6 +151,15 @@ Determine which Microsoft Graph API permissions you need depending on the compon
   }
 ]
 ```
+
+## Deploy the Microsoft Graph Toolkit SharePoint Framework package
+
+Before deploying your SharePoint Framework package to your tenant, you will need to deploy the Microsoft Graph Toolkit SharePoint Framework package to your tenant. You can download the package corresponding to the version of Microsoft Graph Toolkit that you used in your project, from the [Releases](https://github.com/microsoftgraph/microsoft-graph-toolkit/releases) section on GitHub.
+
+**Important:** Since there can be only one version of the SharePoint Framework library for Microsoft Graph Toolkit installed in the tenant, before using MGT in your solution, consult with your organization/customer if they already have a version of SharePoint Framework library for Microsoft Graph Toolkit deployed in their tenant and use the same version to avoid issues.
+
+After downloading the Microsoft Graph Toolkit SharePoint Framework .sppkg package, upload it to your SharePoint Online App Catalog. Go to the [More features page of your SharePoint admin center](https://admin.microsoft.com/sharepoint?page=classicfeatures&modern=true). Select **Open** under **Apps**, then click **App Catalog**, and **Distribute apps for SharePoint**. Upload your `.sppkg` file, and click **Deploy**.
+
 ## Build and deploy your web part
 
 Now, you will build your application and deploy it to SharePoint. Build your application by running the following commands:

--- a/concepts/toolkit/get-started/mgt-spfx.md
+++ b/concepts/toolkit/get-started/mgt-spfx.md
@@ -2,7 +2,7 @@
 title: "SharePoint Framework library for Microsoft Graph Toolkit"
 description: "Use the SharePoint Framework library for Microsoft Graph Toolkit to use Microsoft Graph Toolkit in SharePoint Framework solutions."
 localization_priority: Normal
-author: wmastyka
+author: waldekmastykarz
 ---
 
 # SharePoint Framework library for Microsoft Graph Toolkit

--- a/concepts/toolkit/get-started/mgt-spfx.md
+++ b/concepts/toolkit/get-started/mgt-spfx.md
@@ -1,0 +1,101 @@
+---
+title: "SharePoint Framework library for Microsoft Graph Toolkit"
+description: "Use the SharePoint Framework library for Microsoft Graph Toolkit to use Microsoft Graph Toolkit in SharePoint Framework solutions."
+localization_priority: Normal
+author: wmastyka
+---
+
+# SharePoint Framework library for Microsoft Graph Toolkit
+
+Use the SharePoint Framework library for Microsoft Graph Toolkit to use Microsoft Graph Toolkit in SharePoint Framework solutions.
+
+To prevent multiple components from registering their own set of Microsoft Graph Toolkit components on the page, you should deploy this library to your tenant and reference Microsoft Graph Toolkit components that you use in your solution from this library.
+
+## Installation
+
+To load Microsoft Graph Toolkit components from the library, add the `@microsoft/mgt-spfx` package as a runtime dependency to your SharePoint Framework project:
+
+```bash
+npm install @microsoft/mgt-spfx
+```
+
+or
+
+```bash
+yarn add @microsoft/mgt-spfx
+```
+
+Before deploying your SharePoint Framework package to your tenant, you will need to deploy the `@microsoft/mgt-spfx` SharePoint Framework package to your tenant. You can download the package corresponding to the version of `@microsoft/mgt-spfx` that you used in your project, from the [Releases](https://github.com/microsoftgraph/microsoft-graph-toolkit/releases) section on GitHub.
+
+**Important:** Since there can be only one version of the SharePoint Framework library for Microsoft Graph Toolkit installed in the tenant, before using MGT in your solution, consult with your organization/customer if they already have a version of SharePoint Framework library for Microsoft Graph Toolkit deployed in their tenant and use the same version to avoid issues.
+
+## Usage
+
+When building SharePoint Framework web parts and extensions, reference the Microsoft Graph Toolkit `Provider` and `SharePointProvider` from the `@microsoft/mgt-spfx` package. This will ensure, that your solution will use MGT components that are already registered on the page, rather than instantiating its own. The instantiation process is the same for all web parts no matter which JavaScript framework they use:
+
+```ts
+import { Providers, SharePointProvider } from '@microsoft/mgt-spfx';
+
+// [...] trimmed for brevity
+
+export default class MgtWebPart extends BaseClientSideWebPart<IMgtWebPartProps> {
+  protected async onInit() {
+    if (!Providers.globalProvider) {
+      Providers.globalProvider = new SharePointProvider(this.context);
+    }
+  }
+
+  // [...] trimmed for brevity
+}
+```
+
+When building web parts using framework other than React, you can load components directly in your web part:
+
+```ts
+export default class MgtNoFrameworkWebPart extends BaseClientSideWebPart<IMgtNoFrameworkWebPartProps> {
+  protected async onInit() {
+    if (!Providers.globalProvider) {
+      Providers.globalProvider = new SharePointProvider(this.context);
+    }
+  }
+
+  public render(): void {
+    this.domElement.innerHTML = `
+      <div class="${styles.mgtNoFramework}">
+        <div class="${styles.container}">
+          <div class="${styles.row}">
+            <div class="${styles.column}">
+              <span class="${styles.title}">No framework webpart</span>
+              <mgt-person person-query="me" show-name show-email></mgt-person>
+            </div>
+          </div>
+        </div>
+      </div>`;
+  }
+
+  // [...] trimmed for brevity
+}
+```
+
+If you build web part using React, load components from the `@microsoft/mgt-react` package:
+
+```tsx
+import { Person } from '@microsoft/mgt-react';
+
+// [...] trimmed for brevity
+
+export default class MgtReact extends React.Component<IMgtReactProps, {}> {
+  public render(): React.ReactElement<IMgtReactProps> {
+    return (
+      <div className={ styles.mgtReact }>
+        <Person personQuery="me" />
+      </div>
+    );
+  }
+}
+```
+
+## See also
+
+* [Build a SharePoint web part with the Microsoft Graph Toolkit](./build-a-sharepoint-web-part.md)
+* [Learn about authentication providers](../providers/providers.md)

--- a/concepts/toolkit/get-started/overview.md
+++ b/concepts/toolkit/get-started/overview.md
@@ -90,6 +90,10 @@ The `@microsoft/mgt` is the main package that includes all above packages and re
 
 The [`@microsoft/mgt-react`](./mgt-react.md) package contains all auto-generated React components and takes dependency on the `@microsoft/mgt` package.
 
+<b>@microsoft/mgt-spfx</b>
+
+The [`@microsoft/mgt-spfx`](./mgt-spfx.md) package contains a SharePoint Framework library that's required to use Microsoft Graph Toolkit in SharePoint Framework solutions.
+
 ## Polyfills
 
 If you're using the ES6 modules from the npm package and you're [targeting a browser such as IE11](https://caniuse.com/#search=components) that does not support web components natively, you will need to include polyfills in your project, as they are not automatically included. Polyfills help to fill in missing browser capabilities in browsers that are still in the process of updating to support Web Component standards. For instructions and to learn more, see [polyfills documentation](https://www.webcomponents.org/polyfills). 

--- a/concepts/toolkit/providers/sharepoint.md
+++ b/concepts/toolkit/providers/sharepoint.md
@@ -35,7 +35,7 @@ public render(): void {
 }
 ```
 
->**Note:** The Microsoft Graph Toolkit requires Typescript 3.7 or newer. Make sure you're using a supported version of Typescript by [installing the right compiler](https://github.com/SharePoint/sp-dev-docs/wiki/SharePoint-Framework-v1.8-release-notes#support-for-typescript-27-29-and-3x). If you use SharePoint Framework v1.12 or newer, you already use the correct version of TypeScript in your project.
+>**Note:** The Microsoft Graph Toolkit requires Typescript 3.7 or newer. Make sure you're using a supported version of Typescript by [installing the right compiler](https://github.com/SharePoint/sp-dev-docs/wiki/SharePoint-Framework-v1.8-release-notes#support-for-typescript-27-29-and-3x).
 
 ## Sample
 

--- a/concepts/toolkit/providers/sharepoint.md
+++ b/concepts/toolkit/providers/sharepoint.md
@@ -17,11 +17,11 @@ Initialize the provider inside the `onInit()` method of your web part.
 
 ```ts
 // import the providers at the top of the page
-import {Providers, SharePointProvider} from '@microsoft/mgt';
+import {Providers, SharePointProvider} from '@microsoft/mgt-spfx';
 
 // add the onInit() method if not already there in your web part class
 protected async onInit() {
-    Providers.globalProvider = new SharePointProvider(this.context);
+  Providers.globalProvider = new SharePointProvider(this.context);
 }
 ```
 
@@ -29,13 +29,13 @@ Now you can add any component in your `render()` method and it will use the Shar
 
 ```ts
 public render(): void {
-    this.domElement.innerHTML = `
-      <mgt-agenda></mgt-agenda>
-      `;
-  }
+  this.domElement.innerHTML = `
+    <mgt-agenda></mgt-agenda>
+    `;
+}
 ```
 
->**Note:** The Microsoft Graph Toolkit requires Typescript 3.x. Make sure you're using a supported version of Typescript by [installing the right compiler](https://github.com/SharePoint/sp-dev-docs/wiki/SharePoint-Framework-v1.8-release-notes#support-for-typescript-27-29-and-3x).
+>**Note:** The Microsoft Graph Toolkit requires Typescript 3.7 or newer. Make sure you're using a supported version of Typescript by [installing the right compiler](https://github.com/SharePoint/sp-dev-docs/wiki/SharePoint-Framework-v1.8-release-notes#support-for-typescript-27-29-and-3x). If you use SharePoint Framework v1.12 or newer, you already use the correct version of TypeScript in your project.
 
 ## Sample
 


### PR DESCRIPTION
This PR contains updated instructions for using Microsoft Graph Toolkit with SharePoint Framework. It's based on the new structure of MGT that is yet to be released (https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/856).