### PR TITLE
Extends documentation of MGT components' events

### DIFF
--- a/concepts/toolkit/components/agenda.md
+++ b/concepts/toolkit/components/agenda.md
@@ -126,7 +126,7 @@ The following events are fired from the control.
 
 Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
 ------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
-`eventClick` | The user clicks or taps an event. | Selected [event](/graph/api/resources/event) | No | No | No
+`eventClick` | The user clicks or taps an event. | Selected [event](/graph/api/resources/event) | No | No | Yes, with custom **event** template
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/agenda.md
+++ b/concepts/toolkit/components/agenda.md
@@ -124,9 +124,9 @@ To learn more, see [templates](../customize-components/templates.md).
 
 The following events are fired from the control.
 
-| Event | Description |
-| --- | --- |
-| `eventClick` | The user clicks or taps an event.|
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`eventClick` | The user clicks or taps an event. | Selected [event](/graph/api/resources/event) | No | No | No
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/file-list.md
+++ b/concepts/toolkit/components/file-list.md
@@ -131,9 +131,9 @@ To learn more, see [styling components](../customize-components/style.md).
 
 ## Events
 
-| Event | Description |
-| ----- | ----------- |
-| `itemClick` | Fired when the user clicks a file. Returns the file details. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`itemClick` | Fired when the user clicks a file. | Selected [file](/graph/api/resources/driveItem) | No | No | Yes, with custom **file** template
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/get.md
+++ b/concepts/toolkit/components/get.md
@@ -42,9 +42,12 @@ You can use several attributes to change the behavior of the component. The only
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `dataChange` | The detail contains the `response` and `error` objects. | Fired when the response or error change. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`dataChange` | Fired after the component loaded its data. | `{ response: any, error: any }`. The `response` property contains the response retrieved from Microsoft Graph. The `error` property contains information about the error if one occurred | No | No | Yes
+
+> [!TIP]
+> For more information about the data returned in the `response` property see the API reference of the API that you used in the `resource` property of the Get component.
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/login.md
+++ b/concepts/toolkit/components/login.md
@@ -70,13 +70,13 @@ To learn more, see [styling components](../customize-components/style.md).
 
 The following events are fired from the control.
 
-| Event | Description |
-| --- | --- |
-| `loginInitiated` | The user clicked the sign in button to start the login process - cancelable.|
-| `loginCompleted` | the login process was successful and the user is now signed in. |
-| `loginFailed` | The user canceled the login process or was unable to sign in.|
-| `logoutInitiated` | The user started to logout - cancelable. |
-| `logoutCompleted` | The user signed out. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`loginInitiated` | The user clicked the sign in button to start the login process | None | Yes | No | Yes
+`loginCompleted` | The login process was successful and the user is now signed in | None | No | No | Yes
+`loginFailed` | The user canceled the login process or was unable to sign in | None | No | No | Yes
+`logoutInitiated` | The user started to logout | None | Yes | No | Yes
+`logoutCompleted` | The user signed out | None | No | No | Yes
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/people-picker.md
+++ b/concepts/toolkit/components/people-picker.md
@@ -72,9 +72,9 @@ You can populate selected people data by doing one of the following:
 
 The following events are fired from the component.
 
