### PR TITLE
removing get and list members from protected API list

### DIFF
--- a/api-reference/v1.0/api/conversationmember-get.md
+++ b/api-reference/v1.0/api/conversationmember-get.md
@@ -25,8 +25,6 @@ One of the following permissions is required to call this API. To learn more, in
 
 > **Note**: Permissions marked with * use [resource-specific consent](https://aka.ms/teams-rsc).
 
-> [!NOTE]
-> Before calling this API with application permissions, you must request access. For details, see [Protected APIs in Microsoft Teams](/graph/teams-protected-apis).
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/conversationmember-list.md
+++ b/api-reference/v1.0/api/conversationmember-list.md
@@ -28,8 +28,6 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account)|Not supported.|
 |Application| Not supported. |
 
-> [!NOTE]
-> Before calling this API with application permissions, you must request access. For details, see [Protected APIs in Microsoft Teams](/graph/teams-protected-apis).
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/concepts/teams-protected-apis.md
+++ b/concepts/teams-protected-apis.md
@@ -25,8 +25,6 @@ The following APIs are currently protected:
 * [Create subscription for new chat messages](/graph/api/subscription-post-subscriptions) using [application permissions](auth/auth-concepts.md#microsoft-graph-permissions)
 * [List all hosted content](/graph/api/chatmessage-list-hostedcontents) using [application permissions](auth/auth-concepts.md#microsoft-graph-permissions)
 * [Get hosted content](/graph/api/chatmessagehostedcontent-get) using [application permissions](auth/auth-concepts.md#microsoft-graph-permissions)
-* [List chat members](/graph/api/conversationmember-list)  using [application permissions](auth/auth-concepts.md#microsoft-graph-permissions)
-* [Get chat member](/graph/api/conversationmember-get)  using [application permissions](auth/auth-concepts.md#microsoft-graph-permissions)
 
 >[!NOTE]
 >[Send message](/graph/api/channel-post-messages) is not a protected API.


### PR DESCRIPTION
Removed list-chat-member and get-chat-member from protected api list, also removed protected api references from those api pages.