### PR TITLE
Fix version and casing for getRecentNotebooks API

### DIFF
--- a/api-reference/beta/api/notebook-getrecentnotebooks.md
+++ b/api-reference/beta/api/notebook-getrecentnotebooks.md
@@ -60,7 +60,7 @@ The following example shows the request.
 # [HTTP](#tab/http)
 <!-- { "blockType": "request", "name": "recent_notebooks", "scopes": "notes.read" } -->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/me/onenote/notebooks/getrecentnotebooks(includePersonalNotebooks=true)
+GET https://graph.microsoft.com/beta/me/onenote/notebooks/getRecentNotebooks(includePersonalNotebooks=true)
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/recent-notebooks-csharp-snippets.md)]


### PR DESCRIPTION
This was causing a Raptor test to fail due to version mismatch and casing.

Fixes #12034