### PR TITLE
contact-get.md update HTTP request hierarchy

### DIFF
--- a/api-reference/v1.0/api/contact-get.md
+++ b/api-reference/v1.0/api/contact-get.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
-A [contact](../resources/contact.md) from a user's store.
+A [contact](../resources/contact.md) in the user's mailbox.
 ```http
 GET /me/contacts/{id}
 GET /users/{id | userPrincipalName}/contacts/{id}

--- a/api-reference/v1.0/api/contact-get.md
+++ b/api-reference/v1.0/api/contact-get.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
-A [contact](../resources/contact.md) from a user's default [contactFolder](../resources/contactfolder.md).
+A [contact](../resources/contact.md) from a user's store.
 ```http
 GET /me/contacts/{id}
 GET /users/{id | userPrincipalName}/contacts/{id}


### PR DESCRIPTION
The current state of the documentation has caused confusion with customers with the following statement: "A contact from a user's default contactFolder." suggesting that a GET /contacts/{id} request only does a look-up against the main contactFolder; whereas in reality, the lookup is made against the entire mailbox's store.