### PR TITLE
FIX: example of adding multiple members to a group in one request (for C#)

### DIFF
--- a/api-reference/v1.0/includes/snippets/csharp/add-multiple-members-to-group-csharp-snippets.md
+++ b/api-reference/v1.0/includes/snippets/csharp/add-multiple-members-to-group-csharp-snippets.md
@@ -6,11 +6,17 @@ description: "Automatically generated file. DO NOT MODIFY"
 
 GraphServiceClient graphClient = new GraphServiceClient( authProvider );
 
+var userReferences = new [] {
+	"https://graph.microsoft.com/v1.0/directoryObjects/{id}",
+	"https://graph.microsoft.com/v1.0/directoryObjects/{id}",
+	"https://graph.microsoft.com/v1.0/directoryObjects/{id}"
+};
+
 var group = new Group
 {
 	AdditionalData = new Dictionary<string, object>()
 	{
-		{"members@odata.bind", "[\"https://graph.microsoft.com/v1.0/directoryObjects/{id}\",\"https://graph.microsoft.com/v1.0/directoryObjects/{id}\",\"https://graph.microsoft.com/v1.0/directoryObjects/{id}\"]"}
+		{ "members@odata.bind", userReferences }
 	}
 };
 


### PR DESCRIPTION
an array has to be set as value for the additional parameter `members@odata.bind`