### PR TITLE
Cae config descriptions graph api may2021

### DIFF
--- a/api-reference/beta/api/continuousaccessevaluationpolicy-get.md
+++ b/api-reference/beta/api/continuousaccessevaluationpolicy-get.md
@@ -43,7 +43,7 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a [continuousAccessEvaluationPolicy](../resources/continuousaccessevaluationpolicy.md) object in the response body.
+If successful, this method returns a `200 OK` response code and a [continuousAccessEvaluationPolicy](../resources/continuousaccessevaluationpolicy.md) object in the response body. If unsuccessful, a 404 error will be returned, indicating that CAE is not currently configured.
 
 ## Examples
 

--- a/api-reference/beta/api/continuousaccessevaluationpolicy-get.md
+++ b/api-reference/beta/api/continuousaccessevaluationpolicy-get.md
@@ -43,7 +43,7 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a [continuousAccessEvaluationPolicy](../resources/continuousaccessevaluationpolicy.md) object in the response body. If unsuccessful, a 404 error will be returned, indicating that CAE is not currently configured.
+If successful, this method returns a `200 OK` response code and a [continuousAccessEvaluationPolicy](../resources/continuousaccessevaluationpolicy.md) object in the response body. If unsuccessful, a `404 NOT FOUND` error will be returned, indicating that CAE is not currently configured.
 
 ## Examples
 


### PR DESCRIPTION
Added possible 404 response indicating that CAE is not configured, that is, CAE is not explicitly enabled or disabled in a tenant.
CC: @lujiangfeng666 & @davidmu1 