### PR TITLE
Update SPO example in EM

### DIFF
--- a/api-reference/beta/api/accesspackage-post-accesspackageresourcerolescopes.md
+++ b/api-reference/beta/api/accesspackage-post-accesspackageresourcerolescopes.md
@@ -127,7 +127,7 @@ Content-type: application/json
 
 #### Request
 
-The following is an example of the request.  The access package resource for the site must already have been added to the access package catalog containing this access package.
+The following is an example of the request for a non-root scope resource.  The access package resource for the site must already have been added to the access package catalog containing this access package. If the [accessPackageResourceScope](../resources/accesspackageresourcescope.md) object obtained from an earlier request to [list access package resources](accesspackagecatalog-list-accesspackageresources.md) has `isRootScope` as the resource is a root scope, include that property with the same value in the `accessPackageResourceScope` in the request.
 
 
 # [HTTP](#tab/http)


### PR DESCRIPTION
In entitlement management, it is necessary when creating a resource role for an access package, to ensure that the isRootScope is included if that was part of the scope definition of the resource.  Developers were omitting it as the example shown here did not have that value, since this example wasn't a root scope.