### PR TITLE
update EM approval object description

### DIFF
--- a/api-reference/beta/api/approval-get.md
+++ b/api-reference/beta/api/approval-get.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve the properties of an [approval](../resources/approval.md) object.
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), retrieves the properties of an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](accesspackageassignmentrequest.md).
 
 ## Permissions
 

--- a/api-reference/beta/api/approval-get.md
+++ b/api-reference/beta/api/approval-get.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), retrieves the properties of an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](accesspackageassignmentrequest.md).
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), retrieves the properties of an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](../resources/accesspackageassignmentrequest.md).
 
 ## Permissions
 

--- a/api-reference/beta/api/approval-list-steps.md
+++ b/api-reference/beta/api/approval-list-steps.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-List the [approvalStep](../resources/approvalstep.md) objects associated with an [approval](../resources/approval.md) object.
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), lists the [approvalStep](../resources/approvalstep.md) objects associated with an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](accesspackageassignmentrequest.md).
 
 ## Permissions
 

--- a/api-reference/beta/api/approval-list-steps.md
+++ b/api-reference/beta/api/approval-list-steps.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), lists the [approvalStep](../resources/approvalstep.md) objects associated with an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](accesspackageassignmentrequest.md).
+In [Azure AD entitlement management](../resources/entitlementmanagement-root.md), lists the [approvalStep](../resources/approvalstep.md) objects associated with an [approval](../resources/approval.md) object.  This call can be made by an approver, providing the identifier of the [access package assignment request](../resources/accesspackageassignmentrequest.md).
 
 ## Permissions
 

--- a/api-reference/beta/resources/approval.md
+++ b/api-reference/beta/resources/approval.md
@@ -27,7 +27,7 @@ In [userConsentRequests](../resources/userconsentrequest.md), the approval objec
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|id|String|The identifier of the approval object.|
+|id|String|The identifier of the approval object.  In entitlement management, it is the same identifier as the identifier of the [access package assignment request](accesspackageassignmentrequest.md).|
 |steps|[approvalStep](../resources/approvalstep.md) collection|Used to represent the decision associated with a single step in the approval process configured in [approvalStage](../resources/approvalstage.md).|
 
 ## Relationships

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -11230,10 +11230,10 @@ items:
             items:
             - name: Approval step
               href: resources/approvalstep.md
-            - name: List approval steps
-              href: api/approval-list-steps.md
             - name: Get approval
               href: api/approval-get.md
+            - name: List approval steps
+              href: api/approval-list-steps.md
             - name: Get approval step
               href: api/approvalstep-get.md
             - name: Update approval step

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -11225,6 +11225,19 @@ items:
             items:
             - name: List
               href: api/accesspackageassignment-list.md
+          - name: Access package assignment approval
+            href: resources/approval.md
+            items:
+            - name: Approval step
+              href: resources/approvalstep.md
+            - name: List approval steps
+              href: api/approval-list-steps.md
+            - name: Get approval
+              href: api/approval-get.md
+            - name: Get approval step
+              href: api/approvalstep-get.md
+            - name: Update approval step
+              href: api/approvalstep-update.md
           - name: Access package assignment policy
             href: resources/accesspackageassignmentpolicy.md
             items:
@@ -11317,20 +11330,6 @@ items:
               href: api/connectedorganization-delete-externalsponsors.md
             - name: Remove internal sponsors
               href: api/connectedorganization-delete-internalsponsors.md
-          - name: Approval
-            href: resources/approval.md
-            items:
-            - name: Get
-              href: api/approval-get.md
-          - name: Approval step
-            href: resources/approvalstep.md
-            items:
-            - name: List
-              href: api/approval-list-steps.md
-            - name: Get 
-              href: api/approvalstep-get.md
-            - name: Update 
-              href: api/approvalstep-update.md
           - name: Entitlement management settings
             href: resources/entitlementmanagementsettings.md
             items:


### PR DESCRIPTION
Add clarification that approval operations are for entitlement management access package assignment approvals, and that the ID of the approval is the same as the request id.