### PR TITLE
Removed clientContext from call.transfer

### DIFF
--- a/api-reference/beta/api/call-transfer.md
+++ b/api-reference/beta/api/call-transfer.md
@@ -48,7 +48,6 @@ In the request body, provide a JSON object with the following parameters.
 | Parameter      | Type    |Description|
 |:---------------|:--------|:----------|
 |transferTarget|[invitationParticipantInfo](../resources/invitationparticipantinfo.md)|The participant which is the target of the transfer.|
-|clientContext|String|Unique Client Context string. Max limit is 256 chars.|
 
 ## Response
 If successful, this method returns a `202 Accepted` response code.
@@ -84,8 +83,7 @@ Content-Length: 430
     },
     "languageId": "languageId-value",
     "region": "region-value"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 # [C#](#tab/csharp)
@@ -274,8 +272,7 @@ Content-Type: application/json
     "languageId": "en-us",
     "region": "amer",
     "replacesCallId": "e5d39592-99bd-4db8-bca8-30fb894ec51d"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 
@@ -465,8 +462,7 @@ Content-Length: 430
     },
     "languageId": "languageId-value",
     "region": "region-value"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 
@@ -643,8 +639,7 @@ Content-Type: application/json
     "languageId": "en-us",
     "region": "amer",
     "replacesCallId": "e5d39592-99bd-4db8-bca8-30fb894ec51d"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 

--- a/api-reference/v1.0/api/call-transfer.md
+++ b/api-reference/v1.0/api/call-transfer.md
@@ -44,7 +44,6 @@ In the request body, provide a JSON object with the following parameters.
 | Parameter      | Type    |Description|
 |:---------------|:--------|:----------|
 |transferTarget|[invitationParticipantInfo](../resources/invitationparticipantinfo.md)|The participant which is the target of the transfer.|
-|clientContext|String|Unique Client Context string. Max limit is 256 chars.|
 
 ## Response
 If successful, this method returns a `202 Accepted` response code.
@@ -78,8 +77,7 @@ Content-Length: 430
       }
     },
     "replacesCallId": "replacesCallId-value"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 # [C#](#tab/csharp)
@@ -270,8 +268,7 @@ Content-Type: application/json
       }
     },
     "replacesCallId": "e5d39592-99bd-4db8-bca8-30fb894ec51d"
-  },
-  "clientContext": "9e90d1c1-f61e-43e7-9f75-d420159aae08"
+  }
 }
 ```
 


### PR DESCRIPTION
We've received customer feedback that `clientContext` is not supported in `transfer` action. Upon checking the schema:
```xml
<Action Name="transfer" IsBound="true">
    <Parameter Name="bindingParameter" Type="graph.call" />
    <Parameter Name="transferTarget" Type="graph.invitationParticipantInfo" Nullable="false" />
</Action>
```
the feedback is correct. `transfer` doesn't have a parameter named "clientContext" hence this PR to remove it from the doc.