### PR TITLE
Updating Identity Reporting limits

### DIFF
--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -4,7 +4,6 @@ description: "Throttling limits the number of concurrent calls to a service to p
 author: "davidmu1"
 ms.localizationpriority: high
 ms.custom: graphiamtop20
-ms.localizationpriority: high
 ---
 
 # Microsoft Graph throttling guidance

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -290,7 +290,7 @@ Other factors that affect a request cost:
 
 | Request type |  Limit per app per tenant |
 | ------------ | ------------------------ |
-| Any | 60 requests per 60 seconds |
+| Any | 5 requests per 10 seconds |
 
 The preceding limits apply to the following resources:
 

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -81,7 +81,7 @@ For a broader discussion of throttling in the Microsoft Cloud, see [Throttling p
 Programming patterns like continuously polling a resource to check for updates and regularly scanning resource collections to check for new or deleted resources are more likely to lead to applications being throttled and degrade overall performances. You should instead leverage [change tracking](delta-query-overview.md) and [change notifications](webhooks.md) when available.
 
 >[!NOTE]
->[Best practices for discovering files and detecting changes at scale](/onedrive/developer/rest-api/concepts/scan-guidance?view=odsp-graph-online) describes best practices in details.
+>[Best practices for discovering files and detecting changes at scale](/onedrive/developer/rest-api/concepts/scan-guidance) describes best practices in details.
 
 ## Throttling and batching
 


### PR DESCRIPTION
Changed Identity reporting limits from 60 requests per 60 seconds to 5 requests per 10 seconds to match the actual policy being applied for the service