### PR TITLE
Add missing reference TOC entries for migration workarounds

### DIFF
--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -123,6 +123,8 @@ items:
         href: /graph/migrate-azure-ad-graph-deploy-test-extend?context=graph/api/beta
       - name: Migration FAQ
         href: /graph/migrate-azure-ad-graph-faq?context=graph/api/beta
+      - name: Configure Azure AD Graph permissions
+        href: /graph/migrate-azure-ad-graph-configure-permissions?context=graph/api/beta
   - name: Use SDKs
     items:
       - name: Overview

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -119,6 +119,8 @@ items:
         href: /graph/migrate-azure-ad-graph-deploy-test-extend?context=graph/api/1.0
       - name: Migration FAQ
         href: /graph/migrate-azure-ad-graph-faq?context=graph/api/1.0
+      - name: Configure Azure AD Graph permissions
+        href: /graph/migrate-azure-ad-graph-configure-permissions?context=graph/api/1.0
   - name: Use SDKs
     items:
       - name: Overview


### PR DESCRIPTION
I forgot that the conceptual content in the Develop node should also be documented in the beta & v1.0 TOCs. This PR addresses this gap to improve discoverability for https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-configure-permissions