### PR TITLE
Add new properties to API documentation

### DIFF
--- a/api-reference/beta/api/reportroot-getmailboxusagedetail.md
+++ b/api-reference/beta/api/reportroot-getmailboxusagedetail.md
@@ -77,6 +77,8 @@ The CSV file has the following headers for columns.
 - Prohibit Send/Receive Quota (Byte)
 - Deleted Item Count
 - Deleted Item Size (Byte)
+- Deleted Item Quota (Byte)
+- Has Archive
 - Report Period
 
 ### JSON
@@ -130,7 +132,7 @@ Follow the 302 redirection and the CSV file that downloads will have the followi
 HTTP/1.1 200 OK
 Content-Type: application/octet-stream
 
-Report Refresh Date,User Principal Name,Display Name,Is Deleted,Deleted Date,Created Date,Last Activity Date,Item Count,Storage Used (Byte),Issue Warning Quota (Byte),Prohibit Send Quota (Byte),Prohibit Send/Receive Quota (Byte),Deleted Item Count,Deleted Item Size (Byte),Report Period
+Report Refresh Date,User Principal Name,Display Name,Is Deleted,Deleted Date,Created Date,Last Activity Date,Item Count,Storage Used (Byte),Issue Warning Quota (Byte),Prohibit Send Quota (Byte),Prohibit Send/Receive Quota (Byte),Deleted Item Count,Deleted Item Size (Byte),Deleted Item Quota (Byte),Has Archive,Report Period
 ```
 
 ### JSON
@@ -182,6 +184,8 @@ Content-Length: 526
       "storageUsedInBytes": 10414748704, 
       "deletedItemCount": 138481,
       "deletedItemSizeInBytes": 10414748704, 
+      "deletedItemQuota": 107374182400,
+      "hasArchive": true,
       "issueWarningQuotaInBytes": 10522698752, 
       "prohibitSendQuotaInBytes": 10630040576, 
       "prohibitSendReceiveQuotaInBytes": 10737418240, 


### PR DESCRIPTION
Two new properties (hasArchive and deletedItemQuota) have been added to the mailbox usage Graph API response; adding these properties to the documentation.  (Resubmitting after fixing perms.)