### PR TITLE
Issue 14278: removing unsupported directory permissions

### DIFF
--- a/api-reference/beta/api/appcatalogs-list-teamsapps.md
+++ b/api-reference/beta/api/appcatalogs-list-teamsapps.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:------------------------------------|
-| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.Read.All, AppCatalog.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
+| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.Read.All, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/teamsapp-delete.md
+++ b/api-reference/beta/api/teamsapp-delete.md
@@ -27,7 +27,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported.|
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/teamsapp-publish.md
+++ b/api-reference/beta/api/teamsapp-publish.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 

--- a/api-reference/beta/api/teamsapp-update.md
+++ b/api-reference/beta/api/teamsapp-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 

--- a/api-reference/v1.0/api/appcatalogs-list-teamsapps.md
+++ b/api-reference/v1.0/api/appcatalogs-list-teamsapps.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged) |
 |:---------------------------------------|:------------------------------------|
-| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.Read.All, AppCatalog.ReadWrite.All, Directory.Read.All, Directory.ReadWrite.All |
+| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.Read.All, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported. |
 | Application                            | Not supported. |
 

--- a/api-reference/v1.0/api/teamsapp-delete.md
+++ b/api-reference/v1.0/api/teamsapp-delete.md
@@ -26,7 +26,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 

--- a/api-reference/v1.0/api/teamsapp-publish.md
+++ b/api-reference/v1.0/api/teamsapp-publish.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account) | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 

--- a/api-reference/v1.0/api/teamsapp-update.md
+++ b/api-reference/v1.0/api/teamsapp-update.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type                        | Permissions (from least to most privileged)|
 |:----------------------------------     |:-------------|
-| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.ReadWrite.All, Directory.ReadWrite.All |
+| Delegated (work or school account)     | AppCatalog.Submit, AppCatalog.ReadWrite.All |
 | Delegated (personal Microsoft account) | Not supported|
 | Application                            | Not supported. |
 


### PR DESCRIPTION
This PR fixes issue: https://github.com/microsoftgraph/microsoft-graph-docs/issues/14278

According to engineering: 
"No new Teams related API is supposed to support Directory.ReadWrite.All. For APIs, that already went to V1, we can't do anything. That is why those permissions still support Directory/Group* permissions."