### PR TITLE
Update intune-deviceconfig-devicecompliancepolicyassignment-create.md

### DIFF
--- a/api-reference/beta/api/intune-deviceconfig-devicecompliancepolicyassignment-create.md
+++ b/api-reference/beta/api/intune-deviceconfig-devicecompliancepolicyassignment-create.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 ``` http
-POST /deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicyId}/assignments
+POST /deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicyId}/assign
 ```
 
 ## Request headers
@@ -63,7 +63,7 @@ If successful, this method returns a `201 Created` response code and a [deviceCo
 ### Request
 Here is an example of the request.
 ``` http
-POST https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicyId}/assignments
+POST https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicyId}/assign
 Content-type: application/json
 Content-length: 452
 


### PR DESCRIPTION
The correct verb is "assign".  When calling "assignments" as in original doc, the error is displayed as below:

     | {"error":{"code":"No method match route template","message":"No OData route exists that match template ~/singleton/navigation/key/navigation with http verb POST for request
     | /DeviceConfiguration_2108/StatelessDeviceConfigurationFEService/deviceManagement/deviceCompliancePolicies('ce0ac224-9f0e-4988-a2dd-78b474b72e91')/assignments.","innerError":{"date":"2021-09-02T21:52:54","request-id":"11b18ba2-83a3-49e1-aa50-fb8a7645878d","client-request-id":"11b18ba2-83a3-49e1-aa50-fb8a7645878d"}}}

"assign" is the path at the end of request, which can be seen by using F12 Developer Tools in MEM portal, when creating an assignment, and "assign" verb works fine. 

Suggestion for documentation improvement: Add more examples for group-based licensing, as this involves a different payload (groupAssignmentTarget inherits from deviceAndAppManagementAssignmentTarget , but that's not immediately obvious)