-| Event | Description |
-| --- | --- |
-| `selectionChanged` | The user added or removed a person from the list of selected/picked people.|
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`selectionChanged` | The user added or removed a person from the list of selected/picked people | Array of selected people, where a person can be a Graph [user](/graph/api/resources/user), [person](/graph/api/resources/person) or [contact](/graph/api/resources/contact) with an additional `personImage` property that contains the URL of the user's photo | No | No | Yes, unless you override the default template
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/person-card.md
+++ b/concepts/toolkit/components/person-card.md
@@ -128,9 +128,9 @@ For example, you can use a template to customize the component attached to the `
 
 The following events are fired from the component.
 
-| Event | Description |
-| --- | --- |
-| `expanded` | The user has opened the expanded details section of the card. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`expanded` | The user has opened the expanded details section of the card | None | No | Yes | Yes, unless you override the default template
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/person.md
+++ b/concepts/toolkit/components/person.md
@@ -111,11 +111,11 @@ To learn more, see [styling components](../customize-components/style.md).
 
 The following events are fired from the component.
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `line1clicked` | The detail contains the respective `person` object | Fired when line1 is clicked. |
-| `line2clicked` | The detail contains the respective `person` object | Fired when line2 is clicked. |
-| `line3clicked` | The detail contains the respective `person` object | Fired when line3 is clicked. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`line1clicked` | Fired when line1 is clicked | The `person` object which can be a Graph [user](/graph/api/resources/user), [person](/graph/api/resources/person) or [contact](/graph/api/resources/contact) with an additional `personImage` property that contains the URL of the user's photo | No | No | Yes, unless you override the default template
+`line2clicked` | Fired when line2 is clicked | The `person` object which can be a Graph [user](/graph/api/resources/user), [person](/graph/api/resources/person) or [contact](/graph/api/resources/contact) with an additional `personImage` property that contains the URL of the user's photo | No | No | Yes, unless you override the default template
+`line3clicked` | Fired when line3 is clicked | The `person` object which can be a Graph [user](/graph/api/resources/user), [person](/graph/api/resources/person) or [contact](/graph/api/resources/contact) with an additional `personImage` property that contains the URL of the user's photo | No | No | Yes, unless you override the default template
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/tasks.md
+++ b/concepts/toolkit/components/tasks.md
@@ -115,12 +115,12 @@ mgt-tasks {
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `taskAdded` | The detail contains the respective `task` object | Fires when a new task has been created. |
-| `taskChanged` | The detail contains the respective `task` object | Fires when task metadata has been changed, such as marking completed. |
-| `taskClick` | The detail contains the respective `task` object | Fires when the user clicks or taps on a task. |
-| `taskRemoved` | The detail contains the respective `task` object | Fires when an existing task has been deleted. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`taskAdded` | Fires when a new task has been created | Newly created task which can be a [plannerTask](/graph/api/resources/plannertask) our [outlookTask](/graph/api/resources/outlooktask) | No | No | Yes
+`taskChanged` | Fires when task metadata has been changed, such as marking completed | Updated task which can be a [plannerTask](/graph/api/resources/plannertask) our [outlookTask](/graph/api/resources/outlooktask) | No | No | No
+`taskClick` | Fires when the user clicks or taps on a task | `task` property with the selected [plannerTask](/graph/api/resources/plannertask) our [outlookTask](/graph/api/resources/outlooktask) | No | No | No
+`taskRemoved` | Fires when an existing task has been deleted | `task` property with the selected [plannerTask](/graph/api/resources/plannertask) our [outlookTask](/graph/api/resources/outlooktask) | No | No | No
 
 For more information about handling events, see [events](../customize-components/events.md).
 

--- a/concepts/toolkit/components/teams-channel-picker.md
+++ b/concepts/toolkit/components/teams-channel-picker.md
@@ -73,21 +73,20 @@ mgt-teams-channel-picker {
 
 ## Events
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `selectionChanged` | The detail contains the currently selected item  of `{channel : `[MicrosoftGraph.Channel](/graph/api/resources/channel)`, team: `[MicrosoftGraph.Team](/graph/api/resources/team)`}` | Fired when user makes a change in selection of a channel. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`selectionChanged` | Fired when user makes a change in selection of a channel | The currently selected item as `{ channel: `[channel](/graph/api/resources/channel)`, team: `[team](/graph/api/resources/team)`}` | No | No | Yes
 
 For more information about handling events, see [events](../customize-components/events.md).
 
 ## Templates
 
- `mgt-teams-channel-picker` supports several [templates](../customize-components/templates.md) that you can use to replace certain parts of the component. To specify a template, include a `<template>` element inside a component and set the `data-type` value to one of the following.
+`mgt-teams-channel-picker` supports several [templates](../customize-components/templates.md) that you can use to replace certain parts of the component. To specify a template, include a `<template>` element inside a component and set the `data-type` value to one of the following.
 
 | Data type | Data context | Description |
 | --- | --- | --- |
 | loading | null: no data | The template used to render the state of the picker while the request to Microsoft Graph is being made. |
 | error | null: no data| The template used if user search returns no users. |
-
 
 The following example shows how to use the `error` template.
 

--- a/concepts/toolkit/components/todo.md
+++ b/concepts/toolkit/components/todo.md
@@ -94,12 +94,9 @@ To learn more, see [styling components](https://docs.microsoft.com/graph/toolkit
 
 The following events are fired from the component.
 
-| Event | Detail | Description |
-| --- | --- | --- |
-| `taskAdded` | The detail contains the respective `task` object | Fires when a new task has been created. |
-| `taskChanged` | The detail contains the respective `task` object | Fires when task metadata has been changed, such as marking completed. |
-| `taskClick` | The detail contains the respective `task` object | Fires when the user clicks or taps on a task. |
-| `taskRemoved` | The detail contains the respective `task` object | Fires when an existing task has been deleted. |
+Event | When is it emitted | Custom data | Cancelable | Bubbles | Works with custom template
+------|-------------------|--------------|:-----------:|:---------:|:---------------------------:|
+`taskClick` | Fires when the user clicks or taps on a task | Selected [task](https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/66a5bbb6591e6260e95dbc00c0d06bcbe8dcef38/packages/mgt-components/src/components/mgt-todo/graph.todo.ts#L41) | No | No | No
 
 For more information about handling events, see [events](../customize-components/events.md).
 


### PR DESCRIPTION
Extends documentation of MGT components' events.
Closes https://github.com/microsoftgraph/microsoft-graph-toolkit/issues/1220