### PR TITLE
Update the Universal Print pricing header

### DIFF
--- a/api-reference/includes/cloudprinting-pricing-disclaimer.md
+++ b/api-reference/includes/cloudprinting-pricing-disclaimer.md
@@ -1,10 +1,10 @@
 ---
 author: nilakhan
 ms.topic: include
-ms.date: 03/02/2021
+ms.date: 05/17/2021
 ---
 
 <!-- markdownlint-disable MD041-->
 
 > [!IMPORTANT]
-> Microsoft is temporarily offering usage of the cloud printing APIs to manage Universal Print at no charge. Microsoft expects to charge for the use of some or all of these APIs in the future. Microsoft will provide advanced notice of pricing changes.
+> Microsoft is offering usage of the cloud printing APIs to manage Universal Print at no charge and there are no foreseeable plans to charge for the use of these APIs.


### PR DESCRIPTION
We've decided not to charge for API usage. Updating the docs pages to reflect this decision.

The string has been fully reviewed by CELA and Marketing.