### PR TITLE
Rename duplicated update_deployment  meta name

### DIFF
--- a/api-reference/beta/api/windowsupdates-deployment-update.md
+++ b/api-reference/beta/api/windowsupdates-deployment-update.md
@@ -65,7 +65,7 @@ In this example, the deployment is paused by updating the `requestedValue` of th
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
-  "name": "update_deployment",
+  "name": "update_deployment_1",
   "@odata.type": "microsoft.graph.windowsUpdates.deployment"
 }
 -->
@@ -144,7 +144,7 @@ In this example, the `settings` property of the deployment is updated to add a m
 #### Request
 <!-- {
   "blockType": "request",
-  "name": "update_deployment",
+  "name": "update_deployment_2",
   "@odata.type": "microsoft.graph.windowsUpdates.deployment"
 }
 -->


### PR DESCRIPTION
The meta name update_deployment in [this]https://docs.microsoft.com/en-us/graph/api/windowsupdates-deployment-update?view=graph-rest-beta&tabs=csharp) was duplicated resulting in overwriting of generated snippet for example 1 with that of the subsequent example. 