### PR TITLE
Updated .NET snippets for SDK v4

### DIFF
--- a/concepts/sdks/choose-authentication-providers.md
+++ b/concepts/sdks/choose-authentication-providers.md
@@ -491,13 +491,17 @@ var tenantId = "common";
 // Value from app registration
 var clientId = "YOUR_CLIENT_ID";
 
-var options = new TokenCredentialOptions
+var options = new InteractiveBrowserCredentialOptions
 {
-    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+    TenantId = tenantId,
+    ClientId = clientId,
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud,
+    // MUST be http://localhost or http://localhost:PORT
+    // See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/System-Browser-on-.Net-Core
+    RedirectUri = new Uri("http://localhost"),
 };
 
-var interactiveCredential = new InteractiveBrowserCredential(
-    tenantId, clientId, options);
+var interactiveCredential = new InteractiveBrowserCredential(options);
 
 var graphClient = new GraphServiceClient(interactiveCredential, scopes);
 ```

--- a/concepts/sdks/choose-authentication-providers.md
+++ b/concepts/sdks/choose-authentication-providers.md
@@ -32,7 +32,7 @@ Authentication providers implement the code required to acquire a token using th
 |                                                                                                        | Interactive        | Delegated Consumer/Org | [Interactive provider](#interactive-provider) |
 
 > [!NOTE]
-> Java and Android developers need to add the [azure-identity](/java/api/overview/azure/identity-readme?view=azure-java-stable) library to get access to the different credentials types. .NET developers need to add the [Azure.Identity](/dotnet/api/azure.identity?view=azure-dotnet) package to get access to the different credentials types.
+> Java and Android developers need to add the [azure-identity](/java/api/overview/azure/identity-readme) library to get access to the different credentials types. .NET developers need to add the [Azure.Identity](/dotnet/api/azure.identity) package to get access to the different credentials types.
 
 ## Authorization code provider
 

--- a/concepts/sdks/choose-authentication-providers.md
+++ b/concepts/sdks/choose-authentication-providers.md
@@ -5,46 +5,66 @@ localization_priority: Normal
 author: MichaelMainer
 ---
 
+<!-- markdownlint-disable MD001 MD024 MD025 -->
+
 # Choose a Microsoft Graph authentication provider based on scenario
 
 Authentication providers implement the code required to acquire a token using the Microsoft Authentication Library (MSAL); handle a number of potential errors for cases like incremental consent, expired passwords, and conditional access; and then set the HTTP request authorization header. The following table lists the set of providers that match the scenarios for different [application types](/azure/active-directory/develop/v2-app-types).
 
-|Scenario | Flow/Grant | Audience | Provider|
-|--|--|--|--|
-| [Single Page App](/azure/active-directory/develop/scenario-spa-acquire-token)| | | |
-| | Implicit | Delegated Consumer/Org |[Implicit Provider](#ImplicitProvider) |
-| [Web App that calls web APIs](/azure/active-directory/develop/scenario-web-app-call-api-acquire-token) | | | |
-| | Authorization Code | Delegated Consumer/Org | [Authorization Code Provider](#AuthCodeProvider) |
-| | Client Credentials  | App Only | [Client Credentials Provider](#ClientCredentialsProvider) |
-| [Web API that calls web APIs](/azure/active-directory/develop/scenario-web-api-call-api-acquire-token) | | | |
-| | On Behalf Of | Delegated Consumer/Org | [On Behalf Of Provider](#OnBehalfOfProvider) |
-| | Client Credentials  | App Only | [Client Credentials Provider](#ClientCredentialsProvider) |
-| [Desktop app that calls web APIs](/azure/active-directory/develop/scenario-desktop-acquire-token) | | | |
-| | Interactive | Delegated Consumer/Org | [Interactive Provider](#InteractiveProvider) |
-| | Integrated Windows | Delegated Org | [Integrated Windows Provider](#IntegratedWindowsProvider) |
-| | Resource Owner  | Delegated Org | [Username / Password Provider](#UsernamePasswordProvider) |
-| | Device Code  | Delegated Org | [Device Code Provider](#DeviceCodeProvider) |
-| [Daemon app](/azure/active-directory/develop/scenario-daemon-acquire-token) | | | |
-| | Client Credentials  | App Only | [Client Credentials Provider](#ClientCredentialsProvider) |
-| [Mobile app that calls web APIs](/azure/active-directory/develop/scenario-mobile-acquire-token) | | | |
-| | Interactive | Delegated Consumer/Org | [Interactive Provider](#InteractiveProvider) |
+| Scenario                                                                                               | Flow/Grant         | Audience               | Provider |
+|--------------------------------------------------------------------------------------------------------|--------------------|------------------------|-----|
+| [Single Page App](/azure/active-directory/develop/scenario-spa-acquire-token)                          |                    |                        |     |
+|                                                                                                        | Implicit           | Delegated Consumer/Org | [Implicit provider](#implicit-provider) |
+| [Web App that calls web APIs](/azure/active-directory/develop/scenario-web-app-call-api-acquire-token) |                    |                        |     |
+|                                                                                                        | Authorization Code | Delegated Consumer/Org | [Authorization code provider](#authorization-code-provider) |
+|                                                                                                        | Client Credentials | App Only               | [Client credentials provider](#client-credentials-provider) |
+| [Web API that calls web APIs](/azure/active-directory/develop/scenario-web-api-call-api-acquire-token) |                    |                        |     |
+|                                                                                                        | On Behalf Of       | Delegated Consumer/Org | [On-behalf-of provider](#on-behalf-of-provider) |
+|                                                                                                        | Client Credentials | App Only               | [Client credentials provider](#client-credentials-provider) |
+| [Desktop app that calls web APIs](/azure/active-directory/develop/scenario-desktop-acquire-token)      |                    |                        |     |
+|                                                                                                        | Interactive        | Delegated Consumer/Org | [Interactive provider](#interactive-provider) |
+|                                                                                                        | Integrated Windows | Delegated Org          | [Integrated Windows provider](#integrated-windows-provider) |
+|                                                                                                        | Resource Owner     | Delegated Org          | [Username/password provider](#usernamepassword-provider) |
+|                                                                                                        | Device Code        | Delegated Org          | [Device code provider](#device-code-provider) |
+| [Daemon app](/azure/active-directory/develop/scenario-daemon-acquire-token)                            |                    |                        |     |
+|                                                                                                        | Client Credentials | App Only               | [Client credentials provider](#client-credentials-provider) |
+| [Mobile app that calls web APIs](/azure/active-directory/develop/scenario-mobile-acquire-token)        |                    |                        |     |
+|                                                                                                        | Interactive        | Delegated Consumer/Org | [Interactive provider](#interactive-provider) |
 
-> Note: Java and android developers need to add the [azure-identity](/java/api/overview/azure/identity-readme?view=azure-java-stable) library in order to get access to the different credentials types.
+> [!NOTE]
+> Java and Android developers need to add the [azure-identity](/java/api/overview/azure/identity-readme?view=azure-java-stable) library to get access to the different credentials types. .NET developers need to add the [Azure.Identity](/dotnet/api/azure.identity?view=azure-dotnet) package to get access to the different credentials types.
 
-## <a name="AuthCodeProvider" ></a>Authorization code provider
+## Authorization code provider
 
 The authorization code flow enables native and web apps to securely obtain tokens in the name of the user. To learn more, see [Microsoft identity platform and OAuth 2.0 authorization code flow](/azure/active-directory/develop/v2-oauth2-auth-code-flow).
 
 # [C#](#tab/CS)
 
 ```csharp
