### PR TITLE
Clarify support of $orderBy on deletedDateTime property

### DIFF
--- a/api-reference/beta/api/directory-deleteditems-list.md
+++ b/api-reference/beta/api/directory-deleteditems-list.md
@@ -56,7 +56,18 @@ GET /directory/deletedItems/microsoft.graph.user
 This API currently supports retrieving object types of applications (microsoft.graph.application), groups (microsoft.graph.group) or users (microsoft.graph.user) from deleted items. The type is specified as a required part of the URI. Calling GET /directory/deleteditems without a type is not supported.
 
 ## Optional query parameters
-This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+This method supports the `$orderBy` [OData query parameter](/graph/query-parameters) to help customize the response. 
+
+### Examples using the $orderBy OData query parameter
+
+The `$orderBy` OData query parameter is supported on the **deletedDateTime**, **displayName**, and **userPrincipalName** properties of the deleted object types. On the **deletedDateTime** property, the query requires adding the [advanced query parameters](/graph/aad-advanced-queries) (**ConsistencyLevel** header set to `true` and `$count=true` query string).
+
+| OData cast | Properties supporting $orderBy | Example |
+| :--- | :--- | :--- |
+| microsoft.graph.user | deletedDateTime, displayName, userPrincipalName | /directory/deletedItems/microsoft.graph.user?$orderBy=userPrincipalName |
+| microsoft.graph.group | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.group?$orderBy=deletedDateTime asc&$count=true |
+| microsoft.graph.application | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.application?$orderBy=displayName |
+| microsoft.graph.device | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.device?$orderBy=deletedDateTime&$count=true |
 
 ## Request headers
 | Name      |Description|

--- a/api-reference/v1.0/api/directory-deleteditems-list.md
+++ b/api-reference/v1.0/api/directory-deleteditems-list.md
@@ -51,12 +51,24 @@ One of the following permissions is required to call this API. To learn more, in
 GET /directory/deleteditems/microsoft.graph.application
 GET /directory/deletedItems/microsoft.graph.group
 GET /directory/deletedItems/microsoft.graph.user
+GET /directory/deletedItems/microsoft.graph.device
 ```
 
 This API currently supports retrieving object types of groups (microsoft.graph.group) or users (microsoft.graph.user) from deleted items. The type is specified as a required part of the URI. Calling GET /directory/deletedItems without a type is not supported.
 
 ## Optional query parameters
-This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+This method supports the `$orderBy` [OData query parameter](/graph/query-parameters) to help customize the response. 
+
+### Examples using the $orderBy OData query parameter
+
+The `$orderBy` OData query parameter is supported on the **deletedDateTime**, **displayName**, and **userPrincipalName** properties of the deleted object types. On the **deletedDateTime** property, the query requires adding the [advanced query parameters](/graph/aad-advanced-queries) (**ConsistencyLevel** header set to `true` and `$count=true` query string).
+
+| OData cast | Properties supporting $orderBy | Example |
+| :--- | :--- | :--- |
+| microsoft.graph.user | deletedDateTime, displayName, userPrincipalName | /directory/deletedItems/microsoft.graph.user?$orderBy=userPrincipalName |
+| microsoft.graph.group | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.group?$orderBy=deletedDateTime asc&$count=true |
+| microsoft.graph.application | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.application?$orderBy=displayName |
+| microsoft.graph.device | deletedDateTime, displayName | /directory/deletedItems/microsoft.graph.device?$orderBy=deletedDateTime&$count=true |
 
 ## Request headers
 | Name      |Description|


### PR DESCRIPTION
`$orderBy` is supported on the **deletedDateTime** property but, not on /users, /groups, /applications directly. Rather, it's supported only on the /directory/deletedItems/{OData cast} endpoint/queries.

So:
- /users?$orderBy=deletedDateTime ❌
- /directory/deletedItems/microsoft.graph.user?$orderBy=deletedDateTime ✔