### PR TITLE
Add example URLs for non-me users

### DIFF
--- a/api-reference/v1.0/api/attachment-createuploadsession.md
+++ b/api-reference/v1.0/api/attachment-createuploadsession.md
@@ -49,6 +49,7 @@ To create an upload session for attaching a file to an **event**:
 <!-- { "blockType": "ignored" } -->
 ```http
 POST /me/events/{id}/attachments/createUploadSession
+POST /users/{id | userPrincipalName}/events/{id}/attachments/createUploadSession
 ```
 
 To create an upload session for attaching a file to a **message**: 
@@ -56,6 +57,7 @@ To create an upload session for attaching a file to a **message**:
 <!-- { "blockType": "ignored" } -->
 ```http
 POST /me/messages/{id}/attachments/createUploadSession
+POST /users/{id | userPrincipalName}/messages/{id}/attachments/createUploadSession
 ```
 
 ## Request headers


### PR DESCRIPTION
This brings the examples to parity with the sister page https://docs.microsoft.com/en-us/graph/api/message-post-attachments?view=graph-rest-1.0&tabs=http#http-request
<img width="706" alt="image" src="https://user-images.githubusercontent.com/284560/127498180-4566161f-0a0a-4893-9b05-7ca5ec88e86b.png">
