### PR TITLE
Update site-getapplicablecontenttypesforlist.md

### DIFF
--- a/api-reference/v1.0/api/site-getapplicablecontenttypesforlist.md
+++ b/api-reference/v1.0/api/site-getapplicablecontenttypesforlist.md
@@ -70,7 +70,7 @@ If successful, this function returns a `200 OK` response code and a [contentType
 }
 -->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/sites/{siteId}/getApplicableContentTypesForList(listId='listId')
+GET https://graph.microsoft.com/v1.0/sites/{siteId}/getApplicableContentTypesForList(listId='{listId}')
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/site-getapplicablecontenttypesforlist-csharp-snippets.md)]


### PR DESCRIPTION
Make `listId` match `siteId` in format. 

`listId` => `{listId}`

This is required for snippet testing using Raptor, so that the code generator can produce the following snippet:-
```csharp

GraphServiceClient graphClient = new GraphServiceClient( authProvider );var getApplicableContentTypesForList = await graphClient.Sites["{site-id}"]
.GetApplicableContentTypesForList("{list-id}")
.Request()
.GetAsync();

```