### PR TITLE
Correct Intune Device Management Permissions

### DIFF
--- a/api-reference/v1.0/api/intune-devices-detectedapp-get.md
+++ b/api-reference/v1.0/api/intune-devices-detectedapp-get.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 
 ## HTTP Request
 <!-- {

--- a/api-reference/v1.0/api/intune-devices-detectedapp-list.md
+++ b/api-reference/v1.0/api/intune-devices-detectedapp-list.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 
 ## HTTP Request
 <!-- {

--- a/api-reference/v1.0/api/intune-devices-manageddevice-get.md
+++ b/api-reference/v1.0/api/intune-devices-manageddevice-get.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 
 ## HTTP Request
 <!-- {

--- a/api-reference/v1.0/api/intune-devices-manageddevice-list.md
+++ b/api-reference/v1.0/api/intune-devices-manageddevice-list.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|DeviceManagementManagedDevices.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
 
 ## HTTP Request
 <!-- {


### PR DESCRIPTION
Correct required application permissions to get and list intune managed devices and detected apps - the application permission type is supported by these endpoints. Resolves https://github.com/microsoftgraph/microsoft-graph-docs/issues/5209 