### PR TITLE
Remove SharePoint/ODB limitation for drive item delta on subfolders.

### DIFF
--- a/api-reference/beta/api/driveitem-delta.md
+++ b/api-reference/beta/api/driveitem-delta.md
@@ -272,8 +272,6 @@ Content-type: application/json
 * The delta feed shows the latest state for each item, not each change. If an item were renamed twice, it would only show up once, with its latest name.
 * The same item may appear more than once in a delta feed, for various reasons. You should use the last occurrence you see.
 * The `parentReference` property on items will not include a value for **path**. This occurs because renaming a folder does not result in any descendants of the folder being returned from **delta**. **When using delta you should always track items by id**.
-* In OneDrive for Business and SharePoint, `delta` is only supported on the `root` folder, not on other folders within a drive.
-
 * Delta query will not return some DriveItem properties, depending on the operation and service type, as shown in the following tables.
 
     **OneDrive for Business**

--- a/api-reference/v1.0/api/driveitem-delta.md
+++ b/api-reference/v1.0/api/driveitem-delta.md
@@ -270,8 +270,6 @@ Content-type: application/json
 * The delta feed shows the latest state for each item, not each change. If an item were renamed twice, it would only show up once, with its latest name.
 * The same item may appear more than once in a delta feed, for various reasons. You should use the last occurrence you see.
 * The `parentReference` property on items will not include a value for **path**. This occurs because renaming a folder does not result in any descendants of the folder being returned from **delta**. **When using delta you should always track items by id**.
-* In OneDrive for Business and SharePoint, `delta` is only supported on the `root` folder, not on other folders within a drive.
-
 * Delta query will not return some DriveItem properties, depending on the operation and service type, as shown in the following tables.
 
     **OneDrive for Business**

--- a/changelog/Microsoft.FileServices.json
+++ b/changelog/Microsoft.FileServices.json
@@ -1556,6 +1556,38 @@
     		"CreatedDateTime": "2021-03-10T11:48:06.486Z",
     		"WorkloadArea": "Sites and lists",
     		"SubArea": ""
+    },
+    {
+        "ChangeList": [{
+            "Id": "4f8f9b37-4149-42d5-80af-3b01fff10780",
+            "ApiChange": "Resource",
+            "ChangedApiName": "delta",
+            "ChangeType": "change",
+            "Description": "Remove SharePoint and OneDrive for Business drive item delta limitation regarding calls targeting non-root folders.",
+            "Target": "driveItem"
+        }],
+        "Id": "4f8f9b37-4149-42d5-80af-3b01fff10780",
+        "Cloud": "prd",
+        "Version": "beta",
+        "CreatedDateTime": "2021-06-08T20:00:00.000Z",
+        "WorkloadArea": "Files",
+        "SubArea": ""
+    },
+    {
+        "ChangeList": [{
+            "Id": "6f3dd177-b9b4-45c0-8893-c65196a2e502",
+            "ApiChange": "Resource",
+            "ChangedApiName": "delta",
+            "ChangeType": "change",
+            "Description": "Remove SharePoint and OneDrive for Business drive item delta limitation regarding calls targeting non-root folders.",
+            "Target": "driveItem"
+        }],
+        "Id": "6f3dd177-b9b4-45c0-8893-c65196a2e502",
+        "Cloud": "prd",
+        "Version": "v1.0",
+        "CreatedDateTime": "2021-06-08T20:00:00.001Z",
+        "WorkloadArea": "Files",
+        "SubArea": ""
     }
   ]
 }

--- a/changelog/Microsoft.FileServices.json
+++ b/changelog/Microsoft.FileServices.json
@@ -1561,15 +1561,15 @@
         "ChangeList": [{
             "Id": "4f8f9b37-4149-42d5-80af-3b01fff10780",
             "ApiChange": "Resource",
-            "ChangedApiName": "delta",
+            "ChangedApiName": "driveItem",
             "ChangeType": "change",
-            "Description": "Remove SharePoint and OneDrive for Business drive item delta limitation regarding calls targeting non-root folders.",
+            "Description": "Removed SharePoint and OneDrive for Business driveItem delta limitation regarding calls targeting non-root folders.",
             "Target": "driveItem"
         }],
         "Id": "4f8f9b37-4149-42d5-80af-3b01fff10780",
         "Cloud": "prd",
         "Version": "beta",
-        "CreatedDateTime": "2021-06-08T20:00:00.000Z",
+        "CreatedDateTime": "2021-06-11T20:00:00.000Z",
         "WorkloadArea": "Files",
         "SubArea": ""
     },
@@ -1577,15 +1577,15 @@
         "ChangeList": [{
             "Id": "6f3dd177-b9b4-45c0-8893-c65196a2e502",
             "ApiChange": "Resource",
-            "ChangedApiName": "delta",
+            "ChangedApiName": "driveItem",
             "ChangeType": "change",
-            "Description": "Remove SharePoint and OneDrive for Business drive item delta limitation regarding calls targeting non-root folders.",
+            "Description": "Removed SharePoint and OneDrive for Business driveItem delta limitation regarding calls targeting non-root folders.",
             "Target": "driveItem"
         }],
         "Id": "6f3dd177-b9b4-45c0-8893-c65196a2e502",
         "Cloud": "prd",
         "Version": "v1.0",
-        "CreatedDateTime": "2021-06-08T20:00:00.001Z",
+        "CreatedDateTime": "2021-06-11T20:00:00.001Z",
         "WorkloadArea": "Files",
         "SubArea": ""
     }


### PR DESCRIPTION
SharePoint/ODB delta requests now support queries against a subfolder. This change removes the documented limitation stating that SharePoint/ODB delta requests must target the root folder.