### PR TITLE
Update riskyusers-confirmcompromised.md

### DIFF
--- a/api-reference/beta/api/riskyusers-confirmcompromised.md
+++ b/api-reference/beta/api/riskyusers-confirmcompromised.md
@@ -39,7 +39,7 @@ POST /riskyUsers/confirmCompromised
 | Authorization  | Bearer {token}. Required. |
 
 ## Request body
-Specify the risky user IDs to dismiss in the request body.
+Specify the risky user IDs to confirm as compromised in the request body.
 
 ## Response
 


### PR DESCRIPTION
fixing typo on row 42, change "dismiss" to "confirm as compromised"