### PR TITLE
Remove preview search note on Graph connector docs

### DIFF
--- a/api-reference/beta/api/connectionoperation-get.md
+++ b/api-reference/beta/api/connectionoperation-get.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Retrieve the properties of a [connectionOperation](../resources/connectionoperation.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/external-post-connections.md
+++ b/api-reference/beta/api/external-post-connections.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Create a new [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-delete.md
+++ b/api-reference/beta/api/externalconnection-delete.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Delete an [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-get.md
+++ b/api-reference/beta/api/externalconnection-get.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Retrieve the properties and relationships of an [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-list.md
+++ b/api-reference/beta/api/externalconnection-list.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Retrieve a list of [externalConnections](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-post-schema.md
+++ b/api-reference/beta/api/externalconnection-post-schema.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Create the schema for a Microsoft Search [connection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-put-items.md
+++ b/api-reference/beta/api/externalconnection-put-items.md
@@ -17,8 +17,6 @@ Create a new [externalItem](../resources/externalitem.md).
 
 This API can be used to create a custom item. Specify the type you are creating by including the `@odata.type` property in the JSON body. The containing [externalConnection](../resources/externalconnection.md) must have a [schema](../resources/schema.md) registered of the corresponding type.
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalconnection-update.md
+++ b/api-reference/beta/api/externalconnection-update.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Update the properties of an [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalitem-delete.md
+++ b/api-reference/beta/api/externalitem-delete.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Delete an [externalitem](../resources/externalitem.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalitem-get.md
+++ b/api-reference/beta/api/externalitem-get.md
@@ -17,8 +17,6 @@ Get the properties and relationships of an [externalitem](../resources/externali
 
 This API is provided for diagnostic purposes only. It is not intended to be used for any other purpose. Repeated requests to this API might result in `429` HTTP errors.
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/externalitem-update.md
+++ b/api-reference/beta/api/externalitem-update.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Update the properties of an [externalitem](../resources/externalitem.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/schema-get.md
+++ b/api-reference/beta/api/schema-get.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Retrieve the properties of a [schema](../resources/schema.md) for an [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/resources/acl.md
+++ b/api-reference/beta/resources/acl.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 An access control entry for an item indexed by a Microsoft Search [externalConnection](externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Properties
 
 | Property       | Type   | Description                                        |

--- a/api-reference/beta/resources/configuration.md
+++ b/api-reference/beta/resources/configuration.md
@@ -3,7 +3,7 @@ title: "configuration resource type"
 description: "Specifies additional application IDs that are allowed to manage the externalConnection and to index content in a externalConnection."
 localization_priority: Normal
 author: "snlraju-msft"
-ms.prod: ""
+ms.prod: "search"
 doc_type: "resourcePageType"
 ---
 

--- a/api-reference/beta/resources/configuration.md
+++ b/api-reference/beta/resources/configuration.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 Specifies additional application IDs that are allowed to manage the externalConnection and to index content in a [externalConnection](../resources/externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Properties
 
 | Property       | Type              | Description |

--- a/api-reference/beta/resources/externalconnection.md
+++ b/api-reference/beta/resources/externalconnection.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 A logical container to add content from an external source into Microsoft Graph.
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Methods
 
 | Method                                                           | Return Type                                   | Description |

--- a/api-reference/beta/resources/externalfile.md
+++ b/api-reference/beta/resources/externalfile.md
@@ -18,8 +18,6 @@ Namespace: microsoft.graph
 
 An item indexed via a Microsoft Search [connection](externalconnection.md). This type derives from the [externalItem](externalitem.md) type.
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Methods
 
 | Method                                                        | Return Type  | Description |

--- a/api-reference/beta/resources/externalitem.md
+++ b/api-reference/beta/resources/externalitem.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 An item added to a Microsoft Graph [connection](externalconnection.md). 
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Methods
 
 | Method                                                        | Return Type                     | Description |

--- a/api-reference/beta/resources/externalitemcontent.md
+++ b/api-reference/beta/resources/externalitemcontent.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 The content of an [externalItem](externalitem.md) indexed via a Microsoft Search [connection](externalconnection.md).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Properties
 
 | Property | Type   | Description                                                                                 |

--- a/api-reference/beta/resources/indexing-api-overview.md
+++ b/api-reference/beta/resources/indexing-api-overview.md
@@ -15,8 +15,6 @@ You can use Microsoft Graph to add custom items to search results in the [Micros
 
 Requests to index data are performed on behalf of an application without the presence of a signed-in user, identified using an [access token with application permission](/graph/auth-v2-service).
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Common use cases
 
 The use cases for the APIs in this section involve building [Microsoft Graph connectors](/microsoftsearch/connectors-overview), which involves the following primary steps:

--- a/api-reference/beta/resources/schema.md
+++ b/api-reference/beta/resources/schema.md
@@ -15,8 +15,6 @@ Namespace: microsoft.graph
 
 The [connection](externalconnection.md) schema determines how your external content will be used in various Microsoft Graph experiences. Schema is a flat list of all the properties that you plan to add to the connection along with their attributes, labels, and aliases. You must register the schema before adding items into the connection.
 
-[!INCLUDE [search-api-preview](../../includes/search-api-preview-signup.md)]
-
 ## Methods
 
 | Method                                                    | Return Type                   | Description |


### PR DESCRIPTION
No longer a targeted release feature, removing preview note from docs.