### PR TITLE
Deprecate Azure AD Graph from List excludes method

### DIFF
--- a/api-reference/beta/api/permissiongrantpolicy-list-excludes.md
+++ b/api-reference/beta/api/permissiongrantpolicy-list-excludes.md
@@ -54,7 +54,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-The following is an example of the request to retrieve the **excludes** condition sets of the built-on permission grant policy `microsoft-application-admin`. This permission grant policy includes all delegated permissions, and all application permissions excluding application permissions for Microsoft Graph and application permissions for Azure AD Graph.
+The following is an example of the request to retrieve the **excludes** condition sets of the built-on permission grant policy `microsoft-application-admin`. This permission grant policy includes all delegated permissions, and all application permissions excluding application permissions for Microsoft Graph and application permissions for Azure AD Graph (deprecated).
 
 
 # [HTTP](#tab/http)

--- a/api-reference/v1.0/api/permissiongrantpolicy-list-excludes.md
+++ b/api-reference/v1.0/api/permissiongrantpolicy-list-excludes.md
@@ -52,7 +52,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-The following is an example of the request to retrieve the **excludes** condition sets of the built-on permission grant policy `microsoft-application-admin`. This permission grant policy includes all delegated permissions, and all application permissions excluding application permissions for Microsoft Graph and application permissions for Azure AD Graph.
+The following is an example of the request to retrieve the **excludes** condition sets of the built-on permission grant policy `microsoft-application-admin`. This permission grant policy includes all delegated permissions, and all application permissions excluding application permissions for Microsoft Graph and application permissions for Azure AD Graph (deprecated).
 
 
 

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -3,6 +3,42 @@
     {
       "ChangeList": [
         {
+          "Id": "b4e9af10-1cb2-4380-adc6-72cf4122f1b8",
+          "ApiChange": "Method",
+          "ChangedApiName": "excludes",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated Azure AD Graph in the [List excludes](https://docs.microsoft.com/en-us/graph/api/permissiongrantpolicy-list-excludes?view=graph-rest-beta) method of the [permissionGrantPolicy](https://docs.microsoft.com/graph/api/resources/permissiongrantpolicy?view=graph-rest-beta) resource type. After June 30, 2022, Azure AD Graph will no longer be supported in the **excludes** condition set. For more information about Azure AD Graph deprecation, see [Migrate Azure Active Directory (Azure AD) Graph apps to Microsoft Graph](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview).",
+          "Target": "excludes"
+        }        
+      ],
+      "Id": "b4e9af10-1cb2-4380-adc6-72cf4122f1b8",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2021-11-01T00:00:00.7458146Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Identity and sign-in"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "3dc18de1-c639-4e70-8c70-a9decb6523c5",
+          "ApiChange": "Method",
+          "ChangedApiName": "excludes",
+          "ChangeType": "Deprecation",
+          "Description": "Deprecated Azure AD Graph in the [List excludes](https://docs.microsoft.com/en-us/graph/api/permissiongrantpolicy-list-excludes?view=graph-rest-1.0) method of the [permissionGrantPolicy](https://docs.microsoft.com/graph/api/resources/permissiongrantpolicy?view=graph-rest-1.0) resource type. After June 30, 2022, Azure AD Graph will no longer be supported in the **excludes** condition set. For more information about Azure AD Graph deprecation, see [Migrate Azure Active Directory (Azure AD) Graph apps to Microsoft Graph](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview).",
+          "Target": "excludes"
+        }        
+      ],
+      "Id": "3dc18de1-c639-4e70-8c70-a9decb6523c5",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2021-11-01T00:00:00.7458146Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Identity and sign-in"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "cc9daa2b-0fbd-42b3-8bfb-b7593e031739",
           "ApiChange": "Method",
           "ChangedApiName": "validatePassword",


### PR DESCRIPTION
The [List excludes](https://docs.microsoft.com/en-us/graph/api/permissiongrantpolicy-list-excludes?view=graph-rest-1.0&tabs=http#example) method of permissionGrantPolicy currently returns an Azure AD Graph + a Microsoft Graph object. The Azure AD Graph object will be removed only when Azure AD Graph is deprecated. This PR marks the object as deprecated in the docs.