### PR TITLE
Add warning section about use of multiple Graph API for WUfB settings

### DIFF
--- a/api-reference/beta/resources/intune-graph-overview.md
+++ b/api-reference/beta/resources/intune-graph-overview.md
@@ -41,6 +41,15 @@ The following example shows how you can determine whether an application is inst
 
 Microsoft Graph controls access to resources via permissions. As a developer, you must specify the permissions you need to access Intune resources. Typically, you specify the permissions in the Azure Active Directory portal. For more information, see [Microsoft Graph permissions reference](/graph/permissions-reference).
 
+## Interaction between Microsoft Graph APIs for Windows updates
+
+Microsoft Graph includes two sets of APIs that you can use to manage Windows updates: 
+
+- [Intune APIs](/graph/intune-concept-overview)
+- [Windows updates APIs](/graph/windowsupdates-concept-overview)
+
+You can use either API to manage Windows updates; however, these two APIs are not compatible with each other. Each can overwrite the configurations made by the other without providing visibility into that action. Use of both APIs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.
+
 ## What's new
 Find out about the [latest new features and updates](/graph/whats-new-overview) for this API set.
 

--- a/api-reference/beta/resources/intune-graph-overview.md
+++ b/api-reference/beta/resources/intune-graph-overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the Intune Graph API - Microsoft Graph API"
-description: "Lists the Microsoft Graph API for Intune endpoints (REST) you can use to manage your tenant organization and its devices, apps, access, and resources."
+title: "Working with Intune in Microsoft Graph"
+description: "The Microsoft Graph API for Intune enables programmatic access to Intune information for your tenant; the API performs the same Intune operations as those available through the Azure Portal."
 author: "rolyon"
 ms.localizationpriority: high
 ms.prod: "intune"

--- a/api-reference/v1.0/resources/intune-graph-overview.md
+++ b/api-reference/v1.0/resources/intune-graph-overview.md
@@ -46,14 +46,14 @@ The Microsoft Graph API controls access to resources via permissions. As a devel
 ## What's new
 Find out about the [latest new features and updates](/graph/whats-new-overview) for this API set.
 
-## Interaction between Graph APIs for Windows Updates
+## Interaction between Microsoft Graph APIs for Windows Updates
 
-With Graph, there are two sets of APIs you can use to manage Windows Updates: 
+With Microsoft Graph, there are two sets of APIs you can use to manage Windows Updates: 
 
