### PR TITLE
- adds outlook subscription limitation that got removed because of bad merge

### DIFF
--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -93,9 +93,11 @@ When subscribing to Outlook resources such as **messages**, **events** or **cont
 
 `/users/sh.o'neal@contoso.com/messages`
 
-Use: 
+Use:
 
 `/users/{guid-user-id}/messages`
+
+A maximum of 1000 active subscriptions per mailbox for all applications is allowed.
 
 ### Teams resource limitations
 


### PR DESCRIPTION
- adds the outlook limitation back in the webhook concept page

this commit https://github.com/microsoftgraph/microsoft-graph-docs/commit/be34ab95cf1423d7e95f428cfb8f1ef067b7d12c
was conflicting with that one https://github.com/microsoftgraph/microsoft-graph-docs/commit/1f7dd2d2afd230e59aada1d61d30ac47bb7d03c3#diff-23f74b5a6c6935903d87e6f17ef663f5cb4a98d5afbf06fd5e7d1e4c32998490

And I didn't handle the merge properly at the time.

This PR restores the information after someone asked me about the limitation.