### PR TITLE
Add details about response object

### DIFF
--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -30,7 +30,6 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/joinedTeams
-or
 GET /users/{id | user-principal-name}/joinedTeams
 ```
 
@@ -51,7 +50,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only the **id**, **displayName**, and **description** properties of a [team](../resources/team.md). To get all properties, use the [Get team](../api/team-get.md) operation. For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns only the **id**, **displayName**, and **description** properties of a [team](../resources/team.md). To get all properties, use the [Get team](../api/team-get.md) operation. For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -56,7 +56,7 @@ If successful, this method returns a `200 OK` response code and collection of [t
 > **Note:** Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get)].
 
 ## Example
-##### Request
+### Request
 Here is an example of the request.
 
 # [HTTP](#tab/http)
@@ -85,7 +85,7 @@ GET https://graph.microsoft.com/beta/me/joinedTeams
 
 ---
 
-##### Response
+### Response
 Here is an example of the response. Note: The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -53,7 +53,8 @@ Do not supply a request body for this method.
 
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
-> **Note:** Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get)].
+> [!Note]
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
 
 ## Example
 ### Request
@@ -100,22 +101,9 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
-      "createdDateTime": null,
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a"
       "displayName": "Contoso Team",
-      "description": "This is a Contoso team, used to showcase the range of properties supported by this API",
-      "internalId": null,
-      "classification": null,
-      "specialization": null,
-      "visibility": null,
-      "webUrl": null,
-      "isArchived": false,
-      "isMembershipLimitedToOwners": null,
-      "memberSettings": null,
-      "guestSettings": null,
-      "messagingSettings": null,
-      "funSettings": null,
-      "discoverySettings": null
+      "description": "This is a Contoso team, used to showcase the range of properties supported by this API"
     }
   ]
 }
@@ -123,7 +111,8 @@ Content-type: application/json
 
 ## See also
 [List all teams](/graph/teams-list-all-teams)
-[Get team](/graph/team-get)]
+
+[Get team](/graph/team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -53,8 +53,10 @@ Do not supply a request body for this method.
 
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
+> **Note:** Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get)].
+
 ## Example
-### Request
+##### Request
 Here is an example of the request.
 
 # [HTTP](#tab/http)
@@ -83,7 +85,7 @@ GET https://graph.microsoft.com/beta/me/joinedTeams
 
 ---
 
-### Response
+##### Response
 Here is an example of the response. Note: The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
@@ -98,7 +100,22 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "31aa74dd-dd65-43ac-8c4e-0ec1ae5a8ee1"
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
+      "createdDateTime": null,
+      "displayName": "Contoso Team",
+      "description": "This is a Contoso team, used to showcase the range of properties supported by this API",
+      "internalId": null,
+      "classification": null,
+      "specialization": null,
+      "visibility": null,
+      "webUrl": null,
+      "isArchived": false,
+      "isMembershipLimitedToOwners": null,
+      "memberSettings": null,
+      "guestSettings": null,
+      "messagingSettings": null,
+      "funSettings": null,
+      "discoverySettings": null
     }
   ]
 }
@@ -106,6 +123,7 @@ Content-type: application/json
 
 ## See also
 [List all teams](/graph/teams-list-all-teams)
+[Get team](/graph/team-get)]
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request
@@ -112,7 +112,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](../api/team-get.md)
+[Get team](../api/team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request
@@ -112,7 +112,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](../api/team-get)
+[Get team](../api/team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](./team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request
@@ -112,7 +112,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](./team-get)
+[Get team](team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](./team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request
@@ -112,7 +112,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](/graph/team-get)
+[Get team](./team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request
@@ -112,7 +112,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](team-get.md)
+[Get team](../api/team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -101,7 +101,7 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a"
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
       "displayName": "Contoso Team",
       "description": "This is a Contoso team, used to showcase the range of properties supported by this API"
     }

--- a/api-reference/beta/api/user-list-joinedteams.md
+++ b/api-reference/beta/api/user-list-joinedteams.md
@@ -54,7 +54,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ### Request

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -100,7 +100,7 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a"
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
       "displayName": "Contoso Team",
       "description": "This is a Contoso team, used to showcase the range of properties supported by this API"
     }

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -30,7 +30,6 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 ```http
 GET /me/joinedTeams
