### PR TITLE
Add a note about using the DirectoryObject APIs

### DIFF
--- a/api-reference/v1.0/api/user-checkmembergroups.md
+++ b/api-reference/v1.0/api/user-checkmembergroups.md
@@ -19,8 +19,8 @@ types of groups provisioned in Azure AD. Note that Microsoft 365 groups cannot c
 in a Microsoft 365 group is always direct.
 
 > **Note:** This API only works for user accounts, and not for service principal identities. If your application
-supports both, consider using the [DirectoryObject checkMemberGroups endpoint](/graph/api/directoryobject-checkmembergroups)
-instead (at `/directoryObjects/{id}/checkMemberGroups`).
+supports both, consider using the [directoryObject: checkMemberGroups method](/graph/api/directoryobject-checkmembergroups)
+instead.
 
 ## Permissions
 

--- a/api-reference/v1.0/api/user-checkmembergroups.md
+++ b/api-reference/v1.0/api/user-checkmembergroups.md
@@ -19,7 +19,7 @@ types of groups provisioned in Azure AD. Note that Microsoft 365 groups cannot c
 in a Microsoft 365 group is always direct.
 
 > **Note:** This API only works for user accounts, and not for service principal identities. If your application
-supports both, consider using the [directoryObject: checkMemberGroups method](/graph/api/directoryobject-checkmembergroups)
+supports both, consider using [directoryObject: checkMemberGroups method](/graph/api/directoryobject-checkmembergroups)
 instead.
 
 ## Permissions

--- a/api-reference/v1.0/api/user-checkmembergroups.md
+++ b/api-reference/v1.0/api/user-checkmembergroups.md
@@ -18,6 +18,10 @@ You can check up to a maximum of 20 groups per request. This function supports M
 types of groups provisioned in Azure AD. Note that Microsoft 365 groups cannot contain groups. So membership
 in a Microsoft 365 group is always direct.
 
+> **Note:** This API only works for user accounts, and not for service principal identities. If your application
+supports both, consider using the [DirectoryObject checkMemberGroups endpoint](/graph/api/directoryobject-checkmembergroups)
+instead (at `/directoryObjects/{id}/checkMemberGroups`).
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/user-getmembergroups.md
+++ b/api-reference/v1.0/api/user-getmembergroups.md
@@ -18,6 +18,10 @@ This function supports Microsoft 365 and other types of groups provisioned in Az
 request can return is 11000. Note that Microsoft 365 groups cannot contain groups. So membership in a Microsoft 365 group is
 always direct.
 
+> **Note:** This API only works for user accounts, and not for service principal identities. If your application
+supports both, consider using the [DirectoryObject checkMemberGroups endpoint](/graph/api/directoryobject-getmembergroups)
+instead (at `/directoryObjects/{id}/getMemberGroups`).
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/user-getmembergroups.md
+++ b/api-reference/v1.0/api/user-getmembergroups.md
@@ -19,8 +19,8 @@ request can return is 11000. Note that Microsoft 365 groups cannot contain group
 always direct.
 
 > **Note:** This API only works for user accounts, and not for service principal identities. If your application
-supports both, consider using the [DirectoryObject checkMemberGroups endpoint](/graph/api/directoryobject-getmembergroups)
-instead (at `/directoryObjects/{id}/getMemberGroups`).
+supports both, consider using [directoryObject: checkMemberGroups](/graph/api/directoryobject-getmembergroups)
+instead.
 
 ## Permissions
 


### PR DESCRIPTION
There are cases where a developer wanting to support groups in an
application doesn't intend to make a distinction between supporting
user accounts and service principals, but may accidentally introduce
a difference simply because the 'user' APIs are significantly further
up the search results, and don't reference the more general API which
works for both kinds of identities. Here I add a note and links to the
directoryObject APIs for two such pages.