-IConfidentialClientApplication confidentialClientApplication = ConfidentialClientApplicationBuilder
-    .Create(clientId)
-    .WithRedirectUri(redirectUri)
-    .WithClientSecret(clientSecret) // or .WithCertificate(certificate)
-    .Build();
+var scopes = new[] { "User.Read" };
 
-AuthorizationCodeProvider authProvider = new AuthorizationCodeProvider(confidentialClientApplication, scopes);
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Values from app registration
+var clientId = "YOUR_CLIENT_ID";
+var clientSecret = "YOUR_CLIENT_SECRET";
+
+// For authorization code flow, the user signs into the Microsoft
+// identity platform, and the browser is redirected back to your app
+// with an authorization code in the query parameters
+var authorizationCode = "AUTH_CODE_FROM_REDIRECT";
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+var authCodeCredential = new AuthorizationCodeCredential(
+    tenantId, clientId, clientSecret, authorizationCode, options);
+
+var graphClient = new GraphServiceClient(authCodeCredential, scopes);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -90,20 +110,58 @@ Not available, yet. Please vote for or open a [Microsoft Graph feature request](
 
 ---
 
-##  <a name="ClientCredentialsProvider"></a>Client credentials provider
+## Client credentials provider
 
 The client credential flow enables service applications to run without user interaction. Access is based on the identity of the application. For more information, see [Microsoft identity platform and the OAuth 2.0 client credentials flow](/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow).
 
 # [C#](#tab/CS)
 
-```csharp
-IConfidentialClientApplication confidentialClientApplication = ConfidentialClientApplicationBuilder
-    .Create(clientId)
-    .WithTenantId(tenantID)
-    .WithClientSecret(clientSecret)
-    .Build();
+### Using a client secret
 
-ClientCredentialProvider authProvider = new ClientCredentialProvider(confidentialClientApplication);
+```csharp
+var scopes = new[] { "User.Read.All" };
+
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Values from app registration
+var clientId = "YOUR_CLIENT_ID";
+var clientSecret = "YOUR_CLIENT_SECRET";
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+var clientSecretCredential = new ClientSecretCredential(
+    tenantId, clientId, clientSecret, options);
+
+var graphClient = new GraphServiceClient(clientSecretCredential, scopes);
+```
+
+### Using a client certificate
+
+```csharp
+var scopes = new[] { "User.Read" };
+
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Values from app registration
+var clientId = "YOUR_CLIENT_ID";
+var clientCertificate = new X509Certificate2("MyCertificate.pfx");
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+var clientCertCredential = new ClientCertificateCredential(
+    tenantId, clientId, clientCertificate, options);
+
+var graphClient = new GraphServiceClient(clientCertCredential, scopes);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -148,20 +206,53 @@ Not available, yet. Please support or open a [Microsoft Graph feature request](h
 
 ---
 
-##  <a name="OnBehalfOfProvider"></a>On-behalf-of provider
+## On-behalf-of provider
 
 The on-behalf-of flow is applicable when your application calls a service/web API which in turns calls the Microsoft Graph API. Learn more by reading [Microsoft identity platform and OAuth 2.0 On-Behalf-Of flow](/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow)
 
 # [C#](#tab/CS)
 
+The `Azure.Identity` package does not currently support the on-behalf-of flow. Instead create a custom authentication provider using MSAL.
+
 ```csharp
-IConfidentialClientApplication confidentialClientApplication = ConfidentialClientApplicationBuilder
+var scopes = new[] { "User.Read" };
+
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Values from app registration
+var clientId = "YOUR_CLIENT_ID";
+var clientSecret = "YOUR_CLIENT_SECRET";
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+// This is the incoming token to exchange using on-behalf-of flow
+var oboToken = "JWT_TOKEN_TO_EXCHANGE";
+
+var cca = ConfidentialClientApplicationBuilder
     .Create(clientId)
-    .WithRedirectUri(redirectUri)
+    .WithTenantId(tenantId)
     .WithClientSecret(clientSecret)
     .Build();
 
-OnBehalfOfProvider authProvider = new OnBehalfOfProvider(confidentialClientApplication, scopes);
+// DelegateAuthenticationProvider is a simple auth provider implementation
+// that allows you to define an async function to retrieve a token
+// Alternatively, you can create a class that implements IAuthenticationProvider
+// for more complex scenarios
+var authProvider = new DelegateAuthenticationProvider(async (request) => {
+    // Use Microsoft.Identity.Client to retrieve token
+    var assertion = new UserAssertion(oboToken);
+    var result = await cca.AcquireTokenOnBehalfOf(scopes, assertion).ExecuteAsync();
+
+    request.Headers.Authorization =
+        new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", result.AccessToken);
+});
+
+var graphClient = new GraphServiceClient(authProvider);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -190,7 +281,7 @@ Not yet available. Please vote for or open a [Microsoft Graph feature request](h
 
 ---
 
-## <a name="ImplicitProvider"></a>Implicit provider
+## Implicit provider
 
 The implicit grant flow is used in browser-based applications. For more information, see [Microsoft identity platform and Implicit grant flow](/azure/active-directory/develop/v2-oauth2-implicit-grant-flow).
 
@@ -205,7 +296,7 @@ const clientId = "your_client_id"; // Client Id of the registered application
 const callback = (errorDesc, token, error, tokenType) => {};
 // An Optional options for initializing the MSAL @see https://github.com/AzureAD/microsoft-authentication-library-for-js/wiki/MSAL-basics#configuration-options
 const options = {
-	redirectUri: "Your redirect URI",
+  redirectUri: "Your redirect URI",
 };
 const graphScopes = ["user.read", "mail.send"]; // An array of graph scopes
 
@@ -214,7 +305,7 @@ const userAgentApplication = new Msal.UserAgentApplication(clientId, undefined, 
 const authProvider = new MicrosoftGraph.ImplicitMSALAuthenticationProvider(userAgentApplication, graphScopes);
 
 const options = {
-	authProvider, // An instance created from previous step
+  authProvider, // An instance created from previous step
 };
 const Client = MicrosoftGraph.Client;
 const client = Client.initWithMiddleware(options);
@@ -242,20 +333,39 @@ Not applicable.
 
 ---
 
-##  <a name="DeviceCodeProvider"></a>Device code provider
+## Device code provider
 
 The device code flow enables sign in to devices by way of another device. For details, see [Microsoft identity platform and the OAuth 2.0 device code flow](/azure/active-directory/develop/v2-oauth2-device-code).
 
 # [C#](#tab/CS)
 
 ```csharp
-IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
-            .Create(clientId)
-            .Build();
+var scopes = new[] { "User.Read" };
 
-Func<DeviceCodeResult, Task> deviceCodeReadyCallback = async dcr => await Console.Out.WriteLineAsync(dcr.Message);
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
 
-DeviceCodeProvider authProvider = new DeviceCodeProvider(publicClientApplication, scopes, deviceCodeReadyCallback);
+// Value from app registration
+var clientId = "YOUR_CLIENT_ID";
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+// Callback function that receives the user prompt
+// Prompt contains the generated device code that use must
+// enter during the auth process in the browser
+Func<DeviceCodeInfo, CancellationToken, Task> callback = (code, cancellation) => {
+    Console.WriteLine(code.Message);
+    return Task.FromResult(0);
+};
+
+var deviceCodeCredential = new DeviceCodeCredential(
+    callback, tenantId, clientId, options);
+
+var graphClient = new GraphServiceClient(deviceCodeCredential, scopes);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -301,19 +411,42 @@ Not yet available. Please vote for or open a [Microsoft Graph feature request](h
 
 ---
 
-##  <a name="IntegratedWindowsProvider"></a>Integrated Windows provider
+## Integrated Windows provider
 
 The integrated Windows flow provides a way for Windows computers to silently acquire an access token when they are domain joined. For details, see [Integrated Windows authentication](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Integrated-Windows-Authentication).
 
 # [C#](#tab/CS)
 
-```csharp
-IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
-            .Create(clientId)
-            .WithTenantId(tenantID)
-            .Build();
+The `Azure.Identity` package does not currently support Windows integrated authentication. Instead create a custom authentication provider using MSAL.
 
-IntegratedWindowsAuthenticationProvider authProvider = new IntegratedWindowsAuthenticationProvider(publicClientApplication, scopes);
+```csharp
+var scopes = new[] { "User.Read" };
+
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Value from app registration
+var clientId = "YOUR_CLIENT_ID";
+
+var pca = PublicClientApplicationBuilder
+    .Create(clientId)
+    .WithTenantId(tenantId)
+    .Build();
+
+// DelegateAuthenticationProvider is a simple auth provider implementation
+// that allows you to define an async function to retrieve a token
+// Alternatively, you can create a class that implements IAuthenticationProvider
+// for more complex scenarios
+var authProvider = new DelegateAuthenticationProvider(async (request) => {
+    // Use Microsoft.Identity.Client to retrieve token
+    var result = await pca.AcquireTokenByIntegratedWindowsAuth(scopes).ExecuteAsync();
+
+    request.Headers.Authorization =
+        new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", result.AccessToken);
+});
+
+var graphClient = new GraphServiceClient(authProvider);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -342,18 +475,31 @@ Not applicable.
 
 ---
 
-##  <a name="InteractiveProvider"></a>Interactive provider
+## Interactive provider
 
 The interactive flow is used by mobile applications (Xamarin and UWP) and desktops applications to call Microsoft Graph in the name of a user. For details, see [Acquiring tokens interactively](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively).
 
 # [C#](#tab/CS)
 
 ```csharp
-IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
-            .Create(clientId)
-            .Build();
+var scopes = new[] { "User.Read" };
 
-InteractiveAuthenticationProvider authProvider = new InteractiveAuthenticationProvider(publicClientApplication, scopes);
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
+
+// Value from app registration
+var clientId = "YOUR_CLIENT_ID";
+
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+var interactiveCredential = new InteractiveBrowserCredential(
+    tenantId, clientId, options);
+
+var graphClient = new GraphServiceClient(interactiveCredential, scopes);
 ```
 
 # [Javascript](#tab/Javascript)
@@ -419,27 +565,34 @@ Not applicable.
 
 ---
 
-##  <a name="UsernamePasswordProvider"></a>Username/password provider
+## Username/password provider
 
 The username/password provider allows an application to sign in a user by using their username and password. Use this flow only when you cannot use any of the other OAuth flows. For more information, see [Microsoft identity platform and the OAuth 2.0 resource owner password credential](/azure/active-directory/develop/v2-oauth-ropc)
-
-
 
 # [C#](#tab/CS)
 
 ```csharp
-IPublicClientApplication publicClientApplication = PublicClientApplicationBuilder
-            .Create(clientId)
-            .WithTenantId(tenantID)
-            .Build();
+var scopes = new[] { "User.Read" };
 
-UsernamePasswordProvider authProvider = new UsernamePasswordProvider(publicClientApplication, scopes);
+// Multi-tenant apps can use "common",
+// single-tenant apps must use the tenant ID from the Azure portal
+var tenantId = "common";
 
-GraphServiceClient graphClient = new GraphServiceClient(authProvider);
+// Value from app registration
+var clientId = "YOUR_CLIENT_ID";
 
-User me = await graphClient.Me.Request()
-                .WithUsernamePassword(email, password)
-                .GetAsync();
+var options = new TokenCredentialOptions
+{
+    AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
+};
+
+var userName = "adelev@contoso.com";
+var password = "P@ssword1!";
+
+var userNamePasswordCredential = new UsernamePasswordCredential(
+    userName, password, tenantId, clientId, options);
+
+var graphClient = new GraphServiceClient(userNamePasswordCredential, scopes);
 ```
 
 # [Javascript](#tab/Javascript)

--- a/concepts/sdks/choose-authentication-providers.md
+++ b/concepts/sdks/choose-authentication-providers.md
@@ -61,6 +61,7 @@ var options = new TokenCredentialOptions
     AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
 };
 
+// https://docs.microsoft.com/dotnet/api/azure.identity.authorizationcodecredential
 var authCodeCredential = new AuthorizationCodeCredential(
     tenantId, clientId, clientSecret, authorizationCode, options);
 
@@ -134,6 +135,7 @@ var options = new TokenCredentialOptions
     AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
 };
 
+// https://docs.microsoft.com/dotnet/api/azure.identity.clientsecretcredential
 var clientSecretCredential = new ClientSecretCredential(
     tenantId, clientId, clientSecret, options);
 
@@ -158,6 +160,7 @@ var options = new TokenCredentialOptions
     AuthorityHost = AzureAuthorityHosts.AzurePublicCloud
 };
 
