### PR TITLE
Link for sharedDriveItem

### DIFF
--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -9911,6 +9911,8 @@ items:
       - name: Permissions
         href: resources/permission.md
         items:
+        - name: "Shared driveItem"
+          href: resources/shareddriveitem.md
         - name: Create sharing link
           href: api/driveitem-createlink.md
         - name: Use sharing links

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -3858,6 +3858,8 @@ items:
       - name: Permissions
         href: resources/permission.md
         items:
+        - name: "Shared driveItem"
+          href: resources/shareddriveitem.md
         - name: Create sharing link
           href: api/driveitem-createlink.md
         - name: Use sharing links


### PR DESCRIPTION
The sharedDriveItem resource link is added under Permissions.