### PR TITLE
Get subscription throttling limits

### DIFF
--- a/includes/throttling-subscription-services.md
+++ b/includes/throttling-subscription-services.md
@@ -8,7 +8,7 @@ ms.topic: include
 <!-- this file is auto-generated don't edit it manually! -->
 
 | Request type | Limit per app for all tenants | Limit per tenant for all apps | Limit per app per tenant |
-| ------------ | ----------------------------- | ----------------------------- | ------------------------ |
+| ------------- | ----------------------------- | ----------------------------- | ------------------------ |
 | POST, PUT, DELETE, PATCH | 5000 requests per 20 seconds | 2000 requests per 20 seconds | 1000 requests per 20 seconds |
 | GET Subscription by Id | 5000 requests per 20 seconds | 2000 requests per 20 seconds | 1000 requests per 20 seconds |
 | GET Subscription List | 80 requests per 20 seconds | 40 requests per 20 seconds | 40 requests per 20 seconds |

--- a/includes/throttling-subscription-services.md
+++ b/includes/throttling-subscription-services.md
@@ -10,7 +10,8 @@ ms.topic: include
 | Request type | Limit per app for all tenants | Limit per tenant for all apps | Limit per app per tenant |
 | ------------ | ----------------------------- | ----------------------------- | ------------------------ |
 | POST, PUT, DELETE, PATCH | 5000 requests per 20 seconds | 2000 requests per 20 seconds | 1000 requests per 20 seconds |
-| Any | 240 requests per 20 seconds | 120 requests per 20 seconds | 120 requests per 20 seconds |
+| GET Subscription by Id | 5000 requests per 20 seconds | 2000 requests per 20 seconds | 1000 requests per 20 seconds |
+| GET Subscription List | 80 requests per 20 seconds | 40 requests per 20 seconds | 40 requests per 20 seconds |
 
 The preceding limits apply to the following resources:  
 


### PR DESCRIPTION
**POST, PUT, DELETE, PATCH**
Limit per app for all tenants: 5000 requests per 20 seconds
Limit per tenant for all apps: 2000 requests per 20 seconds
Limit per app per tenant: 1000 requests per 20 seconds

**GET Subscription by Id**
Limit per app for all tenants: 5000 requests per 20 seconds
Limit per tenant for all apps: 2000 requests per 20 seconds
Limit per app per tenant: 1000 requests per 20 seconds

**GET Subscription List**
Limit per app for all tenants: 80requests per 20 seconds
Limit per tenant for all apps: 40requests per 20 seconds
Limit per app per tenant: 40requests per 20 seconds
