### PR TITLE
TOC - Devices and apps should not be expanded by default

### DIFF
--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -1708,7 +1708,7 @@ items:
         - name: Delete
           href: api/bookingstaffmember-delete.md
     - name: Devices and apps
-      expanded: true
+      expanded: false
       items:
       - name: Cloud printing
         items:

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -1274,7 +1274,7 @@ items:
           - name: Delete a history item
             href: api/projectrome-delete-historyitem.md
     - name: Devices and apps
-      expanded: true
+      expanded: false
       items:
       - name: Cloud printing
         items:


### PR DESCRIPTION
Fixes a minor issue with the TOC where "Devices and apps" was expanded by default (`expanded: true`).

This topic has been expanded for a long time so it's possible this was intentional (although I'm not sure why it would be).