### PR TITLE
Fix - Add permissionsGrant relationship to group resource

### DIFF
--- a/api-reference/beta/api/group-list-permissiongrants.md
+++ b/api-reference/beta/api/group-list-permissiongrants.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-List all [resource-specific permission grants](../resources/resourcespecificpermissiongrant.md) on the [group](../resources/group.md). This is a list of Azure AD apps that have access to the chat along with the kind of access that each app has.
+List all [resource-specific permission grants](../resources/resourcespecificpermissiongrant.md) on the [group](../resources/group.md). This is a list of Azure AD apps that have access to the group along with the kind of access that each app has.
 
 ## Permissions
 

--- a/api-reference/beta/resources/group.md
+++ b/api-reference/beta/resources/group.md
@@ -185,6 +185,7 @@ This resource supports:
 |membersWithLicenseErrors|[user](user.md) collection|A list of group members with license errors from this group-based license assignment. Read-only.|
 |onenote|[onenote](onenote.md)| Read-only.|
 |owners|[directoryObject](directoryobject.md) collection|The owners of the group. The owners are a set of non-admin users who are allowed to modify this object. HTTP Methods: GET (supported for all groups), POST (supported for security groups and mail-enabled security groups), DELETE (supported only for security groups) Read-only. Nullable.|
+|permissionGrants|[resourceSpecificPermissionGrant](resourcespecificpermissiongrant.md)|The permission that has been granted for a group to a specific application.|
 |photo|[profilePhoto](profilephoto.md)| The group's profile photo. |
 |photos|[profilePhoto](profilephoto.md) collection| The profile photos owned by the group. Read-only. Nullable.|
 |planner|[plannerGroup](plannergroup.md)| Selective Planner services available to the group. Read-only. Nullable. |

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -556,6 +556,8 @@ items:
           href: api/group-list-owners.md
         - name: List photos
           href: api/group-list-photos.md
+        - name: List permission grants
+          href: api/group-list-permissiongrants.md
         - name: Permanently delete group
           href: api/directory-deleteditems-delete.md
         - name: Remove favorite

--- a/api-reference/v1.0/api/group-list-permissiongrants.md
+++ b/api-reference/v1.0/api/group-list-permissiongrants.md
@@ -1,0 +1,110 @@
+---
+title: "List permissionGrants of a group"
+description: "Retrieve permissionGrants of a group."
+author: "akjo"
+localization_priority: Priority
+ms.prod: "microsoft-teams"
+doc_type: apiPageType
+---
+
+# List permissionGrants of a group
+
+Namespace: microsoft.graph
+
+List all [resource-specific permission grants](../resources/resourcespecificpermissiongrant.md) on the [group](../resources/group.md). This is a list of Azure AD apps that have access to the chat along with the kind of access that each app has.
+
+## Permissions
+
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+| Permission Type                        | Permissions (from least to most privileged)                                          |
+| :------------------------------------- | :----------------------------------------------------------------------------------- |
+| Delegated (work or school account)     | GroupMember.Read.All, GroupMember.ReadWrite.All, Group.Read.All, Group.ReadWrite.All |
+| Delegated (personal Microsoft account) | Not supported.                                                                       |
+| Application                            | GroupMember.Read.All, GroupMember.ReadWrite.All, Group.Read.All, Group.ReadWrite.All |
+
+## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /groups/{group-id}/permissionGrants
+```
+
+## Optional query parameters
+
+This operation does not support the [OData query parameters](/graph/query-parameters) to customize the response.
+
+## Request headers
+
+| Header           | Value                      |
+| :--------------- | :------------------------- |
+| Authorization    | Bearer {token}. Required.  |
+
+## Request body
+
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a list of [resourceSpecificPermissionGrant](../resources/resourcespecificpermissiongrant.md) objects in the response body.
+
+## Examples
+
+### Request
+
+The following is an example of the request.
+
+<!-- {
+  "blockType": "request",
+  "name": "group_list_permission_grants"
+}-->
+```msgraph-interactive
+GET https://graph.microsoft.com/v1.0/groups/14c981a4-dca9-4565-bae6-e13ada8861be/permissionGrants
+```
+
+### Response
+
+The following example shows the response.
+
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.resourceSpecificPermissionGrant"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#permissionGrants",
+    "value": [
+        {
+            "id": "ZfwbxSIj9OGOBxsBmwY555mOHr_W6qN7LEbFYIIcM5A",
+            "deletedDateTime": null,
+            "clientId": "771b9da9-2260-41eb-a587-4d936e4aa08c",
+            "clientAppId": "fdebf36e-8b3a-4b00-99fb-2e4d1da706d6",
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "permissionType": "Application",
+            "permission": "TeamMember.Read.Group"
+        },
+        {
+            "id": "WsYCHhlwjliiK19ONpJiWq6rtFy-Tg1q8h9-f-DATto",
+            "deletedDateTime": null,
+            "clientId": "771b9da9-2260-41eb-a587-4d936e4aa08c",
+            "clientAppId": "fdebf36e-8b3a-4b00-99fb-2e4d1da706d6",
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "permissionType": "Application",
+            "permission": "TeamsTab.Create.Group"
+        },
+        {
+            "id": "wtAZautz7ilRA0kgHYWr2Ss2FTK3jPkf-HPhj3FS1wo",
+            "deletedDateTime": null,
+            "clientId": "74c92190-dc0e-485a-81c6-fdffd4aadfd8",
+            "clientAppId": "69024002-35ae-4574-a219-f261183580b4",
+            "resourceAppId": "00000003-0000-0000-c000-000000000000",
+            "permissionType": "Application",
+            "permission": "TeamMember.Read.Group"
+        }
+    ]
+}
+```

