### PR TITLE
Update Assignments GET APIs to include AppOnly support

### DIFF
--- a/api-reference/beta/api/educationassignment-get-rubric.md
+++ b/api-reference/beta/api/educationassignment-get-rubric.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Not supported. |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationassignment-get-rubric.md
+++ b/api-reference/beta/api/educationassignment-get-rubric.md
@@ -1,6 +1,6 @@
 ---
 title: "Get educationRubric attached to educationAssignment"
-description: "Get the educaitonRubric attached to an educationAssignment, if one exists."
+description: "Get the educationRubric attached to an educationAssignment, if one exists."
 localization_priority: Normal
 author: "dipakboyed"
 ms.prod: "education"

--- a/api-reference/beta/api/educationassignment-get.md
+++ b/api-reference/beta/api/educationassignment-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported.  | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationassignment-get.md
+++ b/api-reference/beta/api/educationassignment-get.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Get the properties and relationships of an assignment. Students can only see assignments assigned to them; teachers can see all assignments in a class.
+Get the properties and relationships of an assignment. Students can only see assignments assigned to them; teachers and applications with application permissions can see all assignments in a class.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/educationassignment-list-categories.md
+++ b/api-reference/beta/api/educationassignment-list-categories.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not Supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationassignment-list-resources.md
+++ b/api-reference/beta/api/educationassignment-list-resources.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationassignment-list-submissions.md
+++ b/api-reference/beta/api/educationassignment-list-submissions.md
@@ -1,6 +1,6 @@
 ---
 title: "List submissions"
-description: "List all the submissions associated with this assignment. A teacher can get all the submissions while a student can only get submissions that they are associated with."
+description: "List all the submissions associated with this assignment. A teacher or an application with application permissions can get all the submissions while a student can only get submissions that they are associated with."
 author: "dipakboyed"
 localization_priority: Normal
 ms.prod: "education"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-List all the submissions associated with this assignment. A teacher can get all the submissions while a student can only get submissions that they are associated with.
+List all the submissions associated with this assignment. A teacher or an application with application permissions can get all the submissions while a student can only get submissions that they are associated with.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/educationassignment-list-submissions.md
+++ b/api-reference/beta/api/educationassignment-list-submissions.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not Supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationassignmentdefaults-get.md
+++ b/api-reference/beta/api/educationassignmentdefaults-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)| EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 |Delegated (personal Microsoft account)| Not supported. |
-|Application| Not supported. |
+|Application| EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationassignmentresource-get.md
+++ b/api-reference/beta/api/educationassignmentresource-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite   |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application |  Not supported. | 
+|Application |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationassignmentsettings-get.md
+++ b/api-reference/beta/api/educationassignmentsettings-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application| EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationcategory-get.md
+++ b/api-reference/beta/api/educationcategory-get.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :----------------------------------------------------------------------------------------------------- |
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported.                                                                                         |
-| Application                            | Not supported.                                                                                         |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationclass-list-assignments.md
+++ b/api-reference/beta/api/educationclass-list-assignments.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :----------------------------------------------------------------------------------------------------- |
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported.                                                                                         |
-| Application                            | Not supported.                                                                                         |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationclass-list-assignments.md
+++ b/api-reference/beta/api/educationclass-list-assignments.md
@@ -1,6 +1,6 @@
 ---
 title: "List assignments"
-description: "Retrieve a list of assignment objects. A teacher is allowed to see all assignment objects for the class. Students can only see assignments that are assigned to them."
+description: "Retrieve a list of assignment objects. A teacher or an application executing with application permissions is allowed to see all assignment objects for the class. Students can only see assignments that are assigned to them."
 author: "mmast-msft"
 localization_priority: Normal
 ms.prod: "education"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve a list of assignment objects. A teacher is allowed to see all assignment objects for the class. Students can only see assignments that are assigned to them.
+Retrieve a list of assignment objects. A teacher or an application executing with application permissions is allowed to see all assignment objects for the class. Students can only see assignments that are assigned to them.
 
 ## Permissions
 

--- a/api-reference/beta/api/educationclass-list-categories.md
+++ b/api-reference/beta/api/educationclass-list-categories.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :----------------------------------------------------------------------------------------------------- |
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported.                                                                                         |
-| Application                            | Not supported.                                                                                         |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationrubric-get.md
+++ b/api-reference/beta/api/educationrubric-get.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Not supported. |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationsubmission-get.md
+++ b/api-reference/beta/api/educationsubmission-get.md
@@ -1,6 +1,6 @@
 ---
 title: "Get educationSubmission"
