### PR TITLE
Refactoring name of MCAS to MDCA

### DIFF
--- a/concepts/overview-major-services.md
+++ b/concepts/overview-major-services.md
@@ -92,7 +92,7 @@ Some services in Microsoft Graph make their debut there, others have been well-k
 
 |Feature     |Supporting services  |Description |More information |
 |:-----------|:--------------------|:-----------|:----------------|
-| Security integration | Azure AD Identity Protection, Azure Information Protection, Azure Security Center, Microsoft Cloud Application Security, Windows Defender Advanced Threat Protection, and [more](/graph/api/resources/security-api-overview) | Provides a unified gateway to security insights and actions across Microsoft and ecosystem partners. | [Security in Microsoft Graph](security-concept-overview.md) |
+| Security integration | Azure AD Identity Protection, Azure Information Protection, Azure Security Center, Microsoft Defender for Cloud Apps, Windows Defender Advanced Threat Protection, and [more](/graph/api/resources/security-api-overview) | Provides a unified gateway to security insights and actions across Microsoft and ecosystem partners. | [Security in Microsoft Graph](security-concept-overview.md) |
 
 
 


### PR DESCRIPTION
Hi, I'm a PM from Microsoft Defender for Cloud Apps (MDCA), formerly MCAS.
During Ignite, we announced rebranding to the Defender suite.
I noticed that few pages referring to our product still use the outdated name, and therefore submitting this update.