### PR TITLE
Simplify titles in Azure AD Graph migration topics

### DIFF
--- a/concepts/migrate-azure-ad-graph-audit-api-use.md
+++ b/concepts/migrate-azure-ad-graph-audit-api-use.md
@@ -1,16 +1,16 @@
 ---
-title: "Examine Azure Active Directory (Azure AD) Graph APIs app usage"
+title: "Examine Azure AD Graph APIs app usage"
 description: "Describes how to audit Azure Active Directory (Azure AD) Graph APIs to migrate an app to Microsoft Graph API."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Examine Azure Active Directory (Azure AD) Graph APIs app usage
+# Examine Azure AD Graph APIs app usage
 
 This is step 2 of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-While planning your migration to Microsoft Graph, take time to review your existing application and to catalog the Azure AD Graph APIs you're currently using.
+While planning your migration to Microsoft Graph, take time to review your existing application and to catalog the Azure Active Directory (Azure AD) Graph APIs you're currently using.
 
 Compare your list to the known differences.  This helps identify specific changes you'll need to make to migrate your app.  These include simple changes easily resolved using an editor's search-and-replace features or more complicated updates that might require more analysis.
 

--- a/concepts/migrate-azure-ad-graph-feature-differences.md
+++ b/concepts/migrate-azure-ad-graph-feature-differences.md
@@ -1,16 +1,16 @@
 ---
-title: "Feature differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph"
+title: "Feature differences between Azure AD Graph and Microsoft Graph"
 description: "Describes feature differences between Azure Active Directory (Azure AD) Graph API and Microsoft Graph API, in order to help you migrate apps quickly and easily."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Feature differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph
+# Feature differences between Azure AD Graph and Microsoft Graph
 
 This article is part of *step 1: review API differences* of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-Many features in Microsoft Graph work similarly to their Azure AD Graph counterparts. However, a few have been changed or improved. Here, you'll learn how to adapt your apps to take advantage of these differences.  Frequently, the changes are minor, but well worth the effort.
+Many features in Microsoft Graph work similarly to their Azure Active Directory (Azure AD) Graph counterparts. However, a few have been changed or improved. Here, you'll learn how to adapt your apps to take advantage of these differences.  Frequently, the changes are minor, but well worth the effort.
 
 This article explores how Microsoft Graph handles:
 

--- a/concepts/migrate-azure-ad-graph-method-differences.md
+++ b/concepts/migrate-azure-ad-graph-method-differences.md
@@ -1,16 +1,16 @@
 ---
-title: "Method differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph"
+title: "Method differences between Azure AD Graph and Microsoft Graph"
 description: "Describes method differences between Azure Active Directory (Azure AD) Graph API and Microsoft Graph API (REST)."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Method differences between Azure Active Directory (Azure AD) and Microsoft Graph
+# Method differences between Azure AD Graph and Microsoft Graph
 
 This article is part of *step 1: review API differences* of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-A handful of Azure AD Graph methods have also changed.  If a method is **not** shown in this list, it is already available in the [v1.0 version](/graph/api/overview) of Microsoft Graph, with exactly the same name as in Azure AD Graph.
+A handful of Azure Active Directory (Azure AD) Graph methods have also changed.  If a method is **not** shown in this list, it is already available in the [v1.0 version](/graph/api/overview) of Microsoft Graph, with exactly the same name as in Azure AD Graph.
 
 |Azure AD Graph <br>(v1.6) method |Microsoft Graph<br>(resource/method)|Comments|
 |---|---|---|

--- a/concepts/migrate-azure-ad-graph-overview.md
+++ b/concepts/migrate-azure-ad-graph-overview.md
@@ -1,19 +1,19 @@
 ---
-title: "Migrate Azure Active Directory (Azure AD) Graph apps to Microsoft Graph"
+title: "Migrate Azure AD Graph apps to Microsoft Graph"
 description: "Describes how to migrate Azure Active Directory (Azure AD) API apps to Microsoft Graph API."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Migrate Azure Active Directory (Azure AD) Graph apps to Microsoft Graph
+# Migrate Azure AD Graph apps to Microsoft Graph
 
 > [!WARNING]
 > **Azure Active Directory (Azure AD) Graph is deprecated**. To avoid loss of functionality, migrate your applications to Microsoft Graph before June 30, 2022 when Azure AD Graph API endpoints will stop responding to requests.
 >
 > Microsoft will continue technical support and apply security fixes for Azure AD Graph until June 30, 2022 when all functionality and support will end. If you fail to migrate your applications to Microsoft Graph before June 30, 2022, you put their functionality and stability at risk.
 
