### PR TITLE
update channel page to reflect isFavoriteByDefault behavior during channel creation

### DIFF
--- a/api-reference/beta/resources/channel.md
+++ b/api-reference/beta/resources/channel.md
@@ -52,7 +52,7 @@ where files are shared, and where tabs are added.
 |description|String|Optional textual description for the channel.|
 |displayName|String|Channel name as it will appear to the user in Microsoft Teams.|
 |id|String|The channel's unique identifier. Read-only.|
-|isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically with [Create team](../api/team-post.md). Default: `false`.|
+|isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically during channel creation. Default: `false`.|
 |email|String| The email address for sending messages to the channel. Read-only.|
 |webUrl|String|A hyperlink that will go to the channel in Microsoft Teams. This is the URL that you get when you right-click a channel in Microsoft Teams and select Get link to channel. This URL should be treated as an opaque blob, and not parsed. Read-only.|
 |membershipType|[channelMembershipType](../resources/enums.md#channelmembershiptype-values)|The type of the channel. Can be set during creation and cannot be changed. Default: standard.|

--- a/api-reference/v1.0/resources/channel.md
+++ b/api-reference/v1.0/resources/channel.md
@@ -49,7 +49,7 @@ where files are shared, and where tabs are added.
 |description|String|Optional textual description for the channel.|
 |displayName|String|Channel name as it will appear to the user in Microsoft Teams.|
 |id|String|The channel's unique identifier. Read-only.|
-|isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically with [Create team](../api/team-post.md). Default: `false`.|
+|isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically during channel creation. Default: `false`.|
 |email|String| The email address for sending messages to the channel. Read-only.|
 |webUrl|String|A hyperlink that will go to the channel in Microsoft Teams. This is the URL that you get when you right-click a channel in Microsoft Teams and select Get link to channel. This URL should be treated as an opaque blob, and not parsed. Read-only.|
 |membershipType|[channelMembershipType](../resources/enums.md#channelmembershiptype-values)|The type of the channel. Can be set during creation and cannot be changed. Possible values are: `standard` - Channel inherits the list of members of the parent team; `private` - Channel can have members that are a subset of all the members on the parent team.


### PR DESCRIPTION
isFavoriteByDefault property can be set during channel creation as well as team creation. updated the document to reflect this behavior.