### PR TITLE
Adding forgotten API: /shares/shareIdOrEncodedSharingUrl

### DIFF
--- a/api-reference/beta/api/driveitem-get-content.md
+++ b/api-reference/beta/api/driveitem-get-content.md
@@ -34,6 +34,7 @@ GET /drives/{drive-id}/items/{item-id}/content
 GET /groups/{group-id}/drive/items/{item-id}/content
 GET /me/drive/root:/{item-path}:/content
 GET /me/drive/items/{item-id}/content
+GET /shares/{shareIdOrEncodedSharingUrl}/driveItem/content
 GET /sites/{siteId}/drive/items/{item-id}/content
 GET /users/{userId}/drive/items/{item-id}/content
 ```

--- a/api-reference/v1.0/api/driveitem-get-content.md
+++ b/api-reference/v1.0/api/driveitem-get-content.md
@@ -32,6 +32,7 @@ GET /drives/{drive-id}/items/{item-id}/content
 GET /groups/{group-id}/drive/items/{item-id}/content
 GET /me/drive/root:/{item-path}:/content
 GET /me/drive/items/{item-id}/content
+GET /shares/{shareIdOrEncodedSharingUrl}/driveItem/content
 GET /sites/{siteId}/drive/items/{item-id}/content
 GET /users/{userId}/drive/items/{item-id}/content
 ```


### PR DESCRIPTION
Added the forgotten `/shares/{shareIdOrEncodedSharingUrl}/driveItem/content` variation to section "HTTP request"