### PR TITLE
Apply workaround for raw count responses

### DIFF
--- a/api-reference/beta/api/group-list-transitivemembers.md
+++ b/api-reference/beta/api/group-list-transitivemembers.md
@@ -129,7 +129,7 @@ Content-type: application/json
 The following is an example of the request.
 
 <!-- {
-  "blockType": "ignore",
+  "blockType": "ignored",
   "name": "get_group_transitivemembers_count"
 }-->
 

--- a/api-reference/beta/api/group-list-transitivemembers.md
+++ b/api-reference/beta/api/group-list-transitivemembers.md
@@ -129,7 +129,7 @@ Content-type: application/json
 The following is an example of the request.
 
 <!-- {
-  "blockType": "request",
+  "blockType": "ignore",
   "name": "get_group_transitivemembers_count"
 }-->
 

--- a/api-reference/beta/api/group-list-transitivemembers.md
+++ b/api-reference/beta/api/group-list-transitivemembers.md
@@ -149,9 +149,8 @@ The following is an example of the response.
 HTTP/1.1 200 OK
 Content-type: text/plain
 
+893
 ```
-
-`893`
 
 
 ### Example 3: Use the microsoft.graph.group OData cast to get only members that are groups

--- a/api-reference/v1.0/api/group-list-transitivemembers.md
+++ b/api-reference/v1.0/api/group-list-transitivemembers.md
@@ -126,7 +126,7 @@ Content-type: application/json
 The following is an example of the request.
 
 <!-- {
-  "blockType": "request",
+  "blockType": "ignore",
   "name": "get_group_transitivemembers_count"
 }-->
 

--- a/api-reference/v1.0/api/group-list-transitivemembers.md
+++ b/api-reference/v1.0/api/group-list-transitivemembers.md
@@ -148,9 +148,9 @@ The following is an example of the response.
 HTTP/1.1 200 OK
 Content-type: text/plain
 
-```
 
-`893`
+893
+```
 
 ### Example 3: Use the microsoft.graph.group OData cast to get only members that are groups
 

--- a/api-reference/v1.0/api/group-list-transitivemembers.md
+++ b/api-reference/v1.0/api/group-list-transitivemembers.md
@@ -126,7 +126,7 @@ Content-type: application/json
 The following is an example of the request.
 
 <!-- {
-  "blockType": "ignore",
+  "blockType": "ignored",
   "name": "get_group_transitivemembers_count"
 }-->
 


### PR DESCRIPTION
To add raw count responses into the response object, we must ignore validation of the example's request/response pair. Unfortunately, this means we won't have code snippets for these examples.