### PR TITLE
Rename unknownfuturevalue to unknownFutureValue for search API

### DIFF
--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -820,6 +820,7 @@ Namespace: microsoft.graph
 |list|
 |listItem|
 |drive|
+|unknownFutureValue|
 
 ### searchAlterationType values
 

--- a/api-reference/beta/resources/search-api-overview.md
+++ b/api-reference/beta/resources/search-api-overview.md
@@ -187,6 +187,7 @@ For backward compatibility, the original properties and types are accessible and
 | [searchHit](./searchhit.md)        | Remove property | **_sortField** | Not applicable |
 | [searchHit](./searchhit.md)        | Rename property | **_source** | **resource** |
 | [searchHit](./searchhit.md)        | Rename property | **_summary**  | **summary**  |
+| [entityTypes](./enums.md)          | Rename enum value | **unknownfuturevalue**  | **unknownFutureValue**  |
 
 ## See also
 


### PR DESCRIPTION
Previously it used wrong casing.