### PR TITLE
Fix bug in documentation for listing print jobs for a printer share

### DIFF
--- a/api-reference/beta/api/printershare-list-jobs.md
+++ b/api-reference/beta/api/printershare-list-jobs.md
@@ -18,7 +18,7 @@ Retrieve a list of print jobs associated with the [printerShare](../resources/pr
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-To use the Universal Print service, the user or app's tenant must have an active Universal Print subscription, a permission that grants [Get printerShare](printershare-get.md) access, and one of the permissions listed in the following table. The signed in user must be a [Printer Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#printer-administrator).
+To use the Universal Print service, the user or app's tenant must have an active Universal Print subscription, a permission that grants [Get printerShare](printershare-get.md) access, and one of the permissions listed in the following table. 
 
 To read print jobs from another user, the signed in user needs to be a print administrator and have the PrintJob.ReadBasic.All, PrintJob.Read.All, PrintJob.ReadWriteBasic.All, or PrintJob.ReadWrite.All permission.
 

--- a/api-reference/v1.0/api/printershare-list-jobs.md
+++ b/api-reference/v1.0/api/printershare-list-jobs.md
@@ -17,7 +17,7 @@ Retrieve a list of print jobs associated with the [printerShare](../resources/pr
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-To use the Universal Print service, the user or app's tenant must have an active Universal Print subscription, a permission that grants [Get printerShare](printershare-get.md) access, and one of the permissions listed in the following table. The signed in user must be a [Printer Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#printer-administrator).
+To use the Universal Print service, the user or app's tenant must have an active Universal Print subscription, a permission that grants [Get printerShare](printershare-get.md) access, and one of the permissions listed in the following table.
 
 To read print jobs from another user, the signed in user needs to be a print administrator and have the PrintJob.ReadBasic.All, PrintJob.Read.All, PrintJob.ReadWriteBasic.All, or PrintJob.ReadWrite.All permission.
 


### PR DESCRIPTION
In permissions section, we have mentioned that printer administrator role is required for listing print jobs for a printer share. 
However, that is not true. 
Even non admins can list print jobs from a printer share