### PR TITLE
On 'Remove member from chat' article, fixed required delegate permissions

### DIFF
--- a/api-reference/beta/api/chat-delete-members.md
+++ b/api-reference/beta/api/chat-delete-members.md
@@ -19,7 +19,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)| ChatMember.ReadWrite.All |
+|Delegated (work or school account)| ChatMember.ReadWrite |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application| Chat.Manage.Chat*, ChatMember.ReadWrite.All |
 

--- a/api-reference/v1.0/api/chat-delete-members.md
+++ b/api-reference/v1.0/api/chat-delete-members.md
@@ -17,7 +17,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)| ChatMember.ReadWrite.All |
+|Delegated (work or school account)| ChatMember.ReadWrite |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application| ChatMember.ReadWrite.All |
 


### PR DESCRIPTION
For delegated permissions, changed **ChatMember.ReadWrite.All** to **ChatMember.ReadWrite**