### PR TITLE
[mgt] adding personPresence property to mgt-person default template

### DIFF
--- a/concepts/toolkit/components/person.md
+++ b/concepts/toolkit/components/person.md
@@ -124,7 +124,7 @@ The `mgt-person` component supports several [templates](../customize-components/
 | --------- | ------------ | ----------- |
 | loading | none | The template to render while the component is in a loading state. |
 | no-data | none | The template to render when no person image or data is available. | 
-| default | person: The person details object <br> `personImage`: The URL of the image | The default template replaces the entire component with your own. |
+| default | person: The person details object <br> `personImage`: The URL of the image <br> `personPresence`: The presence details object for person  | The default template replaces the entire component with your own. |
 | person-card | person: The person details object <br> `personImage`: The URL of the image | The template to update the mgt-person-card displayed on hover or click. |
 | line1 | person: The person details object | The template for the first line of person metadata. |
 | line2 | person: The person details object | The template for the second line of person metadata. |


### PR DESCRIPTION
*Library:* mgt 
*component* mgt-person
*description:* adding `personPresence` object to the default template of mgt-person to use properties. 
ref:
https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/965