+// https://docs.microsoft.com/dotnet/api/azure.identity.clientcertificatecredential
 var clientCertCredential = new ClientCertificateCredential(
     tenantId, clientId, clientCertificate, options);
 
@@ -212,7 +215,7 @@ The on-behalf-of flow is applicable when your application calls a service/web AP
 
 # [C#](#tab/CS)
 
-The `Azure.Identity` package does not currently support the on-behalf-of flow. Instead create a custom authentication provider using MSAL.
+The `Azure.Identity` package does not support the on-behalf-of flow as of version 1.4.0. Instead create a custom authentication provider using MSAL.
 
 ```csharp
 var scopes = new[] { "User.Read" };
@@ -362,6 +365,7 @@ Func<DeviceCodeInfo, CancellationToken, Task> callback = (code, cancellation) =>
     return Task.FromResult(0);
 };
 
+// https://docs.microsoft.com/dotnet/api/azure.identity.devicecodecredential
 var deviceCodeCredential = new DeviceCodeCredential(
     callback, tenantId, clientId, options);
 
@@ -501,6 +505,7 @@ var options = new InteractiveBrowserCredentialOptions
     RedirectUri = new Uri("http://localhost"),
 };
 
+// https://docs.microsoft.com/dotnet/api/azure.identity.interactivebrowsercredential
 var interactiveCredential = new InteractiveBrowserCredential(options);
 
 var graphClient = new GraphServiceClient(interactiveCredential, scopes);


### PR DESCRIPTION
Version 4 of the SDK supports using Azure.Identity credentials instead of IAuthenticationProviders. The providers previously shown were from the Microsoft.Graph.Auth package, which is not supported.

Fixes #13081
Fixes #11067
Fixes #10880
Fixes #9508
Fixes #8655
Fixes #5070