### PR TITLE
Add the documentation for the allow-any-email attribute in the people picker component

### DIFF
--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -7,7 +7,7 @@ author: elisenyang
 
 # People-Picker component in the Microsoft Graph Toolkit
 
-You can use the `mgt-people-picker` web component to search for people and/or groups. By default, the component will search for all people and users in the organization, but you can change the behavior to also search for groups, or only groups. You can also filter the search to a specific group. Additionally, you can include email addresses of people that are not in your contact list.
+You can use the `mgt-people-picker` web component to search for people and/or groups. By default, the component will search for all people and users in the organization, but you can change the behavior to also search for groups, or only groups. You can also filter the search to a specific group. Additionally, you can allow the user to enter and select any email address.
 
 ## Example
 
@@ -34,7 +34,7 @@ By default, the `mgt-people-picker` component fetches people from the `/me/peopl
 | default-selected-user-ids | defaultSelectedUserIds | When provided a string of comma-separated Microsoft Graph user IDs, the component renders the respective users as selected upon initialization.
 | selection-mode | selectionMode | Used to indicate whether to allow selecting multiple items (users or groups) or just a single item. Available options are: `single`, `multiple`. Default value is `multiple`.
 | disabled | disabled | Sets whether the people picker is disabled. When disabled, the user is not able to search or select people.
-| allow-any-email | allowAnyEmail | Indicates whether the people picker can accept email addresses that are not in your contact list. Default value is `false`. When you finish typing an email address, you can press comma (`,`), semicolon (`;`), tab or enter keys to add it.
+| allow-any-email | allowAnyEmail | Indicates whether the people picker can accept email addresses without selecting a person. Default value is `false`. When you finish typing an email address, you can press comma (`,`), semicolon (`;`), tab or enter keys to add it.
 
 The following is a `show-max` example.
 

--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -7,7 +7,7 @@ author: elisenyang
 
 # People-Picker component in the Microsoft Graph Toolkit
 
-You can use the `mgt-people-picker` web component to search for people and/or groups. By default, the component will search for all people and users in the organization, but you can change the behavior to also search for groups, or only groups. You can also filter the search to a specific group.
+You can use the `mgt-people-picker` web component to search for people and/or groups. By default, the component will search for all people and users in the organization, but you can change the behavior to also search for groups, or only groups. You can also filter the search to a specific group. Additionally, you can include email addresses of people that are not in your contact list.
 
 ## Example
 
@@ -34,6 +34,7 @@ By default, the `mgt-people-picker` component fetches people from the `/me/peopl
 | default-selected-user-ids | defaultSelectedUserIds | When provided a string of comma-separated Microsoft Graph user IDs, the component renders the respective users as selected upon initialization.
 | selection-mode | selectionMode | Used to indicate whether to allow selecting multiple items (users or groups) or just a single item. Available options are: `single`, `multiple`. Default value is `multiple`.
 | disabled | disabled | Sets whether the people picker is disabled. When disabled, the user is not able to search or select people.
+| allow-any-email | allowAnyEmail | Indicates whether the people picker can accept email addresses that are not in your contact list. Default value is `false`.
 
 The following is a `show-max` example.
 

--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -34,7 +34,7 @@ By default, the `mgt-people-picker` component fetches people from the `/me/peopl
 | default-selected-user-ids | defaultSelectedUserIds | When provided a string of comma-separated Microsoft Graph user IDs, the component renders the respective users as selected upon initialization.
 | selection-mode | selectionMode | Used to indicate whether to allow selecting multiple items (users or groups) or just a single item. Available options are: `single`, `multiple`. Default value is `multiple`.
 | disabled | disabled | Sets whether the people picker is disabled. When disabled, the user is not able to search or select people.
-| allow-any-email | allowAnyEmail | Indicates whether the people picker can accept email addresses that are not in your contact list. Default value is `false`.
+| allow-any-email | allowAnyEmail | Indicates whether the people picker can accept email addresses that are not in your contact list. Default value is `false`. When you finish typing an email address, you can press comma (`,`), semicolon (`;`), tab or enter keys to add it.
 
 The following is a `show-max` example.
 


### PR DESCRIPTION
Documented the new attribute `allow-any-email` in the people picker component. Comes from the issue https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/934 and PR https://github.com/microsoftgraph/microsoft-graph-toolkit/pull/1069.