### PR TITLE
Update organizationalbrandingproperties

### DIFF
--- a/api-reference/beta/api/organizationalbrandingproperties-create.md
+++ b/api-reference/beta/api/organizationalbrandingproperties-create.md
@@ -33,8 +33,8 @@ The **id** property is ignored on PUT/PATCH to the /branding singleton. If Conte
 <!-- { "blockType": "ignored" } -->
 
 ```http
-PUT /organization/{id}/branding
-PATCH /organization/{id}/branding
+PUT /organization/{tenant id}/branding
+PATCH /organization/{tenant id}/branding
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
Added {tenant id} instead of {id} because "id" is already in use as a property id.