### PR TITLE
Remove instances from accessReviewScheduleDefinition sub-node

### DIFF
--- a/api-reference/v1.0/resources/accessreviewscheduledefinition.md
+++ b/api-reference/v1.0/resources/accessreviewscheduledefinition.md
@@ -26,7 +26,6 @@ Inherits from [entity](../resources/entity.md).
 |[Delete accessReviewScheduleDefinition](../api/accessreviewscheduledefinition-delete.md) | None. | Delete an accessReviewScheduleDefinition with a specified **id**. |
 |[Update accessReviewScheduleDefinition](../api/accessreviewscheduledefinition-update.md) | None. | Update properties of an accessReviewScheduleDefinition with a specified **id**. |
 |[filterByCurrentUser](../api/accessreviewscheduledefinition-filterbycurrentuser.md)|[accessReviewScheduleDefinition](../resources/accessreviewscheduledefinition.md) collection|Retrieves all definitions for which the calling user is a reviewer on one or more instance.|
-|[List instances](../api/accessreviewscheduledefinition-list-instances.md)|[accessReviewInstance](../resources/accessreviewinstance.md) collection|Get the accessReviewInstance resources from the instances navigation property.|
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -4968,8 +4968,6 @@ items:
             items:
             - name: List
               href: api/accessreviewscheduledefinition-list.md
-            - name: List instances
-              href: api/accessreviewscheduledefinition-list-instances.md
             - name: Get
               href: api/accessreviewscheduledefinition-get.md
             - name: Create


### PR DESCRIPTION
List instances is in the [Access review instance sub-node](https://docs.microsoft.com/en-us/graph/api/accessreviewinstance-list?view=graph-rest-1.0&tabs=http).