### PR TITLE
Doc bug: Add identity provider to user flow is POST, not PATCH

### DIFF
--- a/api-reference/beta/api/b2cidentityuserflow-post-identityproviders.md
+++ b/api-reference/beta/api/b2cidentityuserflow-post-identityproviders.md
@@ -35,7 +35,7 @@ The work or school account needs to belong to one of the following roles:
 <!-- { "blockType": "ignored" } -->
 
 ```http
-PATCH /identity/b2cUserFlows/{id}/identityProviders/$ref
+POST /identity/b2cUserFlows/{id}/identityProviders/$ref
 ```
 
 ## Request headers
@@ -68,7 +68,7 @@ The following is an example of the request.
 -->
 
 ``` http
-PATCH https://graph.microsoft.com/beta/identity/b2cUserFlows/{id}/identityProviders/$ref
+POST https://graph.microsoft.com/beta/identity/b2cUserFlows/{id}/identityProviders/$ref
 Content-type: application/json
 Content-length: 30
 
@@ -107,5 +107,3 @@ The following is an example of the response.
 ```http
 HTTP/1.1 204 No Content
 ```
-
-

--- a/api-reference/beta/api/b2xidentityuserflow-post-identityproviders.md
+++ b/api-reference/beta/api/b2xidentityuserflow-post-identityproviders.md
@@ -35,7 +35,7 @@ The work or school account needs to belong to one of the following roles:
 <!-- { "blockType": "ignored" } -->
 
 ```http
-PATCH /identity/b2xUserFlows/{id}/identityProviders/$ref
+POST /identity/b2xUserFlows/{id}/identityProviders/$ref
 ```
 
 ## Request headers
@@ -68,7 +68,7 @@ The following is an example of the request.
 -->
 
 ``` http
-PATCH https://graph.microsoft.com/beta/identity/b2xUserFlows/{id}/identityProviders/$ref
+POST https://graph.microsoft.com/beta/identity/b2xUserFlows/{id}/identityProviders/$ref
 Content-type: application/json
 Content-length: 30
 

--- a/api-reference/v1.0/api/b2xidentityuserflow-post-identityproviders.md
+++ b/api-reference/v1.0/api/b2xidentityuserflow-post-identityproviders.md
@@ -33,7 +33,7 @@ The work or school account needs to belong to one of the following roles:
 <!-- { "blockType": "ignored" } -->
 
 ```http
-PATCH /identity/b2xUserFlows/{id}/identityProviders/$ref
+POST /identity/b2xUserFlows/{id}/identityProviders/$ref
 ```
 
 ## Request headers
@@ -64,7 +64,7 @@ The following is an example of the request.
 -->
 
 ``` http
-PATCH https://graph.microsoft.com/v1.0/identity/b2xUserFlows/B2X_1_Partner/identityProviders/$ref
+POST https://graph.microsoft.com/v1.0/identity/b2xUserFlows/B2X_1_Partner/identityProviders/$ref
 Content-type: application/json
 Content-length: 30
 


### PR DESCRIPTION
Adding identity providers to a user flow is a POST operation, while docs showed it as PATCH