-description: "Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher has full access to all submissions. "
+description: "Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher or application with application permissions has full access to all submissions. "
 author: "dipakboyed"
 localization_priority: Normal
 ms.prod: "education"
@@ -13,9 +13,9 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher has full access to all submissions.
+Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher or application with application permissions has full access to all submissions.
 
-The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers can add or change grades and feedback. Students will not see the grade or feedback until the assignment has been released.
+The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers or applications with application permissions can add or change grades and feedback. Students will not see the grade or feedback until the assignment has been released.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/educationsubmission-get.md
+++ b/api-reference/beta/api/educationsubmission-get.md
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationsubmission-list-outcomes.md
+++ b/api-reference/beta/api/educationsubmission-list-outcomes.md
@@ -33,7 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Not supported. |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationsubmission-list-resources.md
+++ b/api-reference/beta/api/educationsubmission-list-resources.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :----------------------------------------------------------------------------------------------------- |
 | Delegated (work or school account)     | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 | Delegated (personal Microsoft account) | Not supported.                                                                                         |
-| Application                            | Not supported.                                                                                         |
+| Application                            | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite |
 
 ## HTTP request
 

--- a/api-reference/beta/api/educationsubmission-list-submittedresources.md
+++ b/api-reference/beta/api/educationsubmission-list-submittedresources.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationsubmissionresource-get.md
+++ b/api-reference/beta/api/educationsubmissionresource-get.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationsubmittedsubmissionresource-get.md
+++ b/api-reference/beta/api/educationsubmittedsubmissionresource-get.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) |  EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite  |
 |Delegated (personal Microsoft account) |  Not supported.  |
-|Application | Not supported. | 
+|Application | EduAssignments.ReadBasic, EduAssignments.ReadWriteBasic, EduAssignments.Read, EduAssignments.ReadWrite | 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/educationsubmittedsubmissionresource-get.md
+++ b/api-reference/beta/api/educationsubmittedsubmissionresource-get.md
@@ -1,6 +1,6 @@
 ---
 title: "Get educationSubmittedSubmissionResource"
-description: "Returns a submitted resource. This will be available to a teacher after a student has submitted, and will be available to the student after the teacher has released the submission.  Note that teachers can leave notes in some resources."
+description: "Returns a submitted resource. This will be available to a teacher or an application with application permissions after a student has submitted, and will be available to the student after the teacher has released the submission.  Note that teachers can leave notes in some resources."
 author: "mmast-msft"
 localization_priority: Normal
 ms.prod: "education"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Returns a submitted resource. This will be available to a teacher after a student has submitted, and will be available to the student after the teacher has released the submission.  Note that teachers can leave notes in some resources.
