### PR TITLE
AuthenticationMethodsPolicy: Fixing sample URLs

### DIFF
--- a/api-reference/v1.0/api/emailauthenticationmethodconfiguration-get.md
+++ b/api-reference/v1.0/api/emailauthenticationmethodconfiguration-get.md
@@ -60,7 +60,7 @@ If successful, this method returns a `200 OK` response code and an [emailAuthent
 -->
 
 ```http
-GET /policies/authenticationMethodsPolicy/email
+GET /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/email
 ```
 
 ### Response

--- a/api-reference/v1.0/api/emailauthenticationmethodconfiguration-update.md
+++ b/api-reference/v1.0/api/emailauthenticationmethodconfiguration-update.md
@@ -64,7 +64,7 @@ If successful, this method returns a `204 No Content` response code. It does not
 -->
 
 ```http
-PATCH https://graph.microsoft.com/v1.0/policies/authenticationMethodsPolicy/authenticationMethodConfiguration/email
+PATCH https://graph.microsoft.com/v1.0/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/email
 Content-Type: application/json
 Content-length: 147
 

--- a/api-reference/v1.0/api/featurerolloutpolicy-get.md
+++ b/api-reference/v1.0/api/featurerolloutpolicy-get.md
@@ -126,7 +126,7 @@ The following is an example of the request.
 }-->
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/directory/featureRolloutPolicies/df85e4d9-e8c4-4033-a41c-73419a95c29c?$expand=appliesTo
+GET https://graph.microsoft.com/v1.0/policies/featureRolloutPolicies/df85e4d9-e8c4-4033-a41c-73419a95c29c?$expand=appliesTo
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-featurerolloutpolicy-expand-appliesto-csharp-snippets.md)]

--- a/api-reference/v1.0/api/fido2authenticationmethod-get.md
+++ b/api-reference/v1.0/api/fido2authenticationmethod-get.md
@@ -45,8 +45,8 @@ For delegated scenarios where an admin is acting on another user, the admin need
 }
 -->
 ``` http
-GET /me/authentication/fido2AuthenticationMethod/{id}
-GET /users/{id | userPrincipalName}/authentication/fido2AuthenticationMethod/{id}
+GET /me/authentication/fido2Methods/{id}
+GET /users/{id | userPrincipalName}/authentication/fido2Methods/{id}
 ```
 
 ## Request headers
@@ -66,7 +66,7 @@ If successful, this method returns a `200 OK` response code and the requested [f
 ### Request
 
 ``` http
-GET https://graph.microsoft.com/v1.0/me/authentication/fido2AuthenticationMethod/-2_GRUg2-HYz6_1YG4YRAQ2
+GET https://graph.microsoft.com/v1.0/me/authentication/fido2Methods/-2_GRUg2-HYz6_1YG4YRAQ2
 ```
 
 ### Response


### PR DESCRIPTION
A few sample URLs were inaccurate
- /policies/authenticationMethodsPolicy/
- /authentication/fido2Methods/
