### PR TITLE
Simplier example proposed

### DIFF
--- a/api-reference/beta/api/intune-devices-windowsprotectionstate-get.md
+++ b/api-reference/beta/api/intune-devices-windowsprotectionstate-get.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 ``` http
-GET /deviceManagement/deviceManagementScripts/{deviceManagementScriptId}/deviceRunStates/{deviceManagementScriptDeviceStateId}/managedDevice/windowsProtectionState
+GET /deviceManagement/managedDevices/{managedDeviceId}/windowsProtectionState
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
windowsProtectionState is a subclass/subproperty of managedDevices, there is no reason to aks for a management script, and even more to its run state to access it. My proposed sample works and can be used to retrieve a device WDAV status