--- a/api-reference/v1.0/api/group-list-permissiongrants.md
+++ b/api-reference/v1.0/api/group-list-permissiongrants.md
@@ -11,7 +11,7 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-List all [resource-specific permission grants](../resources/resourcespecificpermissiongrant.md) on the [group](../resources/group.md). This is a list of Azure AD apps that have access to the chat along with the kind of access that each app has.
+List all [resource-specific permission grants](../resources/resourcespecificpermissiongrant.md) on the [group](../resources/group.md). This is a list of Azure AD apps that have access to the group along with the kind of access that each app has.
 
 ## Permissions
 

--- a/api-reference/v1.0/resources/group.md
+++ b/api-reference/v1.0/resources/group.md
@@ -174,6 +174,7 @@ This resource supports:
 |membersWithLicenseErrors|[User](user.md) collection|A list of group members with license errors from this group-based license assignment. Read-only.|
 |onenote|[Onenote](onenote.md)| Read-only.|
 |owners|[directoryObject](directoryobject.md) collection|The owners of the group. The owners are a set of non-admin users who are allowed to modify this object. Limited to 100 owners. HTTP Methods: GET (supported for all groups), POST (supported for Microsoft 365 groups, security groups and mail-enabled security groups), DELETE (supported for Microsoft 365 groups and security groups). Nullable.|
+|permissionGrants|[resourceSpecificPermissionGrant](resourcespecificpermissiongrant.md)|The permission that has been granted for a group to a specific application.|
 |photo|[profilePhoto](profilephoto.md)| The group's profile photo |
 |photos|[profilePhoto](profilephoto.md) collection| The profile photos owned by the group. Read-only. Nullable.|
 |planner|[plannerGroup](plannergroup.md)| Entry-point to Planner resource that might exist for a Unified Group.|

--- a/api-reference/v1.0/resources/resourcespecificpermissiongrant.md
+++ b/api-reference/v1.0/resources/resourcespecificpermissiongrant.md
@@ -1,0 +1,54 @@
+---
+title: "resourceSpecificPermissionGrant resource type"
+description: "Specifies the permission that a specific Azure AD app has."
+author: "AkJo"
+localization_priority: Normal
+ms.prod: "microsoft-teams"
+doc_type: resourcePageType
+---
+
+# resourceSpecificPermissionGrant resource type
+
+Namespace: microsoft.graph
+
+A resourceSpecificPermissionGrant declares the permission that has been granted to a specific AzureAD app for an instance of a resource in Microsoft Graph.
+
+## Methods
+
+|  Method                                                                   |  Return Type                                                                     | Description                                                  | 
+| :------------------------------------------------------------------------ | :------------------------------------------------------------------------------- | :----------------------------------------------------------- |
+|[List permission grants of a group](../api/group-list-permissiongrants.md) | [resourceSpecificPermissionGrant](resourcespecificpermissiongrant.md) collection | List permissions that have been granted in a specific group. |
+
+## Properties
+
+| Property        | Type          | Description                                                                           |
+| :-------------- | :------------ | :------------------------------------------------------------------------------------ |
+| id              | string        | The unique identifier of the resource-specific permission grant. Read-only.           |
+| deletedDateTime | dateTimeOffset| Not used.                                                                             |
+| clientId        | string        | ID of the Azure AD app that has been granted access. Read-only.                            |
+| clientAppId     | string        | ID of the service principal of the Azure AD app that has been granted access. Read-only.   |
+| resourceAppId   | string        | ID of the Azure AD app that is hosting the resource. Read-only.                        |
+| permissionType  | string        | The type of permission. Possible values are: `Application`, `Delegated`. Read-only. |
+| permission      | string        | The name of the permission. Read-only.                                                |
+
+## JSON representation
+
+The following is a JSON representation of the resource.
+
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.resourceSpecificPermissionGrant"
+}-->
+
+```json
+{
+  "id": "string (identifier)",
+  "deletedDateTime": "dateTimeOffset",
+  "clientId": "string",
+  "clientAppId": "string",
+  "resourceAppId": "string",
+  "permissionType": "string",
+  "permission": "string"
+}
+```

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -512,6 +512,8 @@ items:
           href: api/group-list-owners.md
         - name: List photos
           href: api/group-list-photos.md
+        - name: List permission grants
+          href: api/group-list-permissiongrants.md
         - name: Remove favorite
           href: api/group-removefavorite.md
         - name: Remove member


### PR DESCRIPTION
An oversight in the group resource. The **permissionsGrant** relationship was not documented though it's in the metadata.