### PR TITLE
Clarify the contents of the Response from the API

### DIFF
--- a/api-reference/beta/api/intune-enrollment-enrollmentprofile-exportmobileconfig.md
+++ b/api-reference/beta/api/intune-enrollment-enrollmentprofile-exportmobileconfig.md
@@ -45,7 +45,7 @@ GET /deviceManagement/depOnboardingSettings/{depOnboardingSettingId}/enrollmentP
 Do not supply a request body for this method.
 
 ## Response
-If successful, this function returns a `200 OK` response code and a String in the response body.
+If successful, this function returns a `200 OK` response code and a String in the response body. This string is a Base64 encoded blob, and it must be converted back into a bytestream and saved as a `.mobileconfig` file before it can be used to enroll devices.
 
 ## Example
 


### PR DESCRIPTION
When using the API, it wasn't clear right away that the `value` property that was returned was a Base64 encoded file, nor what I needed to do to it in order to use it with devices. While I quickly recognized it as Base64, I initially tried treating it as Base64 encoded UTF-8 text, which looked right when compared to a manually-downloaded `.mobileconfig` file from Intune, but didn't work when tested with iOS devices. I figure that clarifying this here might save other people from some headaches.