### PR TITLE
[MGT] Fixed code example in Provider docs

### DIFF
--- a/concepts/toolkit/providers/providers.md
+++ b/concepts/toolkit/providers/providers.md
@@ -125,7 +125,7 @@ import { Providers, ProviderState } from "@microsoft/mgt";
 //assuming a provider has already been initialized
 
 if (Providers.globalProvider.state === ProviderState.SignedIn) {
-  const token = Providers.globalProvider.getAccessToken({scopes: ['User.Read']})
+  const token = await Providers.globalProvider.getAccessToken({scopes: ['User.Read']})
 }
 ```
 


### PR DESCRIPTION
This PR fixes the `getAccessToken` example in the Provider docs by adding `await` for the call.