### PR TITLE
Update with activated roles details.

### DIFF
--- a/api-reference/beta/api/directoryrole-list.md
+++ b/api-reference/beta/api/directoryrole-list.md
@@ -14,6 +14,11 @@ Namespace: microsoft.graph
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
 List the directory roles that are activated in the tenant.
+
+This operation only returns roles that have been activated. A role becomes activated when an admin activates the role using the [Activate directoryRole](directoryrole-post-directoryroles.md) API. Not all built-in roles are initially activated. 
+
+When assigning a role using the Azure portal, the role activation step is implicitly done on the admin's behalf. To get the full list of roles that are available in Azure AD, use [List directoryRoleTemplates](directoryroletemplate-list.md).
+
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 


### PR DESCRIPTION
Add details about only returning activated roles, same as in [v1 documentation](https://raw.githubusercontent.com/microsoftgraph/microsoft-graph-docs/main/api-reference/v1.0/api/directoryrole-list.md) and still relevant to the beta endpoint.