+Returns a submitted resource. This will be available to a teacher or an application with application permissions after a student has submitted, and will be available to the student after the teacher has released the submission.  Note that teachers can leave notes in some resources.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/changelog/Microsoft.EducationAssignment.json
+++ b/changelog/Microsoft.EducationAssignment.json
@@ -3,6 +3,24 @@
     {
       "ChangeList": [
         {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "EduAssignments.ReadBasic,EduAssignments.ReadWriteBasic,EduAssignments.Read,EduAssignments.ReadWrite",
+          "ChangeType": "Addition",
+          "Description": "Added support for the *EduAssignments.ReadBasic*, *EduAssignments.ReadWriteBasic*, *EduAssignments.Read*, *EduAssignments.ReadWrite* application permissions to get [educationAssignment](https://docs.microsoft.com/en-us/graph/api/resources/educationassignment?view=graph-rest-beta), [educationCategory](https://docs.microsoft.com/en-us/graph/api/resources/educationcategory?view=graph-rest-beta), [educationAssignmentResource](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentresource?view=graph-rest-beta), [educationSubmission](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmission?view=graph-rest-beta), [educationSubmissionResource](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmissionresource?view=graph-rest-beta), [educationRubric](https://docs.microsoft.com/en-us/graph/api/resources/educationrubric?view=graph-rest-beta), [educationAssignmentDefaults](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentdefaults?view=graph-rest-beta), [educationAssignmentSettings](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentsettings?view=graph-rest-beta), [educationOutcome](https://docs.microsoft.com/en-us/graph/api/resources/educationoutcome?view=graph-rest-beta) resources.",
+          "Target": "educationAssignment,educationCategory,educationAssignmentResource,educationSubmission,educationSubmissionResource,educationRubric,educationAssignmentDefaults,educationAssignmentSettings,educationOutcome"
+        }
+      ],
+      "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2021-04-22T00:00:00",
+      "WorkloadArea": "Education",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "b3c8d772-6774-11eb-bfcb-fe6ee26532c0",
           "ApiChange": "Relationship",
           "ChangedApiName": "assignmentDefaults",

--- a/changelog/Microsoft.EducationAssignment.json
+++ b/changelog/Microsoft.EducationAssignment.json
@@ -2,13 +2,77 @@
   "changelog": [
     {
       "ChangeList": [
+         {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationAssignment",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationAssignment](https://docs.microsoft.com/en-us/graph/api/resources/educationassignment?view=graph-rest-beta) resource.",
+          "Target": "educationAssignment"
+        },
         {
           "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
           "ApiChange": "Permission",
-          "ChangedApiName": "EduAssignments.ReadBasic,EduAssignments.ReadWriteBasic,EduAssignments.Read,EduAssignments.ReadWrite",
+          "ChangedApiName": "educationCategory",
           "ChangeType": "Addition",
-          "Description": "Added support for the *EduAssignments.ReadBasic*, *EduAssignments.ReadWriteBasic*, *EduAssignments.Read*, *EduAssignments.ReadWrite* application permissions to get [educationAssignment](https://docs.microsoft.com/en-us/graph/api/resources/educationassignment?view=graph-rest-beta), [educationCategory](https://docs.microsoft.com/en-us/graph/api/resources/educationcategory?view=graph-rest-beta), [educationAssignmentResource](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentresource?view=graph-rest-beta), [educationSubmission](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmission?view=graph-rest-beta), [educationSubmissionResource](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmissionresource?view=graph-rest-beta), [educationRubric](https://docs.microsoft.com/en-us/graph/api/resources/educationrubric?view=graph-rest-beta), [educationAssignmentDefaults](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentdefaults?view=graph-rest-beta), [educationAssignmentSettings](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentsettings?view=graph-rest-beta), [educationOutcome](https://docs.microsoft.com/en-us/graph/api/resources/educationoutcome?view=graph-rest-beta) resources.",
-          "Target": "educationAssignment,educationCategory,educationAssignmentResource,educationSubmission,educationSubmissionResource,educationRubric,educationAssignmentDefaults,educationAssignmentSettings,educationOutcome"
+          "Description": "Added support for application permissions to the [educationCategory](https://docs.microsoft.com/en-us/graph/api/resources/educationcategory?view=graph-rest-beta) resource.",
+          "Target": "educationCategory"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationAssignmentResource",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationAssignmentResource](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentresource?view=graph-rest-beta) resource.",
+          "Target": "educationAssignmentResource"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationSubmission",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationSubmission](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmission?view=graph-rest-beta) resource.",
+          "Target": "educationSubmission"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationSubmissionResource",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationSubmissionResource](https://docs.microsoft.com/en-us/graph/api/resources/educationsubmissionresource?view=graph-rest-beta) resource.",
+          "Target": "educationSubmissionResource"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationRubric",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationRubric](https://docs.microsoft.com/en-us/graph/api/resources/educationrubric?view=graph-rest-beta) resource.",
+          "Target": "educationRubric"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationAssignmentDefaults",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationAssignmentDefaults](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentdefaults?view=graph-rest-beta) resource.",
+          "Target": "educationAssignmentDefaults"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationAssignmentSettings",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationAssignmentSettings](https://docs.microsoft.com/en-us/graph/api/resources/educationassignmentsettings?view=graph-rest-beta) resource.",
+          "Target": "educationAssignmentSettings"
+        },
+        {
+          "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",
+          "ApiChange": "Permission",
+          "ChangedApiName": "educationOutcome",
+          "ChangeType": "Addition",
+          "Description": "Added support for application permissions to the [educationOutcome](https://docs.microsoft.com/en-us/graph/api/resources/educationoutcome?view=graph-rest-beta) resource.",
+          "Target": "educationOutcome"
         }
       ],
       "Id": "55c6e37b-93d5-4684-9145-5d36f338faf3",


### PR DESCRIPTION
Updating the EduAssignments docs to specify that we now support Applications Permissions for certain Assignments GET APIs (READ operations).