-or
 GET /users/{id | user-principal-name}/joinedTeams
 ```
 
@@ -51,7 +50,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only the **id**, **displayName**, and **description** properties of a [team](../resources/team.md). To get all properties, use the [Get team](../api/team-get.md) operation. For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns only the **id**, **displayName**, and **description** properties of a [team](../resources/team.md). To get all properties, use the [Get team](../api/team-get.md) operation. For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](./team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
@@ -111,7 +111,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](/graph/team-get)
+[Get team](./team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -50,7 +50,10 @@ Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and collection of [group](../resources/group.md) objects in the response body.
+If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
+
+> **Note:** Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get)].
+
 ## Example
 ##### Request
 Here is an example of the request.
@@ -96,7 +99,22 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "31aa74dd-dd65-43ac-8c4e-0ec1ae5a8ee1"
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
+      "createdDateTime": null,
+      "displayName": "Contoso Team",
+      "description": "This is a Contoso team, used to showcase the range of properties supported by this API",
+      "internalId": null,
+      "classification": null,
+      "specialization": null,
+      "visibility": null,
+      "webUrl": null,
+      "isArchived": false,
+      "isMembershipLimitedToOwners": null,
+      "memberSettings": null,
+      "guestSettings": null,
+      "messagingSettings": null,
+      "funSettings": null,
+      "discoverySettings": null
     }
   ]
 }
@@ -104,10 +122,12 @@ Content-type: application/json
 
 ## See also
 [List all teams](/graph/teams-list-all-teams)
+[Get team](/graph/team-get)]
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->
-<!-- {
+<!--
+{
   "type": "#page.annotation",
   "description": "List joinedTeams",
   "keywords": "",
@@ -115,4 +135,5 @@ Content-type: application/json
   "tocPath": "",
   "suppressions": [
   ]
-}-->
+}
+-->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
@@ -111,7 +111,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](../api/team-get.md)
+[Get team](../api/team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
@@ -111,7 +111,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](team-get.md)
+[Get team](../api/team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -24,9 +24,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Team.ReadBasic.All, TeamSettings.Read.All, TeamSettings.ReadWrite.All, User.Read.All, User.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
 
-> With user delegated permissions this operation only works for the 'me' user. 
-> With application permissions, it works for all users by specifying  the specific user id. 
-> ('me' alias is not supported with application permissions)
+> **Note:** Currently, with user delegated permissions, this operation only works for the `me` user. With application permissions, it works for all users by specifying the specific user ID (`me` alias is not supported with application permissions). For details, see [Known issues](/graph/known-issues#microsoft-teams-users-list-of-joined-teams-preview).
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
@@ -37,7 +35,7 @@ GET /users/{id | user-principal-name}/joinedTeams
 ```
 
 ## Optional query parameters
-The [OData Query Parameters](/graph/query-parameters) are not currently supported.
+This method does not currently support the [OData query parameters](/graph/query-parameters) to customize the response.
 
 ## Request headers
 | Header       | Value |

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](./team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
@@ -111,7 +111,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](./team-get)
+[Get team](team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -52,7 +52,8 @@ Do not supply a request body for this method.
 
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
-> **Note:** Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get)].
+> [!Note]
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
 
 ## Example
 ##### Request
@@ -99,22 +100,9 @@ Content-type: application/json
 {
   "value": [
     {
-      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a",
-      "createdDateTime": null,
+      "id": "172b0cce-e65d-44ce-9a49-91d9f2e8493a"
       "displayName": "Contoso Team",
-      "description": "This is a Contoso team, used to showcase the range of properties supported by this API",
-      "internalId": null,
-      "classification": null,
-      "specialization": null,
-      "visibility": null,
-      "webUrl": null,
-      "isArchived": false,
-      "isMembershipLimitedToOwners": null,
-      "memberSettings": null,
-      "guestSettings": null,
-      "messagingSettings": null,
-      "funSettings": null,
-      "discoverySettings": null
+      "description": "This is a Contoso team, used to showcase the range of properties supported by this API"
     }
   ]
 }
@@ -122,7 +110,8 @@ Content-type: application/json
 
 ## See also
 [List all teams](/graph/teams-list-all-teams)
