### PR TITLE
Reporting APIs require Directory.Read.All + AuditLog.Read.All

### DIFF
--- a/api-reference/beta/api/directoryaudit-get.md
+++ b/api-reference/beta/api/directoryaudit-get.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | AuditLog.Read.All |
+|Delegated (work or school account) | AuditLog.Read.All and Directory.Read.All |
 |Delegated (personal Microsoft account) | Not supported   |
-|Application | AuditLog.Read.All | 
+|Application | AuditLog.Read.All and Directory.Read.All | 
 
 In addition, apps must be [properly registered](/azure/active-directory/active-directory-reporting-api-prerequisites-azure-portal) to Azure AD.
 

--- a/api-reference/beta/api/directoryaudit-list.md
+++ b/api-reference/beta/api/directoryaudit-list.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | AuditLog.Read.All |
+|Delegated (work or school account) | AuditLog.Read.All and Directory.Read.All |
 |Delegated (personal Microsoft account) | Not supported   |
-|Application | AuditLog.Read.All | 
+|Application | AuditLog.Read.All and Directory.Read.All | 
 
 In addition, apps must be [properly registered](/azure/active-directory/active-directory-reporting-api-prerequisites-azure-portal) to Azure AD.
 

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-| Delegated (work or school account) | AuditLog.Read.All, Directory.Read.All |
+| Delegated (work or school account) | AuditLog.Read.All and Directory.Read.All |
 | Delegated (personal Microsoft account) | Not supported |
-| Application | AuditLog.Read.All, Directory.Read.All | 
+| Application | AuditLog.Read.All and Directory.Read.All | 
 
 Apps must be [properly registered](/azure/active-directory/active-directory-reporting-api-prerequisites-azure-portal) to Azure AD.
 

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -21,9 +21,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type | Permissions (from least to most privileged) |
 |:--------------- |:------------------------------------------- |
-| Delegated (work or school account) | AuditLog.Read.All, Directory.Read.All |
+| Delegated (work or school account) | AuditLog.Read.All and Directory.Read.All |
 | Delegated (personal Microsoft account) | Not supported |
-| Application | AuditLog.Read.All, Directory.Read.All | 
+| Application | AuditLog.Read.All and Directory.Read.All | 
 
 Apps must be [properly registered](/azure/active-directory/active-directory-reporting-api-prerequisites-azure-portal) to Azure AD.
 

--- a/api-reference/v1.0/api/directoryaudit-get.md
+++ b/api-reference/v1.0/api/directoryaudit-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account) | AuditLog.Read.All and Directory.Read.All |
 |Delegated (personal Microsoft account) | Not supported   |
-|Application | AuditLog.Read.All |
+|Application | AuditLog.Read.All and Directory.Read.All |
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/directoryaudit-list.md
+++ b/api-reference/v1.0/api/directoryaudit-list.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 | :------------------------------------- | :------------------------------------------ |
 | Delegated (work or school account)     | AuditLog.Read.All and Directory.Read.All    |
 | Delegated (personal Microsoft account) | Not supported                               |
-| Application                            | AuditLog.Read.All                           |
+| Application                            | AuditLog.Read.All and Directory.Read.All    |
 
 ## HTTP request
 


### PR DESCRIPTION
Reporting APIs require Directory.Read.All as a workaround for the intermittent license check failures if a tenant has a legit license and yet hits license errors. This is temporary until the requirement is removed.