### PR TITLE
Add "Search for sites" and remove duplicate "List subsites" from TOC

### DIFF
--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -13655,6 +13655,8 @@ items:
           href: api/list-create.md
         - name: List subsites
           href: api/site-list-subsites.md
+        - name: Search for sites
+          href: api/site-search.md
         - name: Permissions
           items:
           - name: Permission

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -5951,8 +5951,6 @@ items:
           href: api/site-get.md
         - name: Get lists
           href: api/list-list.md
-        - name: List subsites
-          href: api/site-list-subsites.md
         - name: Get item analytics
           href: api/itemanalytics-get.md
         - name: Follow site
@@ -5977,6 +5975,8 @@ items:
           href: api/list-create.md
         - name: List subsites
           href: api/site-list-subsites.md
+        - name: Search for sites
+          href: api/site-search.md
         - name: Permissions
           href: resources/permission.md
           items:


### PR DESCRIPTION
The Table of Contents is missing an entry for "Search for sites". Adding to v1.0 and Beta TOC.
The v1.0 TOC also had a duplicate "List subsites" entry, so removing the duplicate.