-[Get team](/graph/team-get)]
+
+[Get team](/graph/team-get)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,11 +53,11 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only the **id**, **displayName**, and **description** properties of a [team](../resources/team.md). To get all properties, use the [Get team](../api/team-get.md) operation. For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
-Here is an example of the request.
+The following example shows a request.
 
 # [HTTP](#tab/http)
 <!-- {
@@ -86,7 +86,9 @@ GET https://graph.microsoft.com/v1.0/me/joinedTeams
 ---
 
 ##### Response
-Here is an example of the response. Note: The response object shown here might be shortened for readability.
+The following example shows the response.
+
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,
@@ -109,9 +111,8 @@ Content-type: application/json
 ```
 
 ## See also
-[List all teams](/graph/teams-list-all-teams)
-
-[Get team](../api/team-get.md)
+- [List all teams](/graph/teams-list-all-teams)
+- [Get team](../api/team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/api-reference/v1.0/api/user-list-joinedteams.md
+++ b/api-reference/v1.0/api/user-list-joinedteams.md
@@ -53,7 +53,7 @@ Do not supply a request body for this method.
 If successful, this method returns a `200 OK` response code and collection of [team](../resources/team.md) objects in the response body.
 
 > [!Note]
-> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
+> Currently, this API call returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](../api/team-get.md). For details, see [known issues](/graph/known-issues#unable-to-return-all-values-for-properties-for-a-user-joined-teams).
 
 ## Example
 ##### Request
@@ -111,7 +111,7 @@ Content-type: application/json
 ## See also
 [List all teams](/graph/teams-list-all-teams)
 
-[Get team](../api/team-get)
+[Get team](../api/team-get.md)
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -351,6 +351,9 @@ The filter query to get members of a team based on their roles `GET /teams/team-
 ### Missing properties for chat members
 In certain instances, the `tenantId` / `email` / `displayName` property for the individual members of a chat might not be populated on a `GET /chats/chat-id/members` or `GET /chats/chat-id/members/membership-id` request.
 
+### Unable to return all values for properties for a user joined teams
+The API call for me/joinedTeams returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
+
 ## Users
 
 ### Use the dollar ($) symbol in the userPrincipalName

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -351,7 +351,7 @@ The filter query to get members of a team based on their roles `GET /teams/team-
 ### Missing properties for chat members
 In certain instances, the `tenantId` / `email` / `displayName` property for the individual members of a chat might not be populated on a `GET /chats/chat-id/members` or `GET /chats/chat-id/members/membership-id` request.
 
-### Unable to return all values for properties for a user joined teams
+### Missing properties in the list of teams that a user has joined
 The API call for me/joinedTeams returns values only for the properties **id**, **displayName**, and **description** of a [team](/graph/api/resources/team). To get information on all properties, use [Get team](/graph/api/team-get).
 
 ## Users

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -352,7 +352,7 @@ The filter query to get members of a team based on their roles `GET /teams/team-
 In certain instances, the `tenantId` / `email` / `displayName` property for the individual members of a chat might not be populated on a `GET /chats/chat-id/members` or `GET /chats/chat-id/members/membership-id` request.
 
 ### Missing properties in the list of teams that a user has joined
-The API call for me/joinedTeams returns returns values only the **id**, **displayName**, and **description** properties of a [team](/graph/api/resources/team). To get all properties, use the [Get team](/graph/api/team-get) operation.
+The API call for [me/joinedTeams](/graph/api/user-list-joinedteams) returns only the **id**, **displayName**, and **description** properties of a [team](/graph/api/resources/team). To get all properties, use the [Get team](/graph/api/team-get) operation.
 
 ## Users
 

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -352,7 +352,7 @@ The filter query to get members of a team based on their roles `GET /teams/team-
 In certain instances, the `tenantId` / `email` / `displayName` property for the individual members of a chat might not be populated on a `GET /chats/chat-id/members` or `GET /chats/chat-id/members/membership-id` request.
 
 ### Unable to return all values for properties for a user joined teams
-The API call for me/joinedTeams returns values only for the properties **id**, **displayName**, and **description** of a [team](../resources/team.md). To get information on all properties, use [Get team](/graph/team-get).
+The API call for me/joinedTeams returns values only for the properties **id**, **displayName**, and **description** of a [team](/graph/api/resources/team). To get information on all properties, use [Get team](/graph/api/team-get).
 
 ## Users
 

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -352,7 +352,7 @@ The filter query to get members of a team based on their roles `GET /teams/team-
 In certain instances, the `tenantId` / `email` / `displayName` property for the individual members of a chat might not be populated on a `GET /chats/chat-id/members` or `GET /chats/chat-id/members/membership-id` request.
 
 ### Missing properties in the list of teams that a user has joined
-The API call for me/joinedTeams returns values only for the properties **id**, **displayName**, and **description** of a [team](/graph/api/resources/team). To get information on all properties, use [Get team](/graph/api/team-get).
+The API call for me/joinedTeams returns returns values only the **id**, **displayName**, and **description** properties of a [team](/graph/api/resources/team). To get all properties, use the [Get team](/graph/api/team-get) operation.
 
 ## Users
 

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -531,7 +531,6 @@ items:
               - name: Change notifications for cloud printing
                 href: universal-print-webhook-notifications.md
               - name: Change notifications in Microsoft Teams
-                href: teams-change-notification-in-microsoft-teams-overview.md
                 items:
                   - name: Overview
                     href: teams-change-notification-in-microsoft-teams-overview.md


### PR DESCRIPTION
Currently, /joinedTeams API call doesn't return values for classSettings properties through it contains the properties in the response object, this commit will keep the user addressed about this context and adds information to see where the values can be fetched from