### PR TITLE
Update teamworktag-delete.md

### DIFF
--- a/api-reference/beta/api/teamworktag-delete.md
+++ b/api-reference/beta/api/teamworktag-delete.md
@@ -19,9 +19,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from most to least privileged)|
 |:---|:---|
-|Delegated (work or school account)|TeamworkTag.ReadWrite|
+|Delegated (work or school account)|Not supported.|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|TeamworkTag.ReadWrite.All|
 
 ## HTTP request
 


### PR DESCRIPTION
Updated permission support to add application and remove delegated. We will add delegated back in once it's unblocked and out.