### PR TITLE
Template for ConsistencyLevel & $count requirement on directoryObject resources

### DIFF
--- a/api-reference/v1.0/api/application-list.md
+++ b/api-reference/v1.0/api/application-list.md
@@ -40,7 +40,7 @@ This method supports the `$count`, `$expand`, `$filter`, `$orderBy`, `$search`, 
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
-| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. It uses an index that may not be up-to-date with recent changes to the object. For more information, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
+| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. It uses an index that may not be up to date with recent changes to the object. For more information on the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/application-list.md
+++ b/api-reference/v1.0/api/application-list.md
@@ -33,14 +33,14 @@ GET /applications
 ```
 ## Optional query parameters
 
-This method supports the `$count`, `$expand`, `$filter`, `$orderBy`, `$search`, `$select`, and `$top` [OData query parameters](/graph/query-parameters) to help customize the response. Some queries are supported only when you use [advanced query parameters](/graph/aad-advanced-queries), that is, the **ConsistencyLevel** header set to `true` and `$count`.
+This method supports the `$count`, `$expand`, `$filter`, `$orderBy`, `$search`, `$select`, and `$top` [OData query parameters](/graph/query-parameters) to help customize the response. Some queries are supported only when you use the **ConsistencyLevel** header set to `eventual` and `$count`. For more information, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries).
 
 ## Request headers
 
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
-| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. It uses an index that may not be up to date with recent changes to the object. For more information on the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
+| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. For more information about the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/application-list.md
+++ b/api-reference/v1.0/api/application-list.md
@@ -33,14 +33,14 @@ GET /applications
 ```
 ## Optional query parameters
 
-This method supports the [OData query parameters](/graph/query-parameters) to help customize the response, including `$search`, `$count`, and `$filter`. You can use `$search` on the **displayName** and **description** properties. When items are added or updated for this resource, they are specially indexed for use with the `$count` and `$search` query parameters. There can be a slight delay between when an item is added or updated and when it is available in the index.
+This method supports the `$count`, `$expand`, `$filter`, `$orderBy`, `$search`, `$select`, and `$top` [OData query parameters](/graph/query-parameters) to help customize the response. Some queries are supported only when you use [advanced query parameters](/graph/aad-advanced-queries), that is, the **ConsistencyLevel** header set to `true` and `$count`.
 
 ## Request headers
 
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
-| ConsistencyLevel | eventual. This header and `$count` are required when using `$search`, or when using `$filter` with the `$orderby` query parameter. It uses an index that may not be up-to-date with recent changes to the object. |
+| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. It uses an index that may not be up-to-date with recent changes to the object. For more information, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/application-list.md
+++ b/api-reference/v1.0/api/application-list.md
@@ -40,7 +40,7 @@ This method supports the `$count`, `$expand`, `$filter`, `$orderBy`, `$search`, 
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
-| ConsistencyLevel | `eventual`. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. For more information about the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
+| ConsistencyLevel | eventual. This header and `$count` are required when using `$search`, or in specific usage of `$filter`. For more information about the use of **ConsistencyLevel** and `$count`, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries). |
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/resources/application.md
+++ b/api-reference/v1.0/resources/application.md
@@ -56,7 +56,7 @@ This resource supports using [delta query](/graph/delta-query-overview) to track
 
 ## Properties
 
->**NOTE:** Specific usage of `$filter` and the `$search` query parameter is supported only when you use [advanced query parameters](/graph/aad-advanced-queries), that is, the **ConsistencyLevel** header set to `true` and `$count`. To confirm properties that require advanced query parameters, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries).
+> **Note:** Specific usage of `$filter` and the `$search` query parameter is supported only when you use the **ConsistencyLevel** header set to `eventual` and `$count`. For more information, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries).
 
 | Property | Type | Description |
 |:---------------|:--------|:----------|

--- a/api-reference/v1.0/resources/application.md
+++ b/api-reference/v1.0/resources/application.md
@@ -56,6 +56,8 @@ This resource supports using [delta query](/graph/delta-query-overview) to track
 
 ## Properties
 
+>**NOTE:** Specific usage of `$filter` and the `$search` query parameter is supported only when you use [advanced query parameters](/graph/aad-advanced-queries), that is, the **ConsistencyLevel** header set to `true` and `$count`. To confirm properties that require advanced query parameters, see [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries).
+
 | Property | Type | Description |
 |:---------------|:--------|:----------|
 | addIns | [addIn](addin.md) collection| Defines custom behavior that a consuming service can use to call an app in specific contexts. For example, applications that can render file streams [may set the addIns property](/onedrive/developer/file-handlers/?view=odsp-graph-online) for its "FileHandler" functionality. This will let services like Office 365 call the application in the context of a document the user is working on. |


### PR DESCRIPTION
Proposal: Adding a note to inform users that some properties require the request to use **ConsistencyLevel: `eventual`** and `$count`.