### PR TITLE
Fix broken links to new connector gallery URL

### DIFF
--- a/concepts/connecting-external-content-connectors-overview.md
+++ b/concepts/connecting-external-content-connectors-overview.md
@@ -26,9 +26,9 @@ The following diagram provides a high-level overview of Microsoft Graph connecto
 
 The 100+ connectors currently available from Microsoft and partners enable you to connect to popular Microsoft and non-Microsoft services. Examples of existing connectors include Azure services, Box, ServiceNow, Salesforce, Google services, MediaWiki, and more.
 
-To learn more about the existing Microsoft Graph connectors, visit the [Microsoft Graph connectors gallery](/microsoft-search/connectors).
+To learn more about the existing Microsoft Graph connectors, visit the [Microsoft Graph connectors gallery](https://www.microsoft.com/microsoft-search/connectors/).
 
-While these connectors help connect to popular services, you may want to integrate with services that aren't available in the existing [connectors gallery](/microsoft-search/connectors). You can use the Microsoft Graph connectors API to build custom connectors to bring your external data into Microsoft 365 experiences, including Microsoft Search, Viva Topics and more (coming soon), within your organization.
+While these connectors help connect to popular services, you may want to integrate with services that aren't available in the existing [connectors gallery](https://www.microsoft.com/microsoft-search/connectors/). You can use the Microsoft Graph connectors API to build custom connectors to bring your external data into Microsoft 365 experiences, including Microsoft Search, Viva Topics and more (coming soon), within your organization.
 
 ## Get started with custom Graph connectors:
 * [Working with the connectors API](connecting-external-content-connectors-api-overview.md)


### PR DESCRIPTION
Connector gallery now hosted on new URL.  Updating broken links to point to new location.