### PR TITLE
Update connecting-external-content-build-quickstart-03-build-app.md

### DIFF
--- a/concepts/connecting-external-content-build-quickstart-03-build-app.md
+++ b/concepts/connecting-external-content-build-quickstart-03-build-app.md
@@ -424,7 +424,7 @@ namespace PartsInventoryConnector.MicrosoftGraph
 {
     public class MicrosoftGraphHelper
     {
-        private class MicrosoftGraphServiceClient _microsoftGraphClient;
+        private GraphServiceClient _microsoftGraphClient;
 
         public MicrosoftGraphHelper(IAuthenticationProvider authProvider)
         {
@@ -434,7 +434,7 @@ namespace PartsInventoryConnector.MicrosoftGraph
             var httpProvider = new HttpProvider(serializer);
 
             // Initialize the Microsoft Graph client
-            _microsoftGraphClient = new MicrosoftGraphServiceClient(authProvider, httpProvider);
+            _microsoftGraphClient = new GraphServiceClient(authProvider, httpProvider);
         }
     }
 }


### PR DESCRIPTION
Changes
1. Class name corrected from MicrosoftGraphServiceClient to GraphServiceClient
2. Removed class keyword as it is not required.