### PR TITLE
Added an "s" to the GET request example

### DIFF
--- a/api-reference/v1.0/api/emailauthenticationmethodconfiguration-get.md
+++ b/api-reference/v1.0/api/emailauthenticationmethodconfiguration-get.md
@@ -33,7 +33,7 @@ For delegated scenarios, the administrator needs the Global admin role. For more
 -->
 
 ```http
-GET https://graph.microsoft.com/v1.0/policies/authenticationMethodsPolicy/authenticationMethodConfiguration/email
+GET https://graph.microsoft.com/v1.0/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/email
 ```
 
 ## Request headers


### PR DESCRIPTION
There was no "s" to authenticationMethodConfiguration. 