### PR TITLE
fix: removed extra slash from example url

### DIFF
--- a/api-reference/v1.0/api/team-get-members.md
+++ b/api-reference/v1.0/api/team-get-members.md
@@ -64,7 +64,7 @@ Here is an example of the request.
   "name": "team-get_member"
 } -->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/teams/ece6f0a1-7ca4-498b-be79-edf6c8fc4d82/members//ZWUwZjVhZTItOGJjNi00YWU1LTg0NjYtN2RhZWViYmZhMDYyIyM3Mzc2MWYwNi0yYWM5LTQ2OWMtOWYxMC0yNzlhOGNjMjY3Zjk=
+GET https://graph.microsoft.com/v1.0/teams/ece6f0a1-7ca4-498b-be79-edf6c8fc4d82/members/ZWUwZjVhZTItOGJjNi00YWU1LTg0NjYtN2RhZWViYmZhMDYyIyM3Mzc2MWYwNi0yYWM5LTQ2OWMtOWYxMC0yNzlhOGNjMjY3Zjk=
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/team-get-member-csharp-snippets.md)]


### PR DESCRIPTION
There was an extra slash in the example url between "members" and the {membership-id}

The generated examples should be updated by the Microsoft Graph DevX Tooling.