### PR TITLE
Expose data boundary property on organization entities

### DIFF
--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -2487,3 +2487,11 @@ Possible values for user account types (group membership), per Windows definitio
 |meeting|
 |screenShare|
 |unknownFutureValue|
+
+### dataBoundary values 
+
+|Member|
+|:---|
+|none|
+|eu|
+|unknownFutureValue|

--- a/api-reference/beta/resources/organization.md
+++ b/api-reference/beta/resources/organization.md
@@ -44,6 +44,7 @@ This resource lets you add your own data to custom properties using [extensions]
 | country | String | Country/region name of the address for the organization. |
 | countryLetterCode | String | Country/region abbreviation for the organization. |
 | createdDateTime | DateTimeOffset | Timestamp of when the organization was created. The value cannot be modified and is automatically populated when the organization is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. |
+| dataBoundary | dataBoundary | The data boundary for the organization. Possible values are: `none`, `eu`, `unknownFutureValue`. |
 | deletedDateTime | DateTimeOffset | Represents date and time of when the Azure AD tenant was deleted using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. |
 | directorySizeQuota | [directorySizeQuota](directorySizeQuota.md) | The directory size quota information of an organization. |
 | displayName | String | The display name for the tenant. |

--- a/api-reference/v1.0/resources/enums.md
+++ b/api-reference/v1.0/resources/enums.md
@@ -1640,3 +1640,11 @@ Possible values for user account types (group membership), per Windows definitio
 |high|
 |critical|
 |unknownFutureValue|
+
+### dataBoundary values 
+
+|Member|
+|:---|
+|none|
+|eu|
+|unknownFutureValue|

--- a/api-reference/v1.0/resources/organization.md
+++ b/api-reference/v1.0/resources/organization.md
@@ -38,6 +38,7 @@ This resource lets you add your own data to custom properties using [extensions]
 | country | String | Country/region name of the address for the organization. |
 | countryLetterCode | String | Country/region abbreviation for the organization. |
 | createdDateTime | DateTimeOffset | Timestamp of when the organization was created. The value cannot be modified and is automatically populated when the organization is created. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. |
+| dataBoundary | dataBoundary | The data boundary for the organization. Possible values are: `none`, `eu`, `unknownFutureValue`. |
 | deletedDateTime | DateTimeOffset | Represents date and time of when the Azure AD tenant was deleted using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. |
 | displayName | String | The display name for the tenant. |
 | id | String | The tenant ID, a unique identifier representing the organization (or tenant). Inherited from [directoryObject](directoryobject.md). Key. Not nullable. Read-only. |

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -8822,6 +8822,58 @@
         "CreatedDateTime":"2021-08-27T04:29:52.029Z",
         "WorkloadArea":"Identity and access",
         "SubArea":"Identity and sign-in"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "41eb3671-5888-478e-912b-c9fcf0d77546",
+          "ApiChange": "EnumType",
+          "ChangedApiName": "dataBoundary",
+          "ChangeType": "Addition",
+          "Description": "Added the **dataBoundary** enumeration type.",
+          "Target": "dataBoundary"
+        },
+        {
+          "Id": "41eb3671-5888-478e-912b-c9fcf0d77546",
+          "ApiChange": "Property",
+          "ChangedApiName": "dataBoundary",
+          "ChangeType": "Addition",
+          "Description": "Added the **dataBoundary** property to [organization](https://docs.microsoft.com/en-us/graph/api/resources/organization?view=graph-rest-beta) resource.",
+          "Target": "organization"
+        }
+      ],
+      "Id": "41eb3671-5888-478e-912b-c9fcf0d77546",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2021-09-17T19:45:05.2000915Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Directory management"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "2724ed08-e3bc-4e56-8448-f1afd09fd2b2",
+          "ApiChange": "EnumType",
+          "ChangedApiName": "dataBoundary",
+          "ChangeType": "Addition",
+          "Description": "Added the **dataBoundary** enumeration type.",
+          "Target": "dataBoundary"
+        },
+        {
+          "Id": "2724ed08-e3bc-4e56-8448-f1afd09fd2b2",
+          "ApiChange": "Property",
+          "ChangedApiName": "dataBoundary",
+          "ChangeType": "Addition",
+          "Description": "Added the **dataBoundary** property to [organization](https://docs.microsoft.com/en-us/graph/api/resources/organization?view=graph-rest-1.0) resource.",
+          "Target": "organization"
+        }
+      ],
+      "Id": "2724ed08-e3bc-4e56-8448-f1afd09fd2b2",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2021-09-17T19:45:05.2000955Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Directory management"
     }
   ]
 }


### PR DESCRIPTION
This PR adds documentation for the new dataBoundary property to be exposed on organization entities, as well as its underlying enum type.