### PR TITLE
Edits on "all" pages

### DIFF
--- a/api-reference/beta/api/windowsupdates-deployment-create.md
+++ b/api-reference/beta/api/windowsupdates-deployment-create.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-create.md
+++ b/api-reference/beta/api/windowsupdates-deployment-create.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-delete.md
+++ b/api-reference/beta/api/windowsupdates-deployment-delete.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-delete.md
+++ b/api-reference/beta/api/windowsupdates-deployment-delete.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-get.md
+++ b/api-reference/beta/api/windowsupdates-deployment-get.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-get.md
+++ b/api-reference/beta/api/windowsupdates-deployment-get.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-list.md
+++ b/api-reference/beta/api/windowsupdates-deployment-list.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-list.md
+++ b/api-reference/beta/api/windowsupdates-deployment-list.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deployment-update.md
+++ b/api-reference/beta/api/windowsupdates-deployment-update.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request
@@ -56,9 +56,11 @@ If successful, this method returns a `202 Accepted` response code and an updated
 
 ## Examples
 
+### Example: Pause a deployment
+
 In this example, the deployment is paused by updating the `requestedValue` of the deployment `state`.
 
-### Request
+#### Request
 <!-- {
   "blockType": "request",
   "name": "update_deployment",
@@ -79,7 +81,7 @@ Content-Type: application/json
 ```
 
 
-### Response
+#### Response
 
 <!-- {
   "blockType": "response",
@@ -115,9 +117,11 @@ Content-Type: application/json
 }
 ```
 
-In this example, the deployment's `settings` are updated to add a monitoring rule.
+### Example: Update deployment settings to add a monitoring rule
 
-### Request
+In this example, the `settings` property of the deployment is updated to add a monitoring rule.
+
+#### Request
 <!-- {
   "blockType": "request",
   "name": "update_deployment",
@@ -146,7 +150,7 @@ Content-Type: application/json
 ```
 
 
-### Response
+#### Response
 
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/windowsupdates-deployment-update.md
+++ b/api-reference/beta/api/windowsupdates-deployment-update.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-list-exclusions.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-list-exclusions.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-list-exclusions.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-list-exclusions.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-list-members.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-list-members.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-list-members.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-list-members.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudience.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudience.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 Update the members and exclusions collections of a [deploymentAudience](../resources/windowsupdates-deploymentaudience.md).
 
-Adding an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object, if it does not already exist.
+Add an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object, if it does not already exist.
 
 If all assets are the same type, you can also use the method [updateAudienceById](windowsupdates-deploymentaudience-updateaudiencebyid.md).
 
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudience.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudience.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 Update the members and exclusions collections of a [deploymentAudience](../resources/windowsupdates-deploymentaudience.md).
 
-Add an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object, if it does not already exist.
+Adding an [azureADDevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object, if it does not already exist.
 
 If all assets are the same type, you can also use the method [updateAudienceById](windowsupdates-deploymentaudience-updateaudiencebyid.md) to update the **deploymentAudience**.
 
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudiencebyid.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudiencebyid.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 Update the members and exclusions collections of a [deploymentAudience](../resources/windowsupdates-deploymentaudience.md) with [updatableAsset](../resources/windowsupdates-updatableasset.md) resources of the same type.
 
-Add an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object if it does not already exist.
+Adding an [azureADDevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object if it does not already exist.
 
 You can also use the method [updateAudience](windowsupdates-deploymentaudience-updateaudience.md) to update the **deploymentAudience**.
 
@@ -24,7 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Delegated (personal Microsoft account)|Not supported.|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudiencebyid.md
+++ b/api-reference/beta/api/windowsupdates-deploymentaudience-updateaudiencebyid.md
@@ -14,7 +14,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 Update the members and exclusions collections of a [deploymentAudience](../resources/windowsupdates-deploymentaudience.md) with [updatableAsset](../resources/windowsupdates-updatableasset.md) resources of the same type.
 
-Adding an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object if it does not already exist.
+Add an [azureADdevice](../resources/windowsupdates-azureaddevice.md) to the members or exclusions collections of a deployment audience automatically creates an Azure AD device object if it does not already exist.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
 |Delegated (work or school account)|WindowsUpdates.ReadWrite.All|
-|Delegated (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
+|Not supported (personal Microsoft account)|WindowsUpdates.ReadWrite.All|
 |Application|WindowsUpdates.ReadWrite.All|
 
 ## HTTP request

--- a/api-reference/beta/resources/windowsupdates-deployablecontent.md
+++ b/api-reference/beta/resources/windowsupdates-deployablecontent.md
@@ -13,7 +13,9 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents content that is deployable by the service. This is an abstract type. 
+Represents content that is deployable by the service.
+
+This is an abstract type. 
 
 Base type for [softwareUpdateReference](../resources/windowsupdates-softwareupdatereference.md).
 

--- a/api-reference/beta/resources/windowsupdates-deployablecontent.md
+++ b/api-reference/beta/resources/windowsupdates-deployablecontent.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents content that is deployable by the service.
+Represents content that is deployable by the service. This is an abstract type. 
 
 ## Properties
 None.

--- a/api-reference/beta/resources/windowsupdates-deployment.md
+++ b/api-reference/beta/resources/windowsupdates-deployment.md
@@ -34,7 +34,7 @@ Represents the deployment of content to a set of devices.
 |createdDateTime|DateTimeOffset|The date and time the deployment was created. Returned by default. Read-only.|
 |id|String|The unique identifier for the deployment. Returned by default. Key. Not nullable. Read-only.|
 |lastModifiedDateTime|DateTimeOffset|The date and time the deployment was last modified. Returned by default. Read-only.|
-|settings|[microsoft.graph.windowsUpdates.deploymentSettings](../resources/windowsupdates-deploymentsettings.md)|Settings specified on the specific deployment governing how to deploy `content`. Returned by default.|
+|settings|[microsoft.graph.windowsUpdates.deploymentSettings](../resources/windowsupdates-deploymentsettings.md)|Settings specified on the specific deployment governing how to deploy **content**. Returned by default.|
 |state|[microsoft.graph.windowsUpdates.deploymentState](../resources/windowsupdates-deploymentstate.md)|Execution status of the deployment. Returned by default.|
 
 ## Relationships

--- a/api-reference/beta/resources/windowsupdates-deploymentsettings.md
+++ b/api-reference/beta/resources/windowsupdates-deploymentsettings.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Settings controlling when and how to deploy an update.
+Settings controlling when and how an update deploys.
 
 Base type of [windowsDeploymentSettings](../resources/windowsupdates-windowsdeploymentsettings.md).
 

--- a/api-reference/beta/resources/windowsupdates-expeditedqualityupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-expeditedqualityupdatereference.md
@@ -24,7 +24,7 @@ Inherits from [qualityUpdateReference](../resources/windowsupdates-qualityupdate
 |:---|:---|:---|
 |classification|microsoft.graph.windowsUpdates.qualityUpdateClassification|Specifies the classification of the referenced content. Supports a subset of the values for **qualityUpdateClassification**. Default value is `security`. Possible values are: `security`. Inherited from [qualityUpdateReference](../resources/windowsupdates-qualityupdatereference.md).|
 |equivalentContent|microsoft.graph.windowsUpdates.equivalentContentOption|Specifies other content to consider as equivalent. Supports a subset of the values for **equivalentContentOption**. Default value is `latestSecurity`. Possible values are: `latestSecurity`.|
-|releaseDateTime|DateTimeOffset|Specifies a quality update with the given `classification` by its publish date (i.e. the last update published on the specified date). Any devices with an update that was published prior to the `releaseDateTime` will receive an expedited quality update. Inherited from [qualityUpdateReference](../resources/windowsupdates-qualityupdatereference.md).|
+|releaseDateTime|DateTimeOffset|Specifies a quality update with the given **classification** by its publish date (i.e. the last update published on the specified date). Any devices with an update that was published prior to the **releaseDateTime** will receive an expedited quality update. Inherited from [qualityUpdateReference](../resources/windowsupdates-qualityupdatereference.md).|
 
 ## Relationships
 None.

--- a/api-reference/beta/resources/windowsupdates-featureupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-featureupdatereference.md
@@ -17,7 +17,7 @@ Represents Windows 10 feature update content.
 
 In a deployment, the same feature update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
-Inherits from [windowsUpdateReference](../resources/windowsupdates-windowsupdatereference.md).
+Inherits from [softwareUpdateReference](../resources/windowsupdates-softwareupdatereference.md).
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/beta/resources/windowsupdates-featureupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-featureupdatereference.md
@@ -17,7 +17,7 @@ Represents Windows 10 feature update content.
 
 In a deployment, the same feature update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
-Inherits from [softwareUpdateReference](../resources/windowsupdates-softwareupdatereference.md).
+Inherits from [windowsUpdateReference](../resources/windowsupdates-windowsupdatereference.md).
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/beta/resources/windowsupdates-qualityupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-qualityupdatereference.md
@@ -17,7 +17,7 @@ Represents Windows 10 quality update content.
 
 In a deployment, the same quality update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
-Inherits from [windowsUpdateReference](../resources/windowsupdates-windowsupdatereference.md). Base type of [expeditedQualityUpdateReference](../resources/windowsupdates-expeditedqualityupdatereference.md).
+Inherits from [softwareUpdateReference](../resources/windowsupdates-windowsupdatereference.md). Base type of [expeditedQualityUpdateReference](../resources/windowsupdates-expeditedqualityupdatereference.md).
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/beta/resources/windowsupdates-qualityupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-qualityupdatereference.md
@@ -17,7 +17,7 @@ Represents Windows 10 quality update content.
 
 In a deployment, the same quality update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
-Inherits from [softwareUpdateReference](../resources/windowsupdates-windowsupdatereference.md). Base type of [expeditedQualityUpdateReference](../resources/windowsupdates-expeditedqualityupdatereference.md).
+Inherits from [windowsUpdateReference](../resources/windowsupdates-windowsupdatereference.md). Base type of [expeditedQualityUpdateReference](../resources/windowsupdates-expeditedqualityupdatereference.md).
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/beta/resources/windowsupdates-rolloutsettings.md
+++ b/api-reference/beta/resources/windowsupdates-rolloutsettings.md
@@ -19,9 +19,9 @@ Settings controlling how an update is deployed over time.
 |Property|Type|Description|
 |:---|:---|:---|
 |startDateTime|DateTimeOffset|Date on which devices in the deployment start receiving the update. When not set, the deployment starts as soon as devices are assigned.|
-|devicesPerOffer|Int32|	Specifies the number of devices that are offered at the same time. Has no effect when `endDateTime` is set. When `endDateTime` and `devicesPerOffer` are both not set, all devices in the deployment are offered content at the same time.|
-|durationBetweenOffers|String|Specifies duration between each set of devices being offered the update. Has an effect when `endDateTime` or `devicesPerOffer` are defined. Default value is `P1D` (1 day).|
-|endDateTime|DateTimeOffset|Specifies the date before which all devices currently in the deployment are offered the update. Devices added after this date are offered immediately. When `endDateTime` and `devicesPerOffer` are both not set, all devices in the deployment are offered content at the same time.|
+|devicesPerOffer|Int32|	Specifies the number of devices that are offered at the same time. Has no effect when **endDateTime** is set. When **endDateTime** and **devicesPerOffer** are both not set, all devices in the deployment are offered content at the same time.|
+|durationBetweenOffers|String|Specifies duration between each set of devices being offered the update. Has an effect when **endDateTime** or **devicesPerOffer** are defined. Default value is `P1D` (1 day).|
+|endDateTime|DateTimeOffset|Specifies the date before which all devices currently in the deployment are offered the update. Devices added after this date are offered immediately. When **endDateTime** and **devicesPerOffer** are both not set, all devices in the deployment are offered content at the same time.|
 
 ## Relationships
 None.

--- a/api-reference/beta/resources/windowsupdates-softwareupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-softwareupdatereference.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents specific update content.
+Represents specific update content. This is an abstract type. 
 
 In a deployment, the same **softwareUpdateReference** could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 

--- a/api-reference/beta/resources/windowsupdates-softwareupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-softwareupdatereference.md
@@ -13,13 +13,15 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents specific update content. This is an abstract type. 
+Represents specific update content.
 
 In a deployment, the same **softwareUpdateReference** could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
 All software update references exist as one of the following derived types: [featureUpdateReference](../resources/windowsupdates-featureupdatereference.md).
 
 Inherits from [deployableContent](../resources/windowsupdates-deployablecontent.md). Base type for [windowsUpdateReference](../resources/windowsupdates-windowsupdatereference.md).
+
+This is an abstract type.
 
 ## Properties
 None.

--- a/api-reference/beta/resources/windowsupdates-windowsupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-windowsupdatereference.md
@@ -13,13 +13,15 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents specific Windows 10 update content. This is an abstract type. 
+Represents specific Windows 10 update content.
 
 In a deployment, the same Windows update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 
 All Windows update references exist as one of the following derived types: [featureUpdateReference](../resources/windowsupdates-featureupdatereference.md) and [expeditedQualityUpdateReference](../resources/windowsupdates-expeditedqualityupdatereference.md).
 
 Inherits from [softwareUpdateReference](../resources/windowsupdates-softwareupdatereference.md). Base type for [featureUpdateReference](../resources/windowsupdates-featureupdatereference.md) and [qualityUpdateReference](../resources/windowsupdates-qualityupdatereference.md).
+
+This is an abstract type.
 
 ## Properties
 None.

--- a/api-reference/beta/resources/windowsupdates-windowsupdatereference.md
+++ b/api-reference/beta/resources/windowsupdates-windowsupdatereference.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents specific Windows 10 update content.
+Represents specific Windows 10 update content. This is an abstract type. 
 
 In a deployment, the same Windows update reference could result in devices receiving different update revisions, but the content is considered contextually equivalent for all devices in the deployment.
 

--- a/concepts/windowsupdates-concept-overview.md
+++ b/concepts/windowsupdates-concept-overview.md
@@ -11,13 +11,13 @@ doc_type: conceptualPageType
 
 ## Why use the Windows Update for Business deployment service?
 
-The Windows Update for Business deployment service provides control over device updates through the ability to approve, schedule and safeguard content delivered by Windows Update. It enables IT Professionals and management tool vendors alike to:
+The Windows Update for Business deployment service provides control over device updates through the ability to approve, schedule and safeguard content delivered by Windows Update. IT Professionals and management tool vendors alike can use the deployment service to:
 * Schedule update deployments to begin on a specific date
 * Stage deployments over a period of days or weeks using rich expressions
 * Bypass pre-configured Windows Update for Business policies to immediately deploy a security update
 * Ensure coverage of hardware and software in your organization through deployments tailored to unique device population(s)
 
-Today, the deployment service supports management of Windows 10 feature updates and expediting Windows 10 security updates. To learn more about the deployment service, please see [Overview of the deployment service]().
+Today, the deployment service supports managing Windows 10 feature updates and expediting Windows 10 security updates. To learn more about the deployment service, please see [Overview of the deployment service]().
 
 ## Prerequisites    
 
@@ -44,7 +44,7 @@ To start using the deployment service, [enroll devices in update management](win
 
 The deployment service simplifies reviewing, approving, scheduling, and deploying content for a diverse device ecosystem. The updates catalog provides a view tailored for approvals, helping you focus on approval decisions that matter and avoiding the need to sort through deep lists of related updates.
 
-Once you have chosen an update to deploy, you can schedule deployments to start at a future time, or deploy over a period of time. If you choose to deploy an update over a period of time, the deployment service will automatically optimize the order in which devices are offered updates. When possible, the service orders devices to ensure that a diversity of hardware and software assets are represented early in the deployment to minimize the number of devices that may encounter an unexpected update issue. 
+Once you choose an update to deploy, you can schedule deployments to start at a future time, or deploy over a period of time. If you choose to deploy an update over a period of time, the deployment service automatically optimizes the order in which devices are offered updates. When possible, the service orders devices to ensure that a diversity of hardware and software assets are represented early in the deployment to minimize the number of devices that may encounter an unexpected update issue. 
 
 Learn more about the deployment service:
 * [Software updates](windowsupdates-software-updates.md)

--- a/concepts/windowsupdates-concept-overview.md
+++ b/concepts/windowsupdates-concept-overview.md
@@ -55,7 +55,7 @@ Learn more about the deployment service:
 
 In the case of a critical security issue, you can use the deployment service to bypass a standard update policy and expedite deployment of a security update.
 
-To learn more, see [Deploy an expedited update](windowsupdates-deploy-expedited-update.md).
+To learn more, see [Deploy an expedited security update](windowsupdates-deploy-expedited-update.md).
 
 ## Protect devices by default
 

--- a/concepts/windowsupdates-deploy-expedited-update.md
+++ b/concepts/windowsupdates-deploy-expedited-update.md
@@ -30,7 +30,7 @@ Expedited security updates also have the following characteristics:
 
 You can query the deployment service catalog to get a list of updates that can be expedited to devices as content in a deployment.
 
-Security updates are represented by the [qualityUpdateCatalogEntry](/graph/api/resources/windowsupdates-qualityupdatecatalogentry) type, with a **qualityUpdateClassification** of `security`. All Windows 10 quality updates that are classified as security updates can be expedited and are tagged with the **isExpeditable** property set to `true` to identify them.
+Security updates are represented by the [qualityUpdateCatalogEntry](/graph/api/resources/windowsupdates-qualityupdatecatalogentry) type, with a **qualityUpdateClassification** of **security**. All Windows 10 quality updates that are classified as security updates can be expedited and are tagged with the **isExpeditable** property set to **true** to identify them.
 
 Below is an example of querying for all Windows 10 security updates that can be deployed as expedited updates by the deployment service. Microsoft recommends to only show the three most current updates, so the example includes `$top=3`.
 
@@ -83,11 +83,11 @@ Content-Type: application/json
 
 A deployment specifies content to deploy, how and when to deploy the content, and the targeted devices. For quality updates, the content is specified using a target compliance date. When a deployment is created, a deployment audience is automatically created as a relationship.
 
-When you deploy an expedited security update to a device, Windows Update will offer an update that brings the device above the minimum compliance level specified. Depending on when each device scans and updates, some devices may receive newer updates (e.g. if there is a newer security update than the one corresponding to the desired minimum compliance level), but all devices will meet the specified security update compliance standard. This behavior of offering the latest applicable update, indicated by the property `equivalentContent` being set to the default value `latestSecurity`, helps keep devices as secure as possible and prevents a device from receiving an expedited update followed by another regular update just days later.
+When you deploy an expedited security update to a device, Windows Update offers an update that brings the device above the minimum compliance level specified. Depending on when each device scans and updates, some devices may receive newer updates (e.g. if there is a newer security update than the one corresponding to the desired minimum compliance level), but all devices meet the specified security update compliance standard. This behavior of offering the latest applicable update, indicated by the property **equivalentContent** being set to the default value **latestSecurity**, helps keep devices as secure as possible and prevents a device from receiving an expedited update followed by another regular update just days later.
 
-You can configure the device restart grace period using the property `daysUntilForcedReboot` in the deployment's user experience settings. The grace period sets the amount of time after installation that the user can control the timing of when the device restarts. If the device has not restarted by the time the grace period expires, it restarts automatically.
+You can configure the device restart grace period using the property **daysUntilForcedReboot** in the deployment's user experience settings. The grace period sets the amount of time after installation that the user can control the timing of when the device restarts. If the device has not restarted by the time the grace period expires, it restarts automatically.
 
-Below is an example of creating a deployment for an expedited quality update. The targeted devices will be specified in the next step.
+Below is an example of creating a deployment for an expedited quality update. The targeted devices are specified in the next step.
 
 ### Request
 
@@ -152,7 +152,7 @@ Content-Type: application/json
 
 ## Step 3: Assign devices to the deployment audience
 
-After a deployment is created, you can assign devices to the deployment audience. Devices can be assigned directly, or via updatable asset groups. Once the deployment audience is successfully updated, Windows Update will start offering the update to the relevant devices according to the deployment's settings.
+After a deployment is created, you can assign devices to the deployment audience. Devices can be assigned directly, or via updatable asset groups. Once the deployment audience is successfully updated, Windows Update starts offering the update to the relevant devices according to the deployment's settings.
 
 Devices are automatically registered with the service when added to the members or exclusions collections of a deployment audience (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice.md) object is automatically created if it does not already exist).
 
@@ -200,4 +200,4 @@ While a deployment is in progress, you can pause the deployment by updating its 
 
 ## After a deployment
 
-After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, it will continue to make sure that Windows Update is offering the update to the assigned devices whenever they reconnect.
+After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, it continues to make sure that Windows Update is offering the update to the assigned devices whenever they reconnect.

--- a/concepts/windowsupdates-deploy-expedited-update.md
+++ b/concepts/windowsupdates-deploy-expedited-update.md
@@ -9,7 +9,7 @@ doc_type: conceptualPageType
 
 # Deploy an expedited security update using the Windows Update for Business deployment service
 
-With the Windows Update for Business deployment service, you can deploy Windows updates to devices in an Azure AD tenant. Today, the deployment service supports deployments of Windows 10 feature updates and expedited security updates. This topic focuses on deployments of expedited security updates. For information on deploying feature updates, see [Deploy a feature update](windowsupdates-deploy-update.md).
+With the Windows Update for Business deployment service, you can deploy Windows updates to devices in an Azure AD tenant. Today, the deployment service supports [deployments](windowsupdates-deployments.md) of Windows 10 feature updates and expedited security updates. This topic focuses on deployments of expedited security updates. For information on deploying feature updates, see [Deploy a feature update](windowsupdates-deploy-update.md).
 
 Expediting a security update overrides Windows Update for Business deferral policies so that the update is installed as quickly as possible. It can be useful when critical security events arise and you need to deploy the latest updates more rapidly than normal. However, while it can help to achieve compliance targets against a specific security update, it is not designed to be used every month. Instead, consider using [compliance deadlines for updates](https://docs.microsoft.com/windows/deployment/update/wufb-compliancedeadlines).
 
@@ -30,7 +30,7 @@ Expedited security updates also have the following characteristics:
 
 You can query the deployment service catalog to get a list of updates that can be expedited to devices as content in a deployment.
 
-Security updates are represented by the [qualityUpdateCatalogEntry](/graph/api/resources/windowsupdates-qualityupdatecatalogentry) type, with a **qualityUpdateClassification** of **security**. All Windows 10 quality updates that are classified as security updates can be expedited and are tagged with the **isExpeditable** property set to **true** to identify them.
+Security updates are represented by the [qualityUpdateCatalogEntry](/graph/api/resources/windowsupdates-qualityupdatecatalogentry) type, with a **qualityUpdateClassification** of `security`. All Windows 10 quality updates that are classified as security updates can be expedited and are tagged with the **isExpeditable** property set to `true` to identify them.
 
 Below is an example of querying for all Windows 10 security updates that can be deployed as expedited updates by the deployment service. Microsoft recommends to only show the three most current updates, so the example includes `$top=3`.
 
@@ -81,11 +81,11 @@ Content-Type: application/json
 
 ## Step 2: Create a deployment
 
-A deployment specifies content to deploy, how and when to deploy the content, and the targeted devices. For quality updates, the content is specified using a target compliance date. When a deployment is created, a deployment audience is automatically created as a relationship.
+A [deployment](/graph/api/resources/windowsupdates-deployment) specifies content to deploy, how and when to deploy the content, and the targeted devices. For quality updates, the content is specified using a target compliance date. When a deployment is created, a deployment audience is automatically created as a relationship.
 
-When you deploy an expedited security update to a device, Windows Update offers an update that brings the device above the minimum compliance level specified. Depending on when each device scans and updates, some devices may receive newer updates (e.g. if there is a newer security update than the one corresponding to the desired minimum compliance level), but all devices meet the specified security update compliance standard. This behavior of offering the latest applicable update, indicated by the property **equivalentContent** being set to the default value **latestSecurity**, helps keep devices as secure as possible and prevents a device from receiving an expedited update followed by another regular update just days later.
+When you deploy an expedited security update to a device, Windows Update offers an update that brings the device above the minimum compliance level specified. Depending on when each device scans and updates, some devices may receive newer updates (e.g. if there is a newer security update than the one corresponding to the desired minimum compliance level), but all devices meet the specified security update compliance standard. This behavior of offering the latest applicable update, indicated by the property **equivalentContent** being set to the default value `latestSecurity`, helps keep devices as secure as possible and prevents a device from receiving an expedited update followed by another regular update just days later.
 
-You can configure the device restart grace period using the property **daysUntilForcedReboot** in the deployment's user experience settings. The grace period sets the amount of time after installation that the user can control the timing of when the device restarts. If the device has not restarted by the time the grace period expires, it restarts automatically.
+You can configure the device restart grace period using the property **daysUntilForcedReboot** in the [user experience settings](/graph/api/resources/windowsupdates-userexperiencesettings) of the deployment. The grace period sets the amount of time after installation that the user can control the timing of when the device restarts. If the device has not restarted by the time the grace period expires, it restarts automatically.
 
 Below is an example of creating a deployment for an expedited quality update. The targeted devices are specified in the next step.
 
@@ -152,9 +152,9 @@ Content-Type: application/json
 
 ## Step 3: Assign devices to the deployment audience
 
-After a deployment is created, you can assign devices to the deployment audience. Devices can be assigned directly, or via updatable asset groups. Once the deployment audience is successfully updated, Windows Update starts offering the update to the relevant devices according to the deployment's settings.
+After a deployment is created, you can assign devices to the [deployment audience](/graph/api/resources/windowsupdates-deploymentaudience). Devices can be assigned directly, or via [updatable asset groups](/graph/api/resources/windowsupdates-updatableassetgroup). Once the deployment audience is successfully updated, Windows Update starts offering the update to the relevant devices according to the deployment settings.
 
-Devices are automatically registered with the service when added to the members or exclusions collections of a deployment audience (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice.md) object is automatically created if it does not already exist).
+Devices are automatically registered with the service when added to the members or exclusions collections of a deployment audience (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice) object is automatically created if it does not already exist).
 
 Below is an example of adding updatable asset groups and Azure AD devices as members of the deployment audience, while also excluding a specific Azure AD device.
 
@@ -196,8 +196,8 @@ HTTP/1.1 202 Accepted
 
 ## During a deployment
 
-While a deployment is in progress, you can pause the deployment by updating its state, as well as update its audience members and exclusions.
+While a deployment is in progress, you can pause the deployment by updating its **state**, as well as update its audience members and exclusions.
 
 ## After a deployment
 
-After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, it continues to make sure that Windows Update is offering the update to the assigned devices whenever they reconnect.
+After all devices assigned to a deployment audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, it continues to make sure that Windows Update is offering the update to the assigned devices whenever they reconnect.

--- a/concepts/windowsupdates-deploy-update.md
+++ b/concepts/windowsupdates-deploy-update.md
@@ -11,7 +11,7 @@ doc_type: conceptualPageType
 
 With the Windows Update for Business deployment service, you can deploy Windows updates to devices in an Azure AD tenant. Today, the deployment service supports [deployments](windowsupdates-deployments.md) of Windows 10 feature updates and expedited security updates. This topic focuses on deployments of feature updates. For information about deploying expedited security updates, see [Deploy an expedited security update](windowsupdates-deploy-expedited-update.md).
 
-When you deploy a feature update to a device, Windows Update offers the specified update to the device if it has not yet received the update. For example, if you deploy Windows 10 feature update version 20H2 to a device that is enrolled in feature update management and is currently on an older version of Windows 10, the device updates to version 20H2. If the device is already at or above version 20H2, it stays on its current version. If the device is not enrolled in feature update management, the device will be unaffected by this operation.
+When you deploy a feature update to a device, Windows Update offers the specified update to the device if it has not yet received the update. For example, if you deploy Windows 10 feature update version 20H2 to a device that is enrolled in feature update management and is currently on an older version of Windows 10, the device updates to version 20H2. If the device is already at or above version 20H2, it stays on its current version. If the device is not enrolled in feature update management, the device is not affected by this operation.
 
 As long as a device remains enrolled in feature update management, the device does not receive any other feature updates from Windows Update unless explicitly deployed using the deployment service.
 
@@ -198,5 +198,5 @@ While a deployment is in progress, you can pause the deployment by updating its 
 
 ## After a deployment
 
-After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, it will continue to make sure that Windows Update is offering the update to the assigned devices whenever they reconnect.
+After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, Windows Update continues to offer the update to the assigned devices whenever they reconnect.
 

--- a/concepts/windowsupdates-deploy-update.md
+++ b/concepts/windowsupdates-deploy-update.md
@@ -62,7 +62,7 @@ Content-Type: application/json
 
 ## Step 2: Create a deployment
 
-A deployment specifies content to deploy, how and when to deploy the content, and the targeted devices. When a deployment is created, a deployment audience is automatically created as a relationship.
+A [deployment](/graph/api/resources/windowsupdates-deployment) specifies content to deploy, how and when to deploy the content, and the targeted devices. When a deployment is created, a deployment audience is automatically created as a relationship.
 
 Below is an example of creating a deployment of a feature update, with optional settings configuring the [deployment schedule](windowsupdates-schedule-deployment.md) and [monitoring rules](windowsupdates-manage-monitoring-rules.md). The targeted devices are specified in the next step.
 
@@ -150,9 +150,9 @@ Content-Type: application/json
 
 ## Step 3: Assign devices to the deployment audience
 
-After a deployment is created, you can assign devices to the deployment audience. Devices can be assigned directly, or via updatable asset groups. Once the deployment audience is successfully updated, Windows Update starts offering the update to the relevant devices according to the deployment settings.
+After a deployment is created, you can assign devices to the [deployment audience](/graph/api/resources/windowsupdates-deploymentaudience). Devices can be assigned directly, or via [updatable asset groups](/graph/api/resources/windowsupdates-updatableassetgroup). Once the deployment audience is successfully updated, Windows Update starts offering the update to the relevant devices according to the deployment settings.
 
-Devices are automatically registered with the service when added to the members or exclusions collections of a deployment audience (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice.md) object is automatically created if it does not already exist).
+Devices are automatically registered with the service when added to the members or exclusions collections of a deployment audience (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice) object is automatically created if it does not already exist).
 
 Below is an example of adding updatable asset groups and Azure AD devices as members of the deployment audience, while also excluding a specific Azure AD device.
 
@@ -194,9 +194,9 @@ HTTP/1.1 202 Accepted
 
 ## During a deployment
 
-While a deployment is in progress, you can pause the deployment by updating its state, as well as update its audience members and exclusions.
+While a deployment is in progress, you can pause the deployment by updating its **state**, as well as update its audience members and exclusions.
 
 ## After a deployment
 
-After all devices assigned to a deployment's audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, Windows Update continues to offer the update to the assigned devices whenever they reconnect.
+After all devices assigned to a deployment audience have been initially offered the update, it is possible that not all devices have started or completed the update, due to factors like device connectivity. As long as the deployment still exists, Windows Update continues to offer the update to the assigned devices whenever they reconnect.
 

--- a/concepts/windowsupdates-deployments.md
+++ b/concepts/windowsupdates-deployments.md
@@ -23,7 +23,7 @@ Deployments have the following key aspects:
 
 Because content and audience are key to the definition of a deployment, you are required to assign both at the time of creation. While content and audience assignments cannot be changed later, device membership within an audience can.
 
-To learn more about creating a deployment, see [Deploy a feature update using the Windows Update for Business deployment service](windowsupdates-deploy-update.md) and [Deploy an expedited update using the Windows Update for Business deployment service](windowsupdates-deploy-expedited-update.md).
+To learn more about creating a deployment, see [Deploy a feature update](windowsupdates-deploy-update.md) and [Deploy an expedited security update](windowsupdates-deploy-expedited-update.md).
 
 ## Configure settings
 
@@ -31,7 +31,7 @@ To learn more about creating a deployment, see [Deploy a feature update using th
 
 [Rollout settings](/graph/api/resources/windowsupdates-rolloutsettings) govern how the content is deployed over time to devices in the deployment audience. You can configure rollout settings for deployments of feature updates.
 
-To learn more about rollout settings, see [Schedule a deployment](windowsupdates-manage-schedule-deployment.md).
+To learn more about rollout settings, see [Schedule a deployment](windowsupdates-schedule-deployment.md).
 
 ### Monitoring
 

--- a/concepts/windowsupdates-deployments.md
+++ b/concepts/windowsupdates-deployments.md
@@ -29,48 +29,50 @@ To learn more about creating a deployment, see [Deploy a feature update using th
 
 ### Rollout
 
-[Rollout settings](windowsupdates-schedule-deployment.md govern how the content is deployed over time to devices in the deployment audience. You can configure rollout settings for deployments of feature update.
+[Rollout settings](/graph/api/resources/windowsupdates-rolloutsettings) govern how the content is deployed over time to devices in the deployment audience. You can configure rollout settings for deployments of feature updates.
 
+To learn more about rollout settings, see [Schedule a deployment](windowsupdates-manage-schedule-deployment.md).
 
 ### Monitoring
 
 You can use [monitoring settings](/graph/api/resources/windowsupdates-monitoringsettings) to configure alerts and automated actions to take based on update signals from devices. Monitoring settings can be configured for deployments of feature updates.
 
 
-To learn more about monitoring settings, see [monitoring settings](windowsupdates-manage-monitoring-rules.md).
+To learn more about monitoring settings, see [Manage monitoring rules](windowsupdates-manage-monitoring-rules.md).
 
 ### User experience
 
 For deployments of expedited quality updates, [user experience settings](/graph/api/resources/windowsupdates-userexperiencesettings) temporarily override existing policies on the device for update experience.
 
+To learn more about user experience settings, see [Deploy an expedited security update](windowsupdates-deploy-expedited-update.md).
 
 ## Get or set lifecycle state
 
 ### States
 
-Deployments move through the following lifecycle states:
+Deployments move through lifecycle states as described in the following table.
 
 | State     | Description                                                                                       |
 |-----------|---------------------------------------------------------------------------------------------------|
-| 'scheduled' | The deployment is waiting for offer conditions to be met to start offering the update to devices. |
-| 'offering'  | The deployment is offering the update to devices.                                                 |
-| 'paused'    | The deployment is paused and prevented from offering the update to devices until it is unpaused.  |
+| `scheduled` | The deployment is waiting for offer conditions to be met to start offering the update to devices. |
+| `offering`  | The deployment is offering the update to devices.                                                 |
+| `paused`    | The deployment is paused and prevented from offering the update to devices until it is unpaused.  |
 
 
 ### Transitions
 
 | Transition                     | Condition                                |
 |--------------------------------|------------------------------------------|
-| 'scheduled' → 'offering'           | Scheduling condition is met.             |
-| 'offering' → 'scheduled'           | Scheduling condition is not met.         |
-| 'scheduled' or 'offering' → 'paused' | There is a request or automatic action to pause. |
-| 'paused' → 'scheduled' or 'offering' | There is no longer a request or automatic action to pause. |
+| `scheduled` → `offering`           | Scheduling condition is met.             |
+| `offering` → `scheduled`           | Scheduling condition is not met.         |
+| `scheduled` or `offering` → `paused` | There is a request or automatic action to pause. |
+| `paused` → `scheduled` or `offering` | There is no longer a request or automatic action to pause. |
 
 ### Resource model
 
 The [deployment](/graph/api/resources/windowsupdates-deployment) resource has a **state** property of type [deploymentState](/graph/api/resources/windowsupdates-deploymentstate) which provides information about the current lifecycle state.
 
-The service determines the effective `value` of the deployment state as a net result of several inputs and asynchronous processes, but you can request a particular value by setting `requestedValue` as one of these inputs. Other inputs to the effective deployment state value include rollout settings and monitoring settings.
+The service determines the effective **value** of the deployment state as a net result of several inputs and asynchronous processes, but you can request a particular value by setting **requestedValue** as one of these inputs. Other inputs to the effective deployment state value include rollout settings and monitoring settings.
 
 ## Multiple deployments
 
@@ -78,4 +80,4 @@ You can assign a device to multiple deployments at one time. These deployments c
 
 When you assign a device to two deployments for content of different update categories (for example, a feature update and an expedited quality update), the deployment service offers content in a sequence according to Microsoft’s recommendation.
 
-When you assign a device to two deployments for content of the same update category (for example, feature update versions 20H1 and 20H2, or quality updates from March 2021 and April 2021), the deployment service offers the content that is higher ranked by Microsoft. For feature updates and quality updates, a more recent update is higher ranked. This behavior does not apply if one of the deployments is still scheduled for the device and is not ready to offer content. In that case, the other deployment delivers content to the device.
+When you assign a device to two deployments for content of the same update category (for example, feature update versions 20H1 and 20H2, or quality updates from March 2021 and April 2021), the deployment service offers the content that is higher ranked by Microsoft. For feature updates and quality updates, more recent updates are higher ranked. This behavior does not apply if one of the deployments is still scheduled for the device and is not ready to offer content. In that case, the other deployment delivers content to the device.

--- a/concepts/windowsupdates-deployments.md
+++ b/concepts/windowsupdates-deployments.md
@@ -20,7 +20,7 @@ Deployments have the following key aspects:
 
 ## Create a deployment with content and an audience
 
-Because content and audience are key to the definition of a deployment, both are required to be assigned at the time of creation. Content and audience assignments cannot be changed later, however, device membership within an audience can.
+Because content and audience are key to the definition of a deployment, you are required to assign both at the time of creation. While content and audience assignments cannot be changed later, device membership within an audience can.
 
 To learn more about creating a deployment, see [Deploy a feature update using the Windows Update for Business deployment service](windowsupdates-deploy-update.md) and [Deploy an expedited update using the Windows Update for Business deployment service](windowsupdates-deploy-expedited-update.md).
 
@@ -28,21 +28,21 @@ To learn more about creating a deployment, see [Deploy a feature update using th
 
 ### Rollout
 
-Rollout settings govern how the content is deployed over time to devices in the deployment audience. Rollout settings can be configured for deployments of feature updates.
+Rollout settings govern how the content is deployed over time to devices in the deployment audience. You can configure rollout settings for deployments of feature update.
 
-To learn more about rollout settings, see [Schedule a deployment using the Windows Update for Business deployment service](windowsupdates-schedule-deployment.md).
+To learn more about rollout settings, see [rollout settings](windowsupdates-schedule-deployment.md).
 
 ### Monitoring
 
-You can use monitoring settings to configure alerts and automated actions to take based on update signals from devices. Monitoring settings can be configured for deployments of feature updates.
+You can use monitoring settings to configure alerts and automated actions to take based on update signals from devices. You can configure monitoring settings for deployments of feature updates.
 
-To learn more about monitoring settings, see [Manage monitoring rules for a deployment using the Windows Update for Business deployment service](windowsupdates-manage-monitoring-rules.md).
+To learn more about monitoring settings, see [monitoring settings](windowsupdates-manage-monitoring-rules.md).
 
 ### User experience
 
 For deployments of expedited quality updates, user experience settings temporarily override existing policies on the device for update experience.
 
-To learn more about user experience settings, see [Deploy and expedited update using the Windows Update for Business deployment service](windowsupdates-deploy-expedited-update.md).
+To learn more about user experience settings, see [user experience settings](windowsupdates-deploy-expedited-update.md).
 
 ## Get or set lifecycle state
 
@@ -52,30 +52,30 @@ Deployments move through the following lifecycle states:
 
 | State     | Description                                                                                       |
 |-----------|---------------------------------------------------------------------------------------------------|
-| Scheduled | The deployment is waiting for offer conditions to be met to start offering the update to devices. |
-| Offering  | The deployment is offering the update to devices.                                                 |
-| Paused    | The deployment is paused and prevented from offering the update to devices until it is unpaused.  |
+| 'scheduled' | The deployment is waiting for offer conditions to be met to start offering the update to devices. |
+| 'offering'  | The deployment is offering the update to devices.                                                 |
+| 'paused'    | The deployment is paused and prevented from offering the update to devices until it is unpaused.  |
 
 
 ### Transitions
 
 | Transition                     | Condition                                |
 |--------------------------------|------------------------------------------|
-| scheduled → offering           | Scheduling condition is met.             |
-| offering → scheduled           | Scheduling condition is not met.         |
-| scheduled or offering → paused | There is a request or automatic action to pause. |
-| paused → scheduled or offering | There is no longer a request or automatic action to pause. |
+| 'scheduled' → 'offering'           | Scheduling condition is met.             |
+| 'offering' → 'scheduled'           | Scheduling condition is not met.         |
+| 'scheduled' or 'offering' → 'paused' | There is a request or automatic action to pause. |
+| 'paused' → 'scheduled' or 'offering' | There is no longer a request or automatic action to pause. |
 
 ### Resource model
 
-The [deployment](/graph/api/resources/windowsupdates-deployment) resource has a `state` property of type [deploymentState](/graph/api/resources/windowsupdates-deploymentstate) which provides information about the current lifecycle state.
+The [deployment](/graph/api/resources/windowsupdates-deployment) resource has a **state** property of type [deploymentState](/graph/api/resources/windowsupdates-deploymentstate) which provides information about the current lifecycle state.
 
-The service will determine the effective `value` of the deployment state as a net result of several inputs and asynchronous processes, but you can request a particular value by setting `requestedValue` as one of these inputs. Other inputs to the effective deployment state value include rollout settings and monitoring settings.
+The service determines the effective `value` of the deployment state as a net result of several inputs and asynchronous processes, but you can request a particular value by setting `requestedValue` as one of these inputs. Other inputs to the effective deployment state value include rollout settings and monitoring settings.
 
 ## Multiple deployments
 
-A device can be assigned to multiple deployments at one time. These deployments can be for content of the same update category (for example, all deployments are feature updates), or for content of different update categories.
+You can assign a device to multiple deployments at one time. These deployments can be for content of the same update category (for example all deployments are feature updates), or for content of different update categories.
 
-When a device is assigned to two deployments for content of different update categories (for example, a feature update and an expedited quality update), the deployment service will offer content in a sequence according to Microsoft’s recommendation.
+When you assign a device to two deployments for content of different update categories (for example, a feature update and an expedited quality update), the deployment service offers content in a sequence according to Microsoft’s recommendation.
 
-When a device is assigned to two deployments for content of the same update category (for example, feature update versions 20H1 and 20H2, or quality updates from March 2021 and April 2021), the deployment service offers the content that is higher ranked by Microsoft. For feature updates and quality updates, an update that is released more recently is higher ranked. This behavior does not apply if one of the deployments is still scheduled for the device and is not ready to offer content. In that case, content from the other deployment is delivered to the device.
+When you assign a device to two deployments for content of the same update category (for example, feature update versions 20H1 and 20H2, or quality updates from March 2021 and April 2021), the deployment service offers the content that is higher ranked by Microsoft. For feature updates and quality updates, a more recent update is higher ranked. This behavior does not apply if one of the deployments is still scheduled for the device and is not ready to offer content. In that case, the other deployment delivers content to the device.

--- a/concepts/windowsupdates-enroll.md
+++ b/concepts/windowsupdates-enroll.md
@@ -9,13 +9,13 @@ doc_type: conceptualPageType
 
 # Enroll in update management by the Windows Update for Business deployment service
 
-When a device is enrolled in update management by the Windows Update for Business deployment service, you can use the deployment service to manage content delivered from Windows Update to that device. You can enroll a device in update management by update category.
+When you enroll device in update management by the Windows Update for Business deployment service, you can use the deployment service to manage content delivered from Windows Update to that device. You can enroll a device in update management by update category.
 
 Today, the deployment service supports enrollment in management of Windows 10 feature updates. At this time, the deployment service does not require enrollment in management of Windows 10 quality updates in order to deploy expedited quality updates.
 
 ## Enroll the device in update management
 
-When you enroll a device in management for a certain update category, the deployment service becomes the authority for updates of that category coming from Windows Update. As a result, device will not receive updates of that category from Windows Update until you deploy an update using the deployment service by assigning it to a [deployment](windowsupdates-deployments.md). Devices are automatically registered with the service when enrolled in management by the service (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice.md) object is automatically created if it does not already exist).
+When you enroll a device in management for a certain update category, the deployment service becomes the authority for updates of that category coming from Windows Update. As a result, devices do not receive updates of that category from Windows Update until you deploy an update using the deployment service by assigning it to a [deployment](windowsupdates-deployments.md). Devices are automatically registered with the service when enrolled in management by the service (i.e. an [azureADDevice](/graph/api/resources/windowsupdates-azureaddevice.md) object is automatically created if it does not already exist).
 
 ### Request
 
@@ -50,7 +50,7 @@ HTTP/1.1 202 Accepted
 
 ## Check the enrollment state of a device
 
-You can check the enrollment state of a device by [getting the device](/graph/api/windowsupdates-azureaddevice-get) and looking at the **enrollments** and **errors** properties on the **azureADDevice** object. A device that is successfully enrolled in update management will have an [updateManagementEnrollment](/graph/api/resources/windowsupdates-updatemanagementenrollment) object in the enrollments collection, and it will not have any [updatableAssetError](/graph/api/resources/windowsupdates-updatableasseterror) objects in the errors collection. A device that the service tried to enroll but encountered an error will have populated collections for both enrollments and errors. A device for which the service has not received any enrollment requests will have empty collections for both enrollments and errors.
+You can check the enrollment state of a device by [getting the device](/graph/api/windowsupdates-azureaddevice-get) and looking at the **enrollments** and **errors** properties on the **azureADDevice** object. A device that is successfully enrolled in update management has an [updateManagementEnrollment](/graph/api/resources/windowsupdates-updatemanagementenrollment) object in the enrollments collection, and it does not have any [updatableAssetError](/graph/api/resources/windowsupdates-updatableasseterror) objects in the errors collection. A device that the service tried to enroll but encountered an error has populated collections for both enrollments and errors. A device for which the service has not received any enrollment requests has empty collections for both enrollments and errors.
 
 The following example shows a device that is successfully enrolled in management of feature updates by the service.
 
@@ -82,7 +82,7 @@ Content-Type: application/json
 
 ## Unenroll from management by the service or unregister from the service 
 
-When you unenroll a device from management by the service for a given update category, the device is no longer managed by the deployment service and may start receiving other updates from Windows Update based on its policy configuration. If the device is assigned to any deployments for the given update category, it will not receive that content. The device remains registered with the service and is still enrolled and receiving content for other update categories (if applicable).
+When you unenroll a device from management by the service for a given update category, the device is no longer managed by the deployment service and may start receiving other updates from Windows Update based on its policy configuration. If the device is assigned to any deployments for the given update category, it does not receive that content. The device remains registered with the service and is still enrolled and receiving content for other update categories (if applicable).
 
 ### Request
 

--- a/concepts/windowsupdates-manage-monitoring-rules.md
+++ b/concepts/windowsupdates-manage-monitoring-rules.md
@@ -15,14 +15,12 @@ Monitoring rules are compatible with deployments of Windows 10 feature updates.
 
 ## Step 1: Create a monitoring rule
 
-You can create a monitoring rule for a deployment by configuring the monitoring settings. Each [deployment](/graph/api/resources/windowsupdates-deployments) can have one active monitoring rule at a time.
+You can create a [monitoring rule](/graph/api/resources/windowsupdates-monitoringrule) for a deployment by configuring the [monitoring settings](/graph/api/resources/windowsupdates-monitoringsettings). Each [deployment](/graph/api/resources/windowsupdates-deployments) can have one active monitoring rule at a time.
 
 Monitoring rules consist of three components:
 * **signal**: The type of update issue to be monitored by the deployment service.
 * **threshold**: When this percentage of devices emit the specified signal, the monitoring rule is triggered.
 * **action**: The action to take when the monitoring rule is triggered.
-
-See [monitoringRule resource type](/graph/api/resources/windowsupdates-monitoringrule) for more information.
 
 Below is an example of creating a monitoring rule for a deployment at the same time as creating the deployment.
 

--- a/concepts/windowsupdates-manage-monitoring-rules.md
+++ b/concepts/windowsupdates-manage-monitoring-rules.md
@@ -100,7 +100,7 @@ Content-Type: application/json
 ```
 
 ## Step 2: Unpause a deployment that was paused by a monitoring rule
-When a monitoring rule is triggered, it provides the opportunity to investigate update issues that may have lead to the monitoring rule being applied. After investigation, you may wish to resume the deployment. There are two ways to do so: removing the monitoring rule or updating the monitoring rule threshold.
+When a monitoring rule triggers, it provides the opportunity to investigate update issues that may have lead to it being applied. After investigation, you may wish to resume the deployment. There are two ways to do so: removing the monitoring rule or updating the monitoring rule threshold.
 
 ### Example: Resume deployment by removing a monitoring rule
 When a monitoring rule that pauses the deployment is triggered, one way to resume the deployment is to remove the rule.

--- a/concepts/windowsupdates-schedule-deployment.md
+++ b/concepts/windowsupdates-schedule-deployment.md
@@ -81,11 +81,11 @@ Content-Type: application/json
 
 ## Stage a deployment over a period of time
 
-You can also schedule a deployment so that assigned devices are offered the update in a gradual rollout that is staged over time. The update will be offered to subsets of devices assigned to the deployment at regular intervals, with the total duration of the rollout determined by either an end date or offering rate. You can think of a gradual rollout as similar to a recurring calendar event series.
+You can also schedule a deployment so that assigned devices are offered the update in a gradual rollout that is staged over time. The update is offered to subsets of devices assigned to the deployment at regular intervals, with the total duration of the rollout determined by either an end date or offering rate. You can think of a gradual rollout as similar to a recurring calendar event series.
 
-One way to stage a deployment over time is to set the `endDateTime` of the deployment. All devices assigned to the deployment will be offered the update within the window between the `startDateTime` and `endDateTime`. If the `startDateTime` is not specified, then the deployment will begin as soon as devices are assigned.
+One way to stage a deployment over time is to set the **endDateTime** of the deployment. All devices assigned to the deployment are offered the update within the window between the **startDateTime** and **endDateTime**. If the **startDateTime** is not specified, then the deployment begins as soon as devices are assigned.
 
-In this example, a new deployment is configured so that a new set of devices is offered the update every week (`durationBetweenOffers` set to seven days), starting on July 1, 2021. All devices will be offered the update before August 1, 2021.
+In this example, you configure a new deployment so that a new set of devices is offered the update every week (**durationBetweenOffers** set to seven days), starting on July 1, 2021. All devices are offered the update before August 1, 2021.
 
 ### Request
 
@@ -151,9 +151,9 @@ Content-Type: application/json
 }
 ```
 
-Another way to stage a deployment over time is to configure the offering rate using `devicesPerOffer`. Devices assigned to the deployment will be offered the update according to the specified rate until all devices have been offered the update.
+Another way to stage a deployment over time is to configure the offering rate using **devicesPerOffer**. Devices assigned to the deployment are offered the update according to the specified rate until all devices have been offered the update.
 
-In this example, a new deployment is configured so that a new set of devices is offered the update every week (`durationBetweenOffers` set to seven days), starting on July 1, 2021. 100 devices will be offered the update at a time until all devices have been offered the update.
+In this example, you configure a new deployment so that a new set of devices is offered the update every week (**durationBetweenOffers** set to seven days), starting on July 1, 2021. 100 devices are offered the update at a time until all devices have been offered the update.
 
 ### Request
 

--- a/concepts/windowsupdates-schedule-deployment.md
+++ b/concepts/windowsupdates-schedule-deployment.md
@@ -15,7 +15,7 @@ Scheduling features are compatible with [deployments](windowsupdates-deployments
 
 ## Schedule a deployment to start at a future date
 
-You can schedule a deployment to start at a future date by configuring its rollout settings. In the example below, all devices assigned the deployment will be offered the update on July 1, 2021.
+You can schedule a deployment to start at a future date by configuring its [rollout settings](/graph/api/resources/windowsupdates-rolloutsettings). In the example below, all devices assigned the deployment will be offered the update on July 1, 2021.
 
 ### Request
 
@@ -85,7 +85,7 @@ You can also schedule a deployment so that assigned devices are offered the upda
 
 ### Example: Stage a deployment at regular intervals between start and end dates
 
-One way to stage a deployment over time is to set the `endDateTime` of the deployment. All devices assigned to the deployment will be offered the update within the window between the `startDateTime` and `endDateTime`. If the `startDateTime` is not specified, then the deployment will begin as soon as devices are assigned.
+One way to stage a deployment over time is to set the **endDateTime** of the deployment. All devices assigned to the deployment will be offered the update within the window between the **startDateTime** and **endDateTime**. If the **startDateTime** is not specified, then the deployment will begin as soon as devices are assigned.
 
 
 In this example, you configure a new deployment so that a new set of devices is offered the update every week (**durationBetweenOffers** set to seven days), starting on July 1, 2021. All devices are offered the update before August 1, 2021.

--- a/concepts/windowsupdates-software-updates.md
+++ b/concepts/windowsupdates-software-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "Software updates with the Windows Update for Business deployment service"
-description: "Software updates are the primary type of content deployable by the deployment service. In order to find specific updates available for deployment you will refer to entries in a catalog."
+description: "Software updates are the primary type of content deployable by the deployment service. In order to find specific updates available for deployment you can refer to entries in a catalog."
 author: "Alice-at-Microsoft"
 localization_priority: Normal
 ms.prod: "w10"
@@ -9,7 +9,7 @@ doc_type: conceptualPageType
 
 # Software updates with the Windows Update for Business deployment service
 
-Software updates are the primary type of content deployable by the deployment service. Look up in a catalog to find specific updates available for [deployment](windowsupdates-deployments.md).
+Software updates are the primary type of content the deployment service deploys. Look up in a catalog to find specific updates available for [deployment](windowsupdates-deployments.md).
 
 You may already be familiar with the [Microsoft Update Catalog](https://www.catalog.update.microsoft.com/) which lists software updates for Windows. The deployment service provides its own [catalog](/graph/api/resources/windowsupdates-catalog), and aggregates equivalent updates under a single [catalogEntry](/graph/api/resources/windowsupdates-catalogentry) to simplify decision making and approval workflows.
 
@@ -57,7 +57,7 @@ Feature updates in the deployment service catalog are identified by version. Ent
 |----------|---------------------------------------------------|
 | version  | Feature update version for the Windows 10 release.|
 
-Below are some examples of feature updates in the deployment service's catalog.
+Below are some examples of feature updates in the deployment service catalog.
 
 | Display name                               | Version |
 |--------------------------------------------|---------|
@@ -77,14 +77,14 @@ Quality updates in the deployment service catalog are identified by a release da
 | classification | Classification (security or non-security) of the quality update. |
 | releaseDateTime | Date and time the update was released or refreshed. |
 
-The following table shows the classification mapping between the deployment service's catalog and the Microsoft Update Catalog:
+The following table shows the classification mapping between the deployment service catalog and the Microsoft Update Catalog.
 
 | Deployment service catalog | Microsoft Update Catalog                                                                                                               |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | Security         | Security Update<br>Critical Update<br>Update (if needed as a dependency)<br>Servicing Stack Update (if needed as a dependency) |
 | Non-security     | Update<br>Servicing Stack Update                                                                                               |
 
-The entries from the Microsoft Update Catalog corresponding to a quality update in the deployment service's catalog with `classification = security` and `releaseDateTime = 2021-03-09` might include the following:
+The entries from the Microsoft Update Catalog corresponding to a quality update in the deployment service catalog with `classification = security` and `releaseDateTime = 2021-03-09` might include the following.
 
 | Title                                                                                   | Products                           | Classification   |
 |-----------------------------------------------------------------------------------------|------------------------------------|------------------|

--- a/concepts/windowsupdates-software-updates.md
+++ b/concepts/windowsupdates-software-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "Software updates with the Windows Update for Business deployment service"
-description: "Software updates are the primary type of content deployable by the deployment service. In order to find specific updates available for deployment you can refer to entries in a catalog."
+description: "Software updates are the primary type of content the deployment service deploys. You can look up in a catalog to find specific updates available to deploy."
 author: "Alice-at-Microsoft"
 localization_priority: Normal
 ms.prod: "w10"
@@ -9,7 +9,7 @@ doc_type: conceptualPageType
 
 # Software updates with the Windows Update for Business deployment service
 
-Software updates are the primary type of content the deployment service deploys. Look up in a catalog to find specific updates available for [deployment](windowsupdates-deployments.md).
+Software updates are the primary type of content the deployment service deploys. You can look up in a catalog to find specific updates available to deploy.
 
 You may already be familiar with the [Microsoft Update Catalog](https://www.catalog.update.microsoft.com/) which lists software updates for Windows. The deployment service provides its own [catalog](/graph/api/resources/windowsupdates-catalog), and aggregates equivalent updates under a single [catalogEntry](/graph/api/resources/windowsupdates-catalogentry) to simplify decision making and approval workflows.
 

--- a/concepts/windowsupdates-software-updates.md
+++ b/concepts/windowsupdates-software-updates.md
@@ -97,4 +97,4 @@ Once you have identified the desired update, assign it as content to a deploymen
 
 ## Examples
 
-To see examples of [listing catalog entries](/graph/api/windowsupdates-catalog-list-entries), see [Deploy a feature update](windowsupdates-deploy-update.md) and [Deploy an expedited update](windowsupdates-deploy-expedited-update.md).
+To see examples of [listing catalog entries](/graph/api/windowsupdates-catalog-list-entries), see [Deploy a feature update](windowsupdates-deploy-update.md) and [Deploy an expedited security update](windowsupdates-deploy-expedited-update.md).


### PR DESCRIPTION
In text descriptions, style property names of resources as bold, not tick marks
Remove possesive on "deployment service"
Use present tense, not future tense
Edit lead-in sentences to tables (no colon)
Format state values
Active voice
Edit link text
Mark abstract types
Update to "Not supported." for personal Microsoft account
Description of inherited properties should refer to the direct parent, not the highest level
Style resource names as bold (when using full name, not when using friendly name)
Add remarks about administrator roles and licensing?