### PR TITLE
Clarity/Correction needed for note about a single App Access Policy a…

### DIFF
--- a/concepts/auth-limit-mailbox-access.md
+++ b/concepts/auth-limit-mailbox-access.md
@@ -15,9 +15,6 @@ Some apps call Microsoft Graph using their own identity and not on behalf of a u
 
 There are scenarios where administrators may want to limit an app to only specific mailboxes and _not all_ Exchange Online mailboxes in the organization. Administrators can identify the set of mailboxes to permit access by putting them in a mail-enabled security group. Administrators can then limit third-party app access to only that set of  mailboxes by creating an application access policy for access to that group.
 
-> [!NOTE]
-> Once an application access policy is configured for an organization, the policy applies to any app that uses the Microsoft Graph API or Exchange Web Services to access Exchange Online mailboxes.
-
 As further described in the [Supported permissions and additional resources](#supported-permissions-and-additional-resources) section below, application access policy restricts mailbox access for apps that have been granted any of the Microsoft Graph or Exchange Web Services permission scopes that the policy supports.
 
 ## Configure ApplicationAccessPolicy


### PR DESCRIPTION
…ffected all MS Graph/EWS Apps

The following note needs to be adjusted (or removed entirely, which I propose as the note is inaccurate and misleading):

> [!NOTE]
> Once an application access policy is configured for an organization, the policy applies to any app that uses the Microsoft Graph API or Exchange Web Services to access Exchange Online mailboxes.


This isn't accurate. Creating a single Application Access Policy does not affect all MS Graph/EWS applications - it only affects applications using the App Id that the Application Access Policy was created for (as creating a new App Access Policy requires a specific App Id to be provided at creation). The current phrasing leads customers to believe that creating a single Application Access Policy (that's tied to a specific App Id) will affect ALL App Registrations.