-Azure AD Graph is deprecated. Update your Azure AD Graph apps to use Microsoft Graph now.
+[Azure AD Graph is deprecated](https://techcommunity.microsoft.com/t5/azure-active-directory-identity/update-your-applications-to-use-microsoft-authentication-library/ba-p/1257363). Update your Azure AD Graph apps to use Microsoft Graph now.
 
 ## Why use Microsoft Graph?
 

--- a/concepts/migrate-azure-ad-graph-property-differences.md
+++ b/concepts/migrate-azure-ad-graph-property-differences.md
@@ -1,16 +1,16 @@
 ---
-title: "Property differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph"
+title: "Property differences between Azure AD Graph and Microsoft Graph"
 description: "Describes property differences between Azure AD Graph resources (entities) and Microsoft Graph, in order to help migrate apps accordingly."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Property differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph
+# Property differences between Azure AD Graph and Microsoft Graph
 
 This article is part of *step 1: review API differences* of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-In general, the best way to compare the Azure AD Graph API to Microsoft Graph is to compare the underlying metadata for each service, especially the resource descriptions:
+In general, the best way to compare the Azure Active Directory (Azure AD) Graph API to Microsoft Graph is to compare the underlying metadata for each service, especially the resource descriptions:
 
 - [Azure AD Graph metadata](https://graph.windows.net/microsoft.com/$metadata?api-version=1.6)
 - [Microsoft Graph beta metadata](https://graph.microsoft.com/beta/$metadata)

--- a/concepts/migrate-azure-ad-graph-request-differences.md
+++ b/concepts/migrate-azure-ad-graph-request-differences.md
@@ -1,16 +1,16 @@
 ---
-title: "Request differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph"
+title: "Request differences between Azure AD Graph and Microsoft Graph"
 description: "Describes how Microsoft Graph requests differ from Azure Active Directory (Azure AD) Graph requests, which helps migrate apps to the newer service.."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Request differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph
+# Request differences between Azure AD Graph and Microsoft Graph
 
 This article is part of *step 1: review API differences* of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-Microsoft Graph and the Azure AD Graph API are both REST APIs and they each support ODATA conventions for query parameters. However, the syntax varies between these two APIs.
+Microsoft Graph and the Azure Active Directory (Azure AD) Graph API are both REST APIs and they each support OData conventions for query parameters. However, the syntax varies between these two APIs.
 
 Use [Graph Explorer](https://aka.ms/ge) to try these request patterns against your own data, as it's a great way to learn about the request and response differences.
 

--- a/concepts/migrate-azure-ad-graph-resource-differences.md
+++ b/concepts/migrate-azure-ad-graph-resource-differences.md
@@ -1,16 +1,16 @@
 ---
-title: "Resource type differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph"
+title: "Resource type differences between Azure AD Graph and Microsoft Graph"
 description: "Describes differences between resources in Azure Active Directory (Azure AD) Graph and resources in Microsoft Graph in order to help migrate apps."
 author: "dkershaw10"
 ms.localizationpriority: medium
 ms.prod: "applications"
 ---
 
-# Resource type differences between Azure Active Directory (Azure AD) Graph and Microsoft Graph
+# Resource type differences between Azure AD Graph and Microsoft Graph
 
 This article is part of *step 1: review API differences* of the [process to migrate apps](migrate-azure-ad-graph-planning-checklist.md).
 
-When migrating apps from Azure AD Graph to Microsoft Graph, be aware that some resources have different names and different types.  For example, if your Azure AD Graph app uses the **tenantInfo** resource, you'll need to update your code to refer to [organization](/graph/api/resources/organization) instead.
+When migrating apps from Azure Active Directory (Azure AD) Graph to Microsoft Graph, be aware that some resources have different names and different types.  For example, if your Azure AD Graph app uses the **tenantInfo** resource, you'll need to update your code to refer to [organization](/graph/api/resources/organization) instead.
 
 The following table highlights differences between Azure AD Graph and Microsoft Graph resources.  It shows resources that have different names or are not available; it also highlights resources available in the beta version of Microsoft Graph but not in the v1.0 version.
 


### PR DESCRIPTION
Applying the [style guide](https://docs.microsoft.com/en-us/style-guide/acronyms#be-careful-with-acronyms-in-titles-and-headings) to simplify titles in the migration articles.