-- The Intune APIs, or [corporate management](https://docs.microsoft.com/graph/intune-concept-overview)
-- The Windows updates APIs, or [device updates](https://docs.microsoft.com/graph/windowsupdates-concept-overview)
+- [The Intune APIs](https://docs.microsoft.com/graph/intune-concept-overview)
+- [The Windows updates APIs](https://docs.microsoft.com/graph/windowsupdates-concept-overview)
   
-While you can use either Graph to manage Windows Updates, use of these two Graphs for Windows Updates are not compatible with each other. Each can overwrite the configurations made by the other Graph without providing visibility to that action. Use of both Graphs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
+While you can use either API to manage Windows Updates, use of these two APIs for Windows Updates are not compatible with each other. Each can overwrite the configurations made by the other without providing visibility to that action. Use of both APIs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
 
 
 ## Next Steps

--- a/api-reference/v1.0/resources/intune-graph-overview.md
+++ b/api-reference/v1.0/resources/intune-graph-overview.md
@@ -15,6 +15,8 @@ The Microsoft Graph API for Intune enables programmatic access to Intune informa
 
 For mobile device management (MDM) scenarios, the Microsoft Graph API for Intune supports standalone deployments; Intune [hybrid deployments](/sccm/mdm/understand/choose-between-standalone-intune-and-hybrid-mobile-device-management) are not supported. 
 
+
+
 ## Using the Microsoft Graph API for Intune
 
 Intune provides data into the Microsoft Graph API in the same way as other cloud services do, with rich entity information and relationship navigation. Use the Microsoft Graph API to combine information from other services and Intune to build rich cross-service applications for IT professionals or end users.     
@@ -43,6 +45,16 @@ The Microsoft Graph API controls access to resources via permissions. As a devel
 
 ## What's new
 Find out about the [latest new features and updates](/graph/whats-new-overview) for this API set.
+
+## Interaction between Graph APIs for Windows Updates
+
+With Graph, there are two sets of APIs you can use to manage Windows Updates: 
+
+- The Intune APIs, or [corporate management](https://docs.microsoft.com/graph/intune-concept-overview)
+- The Windows updates APIs, or [device updates](https://docs.microsoft.com/graph/windowsupdates-concept-overview)
+  
+While you can use either Graph to manage Windows Updates, use of these two Graphs for Windows Updates are not compatible with each other. Each can overwrite the configurations made by the other Graph without providing visibility to that action. Use of both Graphs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
+
 
 ## Next Steps
 

--- a/api-reference/v1.0/resources/intune-graph-overview.md
+++ b/api-reference/v1.0/resources/intune-graph-overview.md
@@ -1,6 +1,6 @@
 ---
-title: "Using the Intune Graph API"
-description: " Intune hybrid deployments are not supported. "
+title: "Working with Intune in Microsoft Graph"
+description: "The Microsoft Graph API for Intune enables programmatic access to Intune information for your tenant; the API performs the same Intune operations as those available through the Azure Portal."
 author: "dougeby"
 ms.localizationpriority: high
 ms.prod: "intune"
@@ -43,18 +43,17 @@ Intune supports both [delegated permissions](/graph/auth-v2-user) and [applicati
 
 The Microsoft Graph API controls access to resources via permissions. As a developer, you must specify the permissions you need to access Intune resources. Typically, you specify the permissions in the Azure Active Directory portal. For more information, see [Microsoft Graph permissions reference](/graph/permissions-reference).
 
+## Interaction between Microsoft Graph APIs for Windows updates
+
+Microsoft Graph includes two sets of APIs that you can use to manage Windows updates: 
+
+- [Intune APIs](/graph/intune-concept-overview)
+- [Windows updates APIs](/graph/windowsupdates-concept-overview)
+
+You can use either API to manage Windows updates; however, these two APIs are not compatible with each other. Each can overwrite the configurations made by the other without providing visibility into that action. Use of both APIs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
+
 ## What's new
 Find out about the [latest new features and updates](/graph/whats-new-overview) for this API set.
-
-## Interaction between Microsoft Graph APIs for Windows Updates
-
-With Microsoft Graph, there are two sets of APIs you can use to manage Windows Updates: 
-
-- [The Intune APIs](/graph/intune-concept-overview)
-- [The Windows updates APIs](/graph/windowsupdates-concept-overview)
-  
-While you can use either API to manage Windows Updates, use of these two APIs for Windows Updates are not compatible with each other. Each can overwrite the configurations made by the other without providing visibility to that action. Use of both APIs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
-
 
 ## Next Steps
 

--- a/api-reference/v1.0/resources/intune-graph-overview.md
+++ b/api-reference/v1.0/resources/intune-graph-overview.md
@@ -50,8 +50,8 @@ Find out about the [latest new features and updates](/graph/whats-new-overview) 
 
 With Microsoft Graph, there are two sets of APIs you can use to manage Windows Updates: 
 
-- [The Intune APIs](https://docs.microsoft.com/graph/intune-concept-overview)
-- [The Windows updates APIs](https://docs.microsoft.com/graph/windowsupdates-concept-overview)
+- [The Intune APIs](/graph/intune-concept-overview)
+- [The Windows updates APIs](/graph/windowsupdates-concept-overview)
   
 While you can use either API to manage Windows Updates, use of these two APIs for Windows Updates are not compatible with each other. Each can overwrite the configurations made by the other without providing visibility to that action. Use of both APIs to manage updates can result in unexpected behaviors, including what appears to be temporary configurations for update deployments that are canceled or modified without an identified cause.   
 


### PR DESCRIPTION
This section is intended to help surface issues between Intune Graph API and WUfB-DS graph API which both manage the same settings but which are not necessarily aware of the settings edit sources. This is a compliment to the warning found here: https://docs.microsoft.com/windows/deployment/update/deployment-service-overview#general

Background details tracked by USER STORY 10195063 (https://msazure.visualstudio.com/Intune/_workitems/edit/10195063)

Note, I wasn't able to work out a general link path to the two linked articles. Those might need further edits to introduce relative paths.