### PR TITLE
Update user-list-manager.md - Added requirement

### DIFF
--- a/api-reference/v1.0/api/user-list-manager.md
+++ b/api-reference/v1.0/api/user-list-manager.md
@@ -49,6 +49,8 @@ This method supports the `$select` and `$expand` [OData query parameters](/graph
 > + The `n` value of `$levels` can be `max` (to return all managers) or a number between 1 and 1000.  
 > + When the `$levels` parameter is not specified, only the immediate manager is returned.  
 > + You can specify `$select` inside `$expand` to select the individual manager's properties. The `$levels` parameter is required: `$expand=manager($levels=max;$select=id,displayName)`
+> + In order to select the expanded manager's properties, the `$count=true` parameter must be added to the query as well as the header,
+`ConsistencyLevel=eventual`. You can see this implemented in Example 2 below.
 
 ## Request headers
 

--- a/api-reference/v1.0/api/user-list-manager.md
+++ b/api-reference/v1.0/api/user-list-manager.md
@@ -50,7 +50,7 @@ This method supports the `$select` and `$expand` [OData query parameters](/graph
 > + When the `$levels` parameter is not specified, only the immediate manager is returned.  
 > + You can specify `$select` inside `$expand` to select the individual manager's properties. The `$levels` parameter is required: `$expand=manager($levels=max;$select=id,displayName)`
 > + In order to select the expanded manager's properties, the `$count=true` parameter must be added to the query as well as the header,
-`ConsistencyLevel=eventual`. You can see this implemented in Example 2 below.
+`ConsistencyLevel=eventual`. You can see this implemented in Example 2.
 
 ## Request headers
 


### PR DESCRIPTION
An essential requirement when trying to select properties of an 
expanded manager property is to add the $count=true parameter
somewhere in the query. Example 2 exhibits this; however, it is not
clearly indicated in the documentation. I added a note that 
highlights this. In addition, I emphasized the need for the required 
header: ConsistencyLevel eventual. Although this is documented, 
our customers frequently miss this requirement, and additional 
emphasis should be helpful. The following note was added:
"In order to select the expanded manager's properties, the 
`$count=true` parameter must be added to the query as well 
as the header, `ConsistencyLevel=eventual`. You can see this 
implemented in Example 2 below."