### PR TITLE
accesspackageassignmentpolicy update example payload

### DIFF
--- a/api-reference/beta/api/accesspackageassignmentpolicy-post.md
+++ b/api-reference/beta/api/accesspackageassignmentpolicy-post.md
@@ -313,7 +313,7 @@ Content-type: application/json
         "approvalStages": [{
                 "approvalStageTimeOutInDays": 14,
                 "isApproverJustificationRequired": true,
-                "isEscalationEnabled": true,
+                "isEscalationEnabled": false,
                 "escalationTimeInMinutes": 11520,
                 "primaryApprovers": [{
                         "@odata.type": "#microsoft.graph.groupMembers",
@@ -328,9 +328,6 @@ Content-type: application/json
                 ]
             }
         ]
-    },
-    "accessReviewSettings": {
-        "isEnabled": false
     },
     "questions": [{
         "isRequired": false,

--- a/api-reference/beta/api/accesspackageassignmentpolicy-update.md
+++ b/api-reference/beta/api/accesspackageassignmentpolicy-update.md
@@ -96,7 +96,7 @@ Content-length: 1000
         "approvalStages": [{
                 "approvalStageTimeOutInDays": 14,
                 "isApproverJustificationRequired": true,
-                "isEscalationEnabled": true,
+                "isEscalationEnabled": false,
                 "escalationTimeInMinutes": 11520,
                 "primaryApprovers": [{
                         "@odata.type": "#microsoft.graph.groupMembers",
@@ -111,9 +111,6 @@ Content-length: 1000
                 ]
             }
         ]
-    },
-    "accessReviewSettings": {
-        "isEnabled": false
     },
     "questions": [{
         "isRequired": false,


### PR DESCRIPTION
In entitlement management an issue was reported with third example of accessPackageAssignmentPolicy post request payload.  The questions part was correct but other aspects of the policy had been trimmed too much that they were no longer semantically valid.  Same example was used in the update payload.