### PR TITLE
GetSubmission and GetSubmissions - Adding Prefer header and expand options in Examples

### DIFF
--- a/api-reference/beta/api/educationassignment-get.md
+++ b/api-reference/beta/api/educationassignment-get.md
@@ -1,7 +1,7 @@
 ---
 title: "Get educationAssignment"
 description: "Get the properties and relationships of an assignment."
-author: "dipakboyed"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: apiPageType
@@ -34,6 +34,8 @@ GET /education/classes/{id}/assignments/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+
+The available `$expand` options for this method are: `categories`, `resources`, `rubric`, `submissions` and `*` which includes all the previous options.
 
 ## Request headers
 | Header       | Value |
@@ -75,10 +77,6 @@ GET https://graph.microsoft.com/beta/education/classes/f4a941ff-9da6-4707-ba5b-0
 [!INCLUDE [sample-code](../includes/snippets/java/get-educationassignment-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-educationassignment-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
 ### Response
@@ -94,6 +92,7 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+Content-length: 279
 
 {
     "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('f4a941ff-9da6-4707-ba5b-0eae93cad0b4')/assignments/$entity",

--- a/api-reference/beta/api/educationassignment-get.md
+++ b/api-reference/beta/api/educationassignment-get.md
@@ -77,6 +77,9 @@ GET https://graph.microsoft.com/beta/education/classes/f4a941ff-9da6-4707-ba5b-0
 [!INCLUDE [sample-code](../includes/snippets/java/get-educationassignment-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
+# [Go](#tab/go)
+[!INCLUDE [sample-code](../includes/snippets/go/get-educationassignment-go-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 ---
 
 ### Response

--- a/api-reference/beta/api/educationassignment-list-submissions.md
+++ b/api-reference/beta/api/educationassignment-list-submissions.md
@@ -303,7 +303,6 @@ Content-length: 4492
 #### Request
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "get_submissions_prefer"

--- a/api-reference/beta/api/educationassignment-list-submissions.md
+++ b/api-reference/beta/api/educationassignment-list-submissions.md
@@ -1,7 +1,7 @@
 ---
 title: "List submissions"
 description: "List all the submissions associated with an assignment."
-author: "dipakboyed"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: apiPageType
@@ -13,9 +13,11 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-List all the submissions associated with an [assignment](../resources/educationassignment.md).
+List all the [submissions](../resources/educationsubmission.md) associated with an [assignment](../resources/educationassignment.md).
 
-A teacher or an application with application permissions can get all the submissions while a student can only get submissions that they are associated with.
+A teacher or an application with application permissions can get all the **submissions**, a student can only get **submissions** that they are associated with.
+
+Provide the header `Prefer: include-unknown-enum-members` to properly list **submissions** with the `reassigned` status. For details, see the examples section.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -29,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /education/classes/{id}/assignments/{id}/submissions
+GET /education/classes/{class-id}/assignments/{assignment-id}/submissions
 ```
 
 ## Optional query parameters
@@ -41,6 +43,7 @@ The following are the available `$expand` options for this method: `outcomes`, `
 | Header       | Value |
 |:---------------|:--------|
 | Authorization  | Bearer {token}. Required.  |
+| Prefer  | `include-unknown-enum-members`. Optional.  |
 
 ## Request body
 Don't supply a request body for this method.
@@ -79,10 +82,6 @@ GET https://graph.microsoft.com/beta/education/classes/f4a941ff-9da6-4707-ba5b-0
 [!INCLUDE [sample-code](../includes/snippets/java/get-submissions-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-submissions-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
 #### Response
@@ -99,6 +98,7 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+Content-length: 873
 
 {
     "value": [
@@ -170,10 +170,6 @@ GET https://graph.microsoft.com/beta/education/classes/72a7baec-c3e9-4213-a850-f
 
 # [Java](#tab/java)
 [!INCLUDE [sample-code](../includes/snippets/java/get-submissions-expand-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-submissions-expand-go-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
 ---
@@ -298,6 +294,135 @@ Content-length: 4492
                     ]
                 }
             ]
+        }
+    ]
+}
+```
+
+### Example 3: Get submissions - Request with optional Prefer header
+#### Request
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "get_submissions_prefer"
+}-->
+```http
+GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions
+Prefer: include-unknown-enum-members
+```
+---
+
+
+#### Response
+The following is an example of the response. 
+
+>**Note:** The response object shown here might be shortened for readability.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.educationSubmission",
+  "isCollection": true
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 4492
+
+{
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions",
+    "value": [
+        {
+            "status": "working",
+            "submittedDateTime": null,
+            "unsubmittedDateTime": null,
+            "returnedDateTime": null,
+            "reassignedDateTime": null,
+            "resourcesFolderUrl": null,
+            "id": "f51a6687-a4a3-a8d9-ac4a-6ff81c5a8da7",
+            "recipient": {
+                "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+                "userId": "0ca0dd79-57eb-4903-97dc-88c769dd2a3d"
+            },
+            "submittedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": "0ca0dd79-57eb-4903-97dc-88c769dd2a3d",
+                    "displayName": null
+                }
+            },
+            "unsubmittedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "returnedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "reassignedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            }
+        },
+        {
+            "status": "reassigned",
+            "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+            "unsubmittedDateTime": null,
+            "returnedDateTime": null,
+            "reassignedDateTime": "2021-11-10T01:03:25.7812455Z",
+            "resourcesFolderUrl": null,
+            "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+            "recipient": {
+                "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+                "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+            },
+            "submittedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+                    "displayName": null
+                }
+            },
+            "unsubmittedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "returnedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "reassignedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+                    "displayName": null
+                }
+            }
         }
     ]
 }

--- a/api-reference/beta/api/educationsubmission-get.md
+++ b/api-reference/beta/api/educationsubmission-get.md
@@ -154,7 +154,6 @@ Content-length: 712
 #### Request
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "get_educationsubmission_prefer"
@@ -235,7 +234,6 @@ Content-length: 712
 #### Request
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "get_submission_expand"

--- a/api-reference/beta/api/educationsubmission-get.md
+++ b/api-reference/beta/api/educationsubmission-get.md
@@ -1,7 +1,7 @@
 ---
 title: "Get educationSubmission"
 description: "Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher or application with application permissions has full access to all submissions. "
-author: "dipakboyed"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: apiPageType
@@ -13,13 +13,15 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Retrieve a particular submission.
+Retrieve a particular [submission](../resources/educationsubmission.md).
 
-A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. 
+A **submission** object represents a student's work for an [assignment](../resources/educationassignment.md). Resources associated with the **submission** represent this work.
 
-Only the **assignedTo** student can see and modify the submission. A teacher or application with application permissions has full access to all submissions.
+Only the **assignedTo** student can see and modify the **submission**. A teacher or application with application permissions has full access to all **submissions**.
 
-The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers or applications with application permissions can add or change grades and feedback. Students will not see the grade or feedback until the assignment has been released.
+The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers or applications with application permissions can add or change grades and feedback. Students will not see the grade or feedback until the **assignment** has been released.
+
+Provide the header `Prefer: include-unknown-enum-members` to properly list **submissions** with the `reassigned` status. For details, see the examples section.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -33,22 +35,27 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /education/classes/{id}/assignments/{id}/submissions/{id}
+GET /education/classes/{class-id}/assignments/{assignment-id}/submissions/{submission-id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+
+The following are the available `$expand` options for this method: `outcomes`, `resources`, `submittedResources`, and `*`, which includes all the previous options. For details, see the examples section.
 
 ## Request headers
 | Header       | Value |
 |:---------------|:--------|
 | Authorization  | Bearer {token}. Required.  |
+| Prefer  | `include-unknown-enum-members`. Optional.  |
 
 ## Request body
 Do not supply a request body for this method.
 ## Response
 If successful, this method returns a `200 OK` response code and an [educationSubmission](../resources/educationsubmission.md) object in the response body.
-## Example
-### Request
+
+## Examples
+### Example 1: Request without optional Prefer header
+#### Request
 The following is an example of the request.
 
 # [HTTP](#tab/http)
@@ -57,7 +64,7 @@ The following is an example of the request.
   "name": "get_educationsubmission"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/education/classes/11010/assignments/19002/submissions/33223
+GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-educationsubmission-csharp-snippets.md)]
@@ -75,13 +82,9 @@ GET https://graph.microsoft.com/beta/education/classes/11010/assignments/19002/s
 [!INCLUDE [sample-code](../includes/snippets/java/get-educationsubmission-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-educationsubmission-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
-### Response
+#### Response
 The following is an example of the response. 
 
 >**Notes:** 
@@ -97,21 +100,319 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+Content-length: 712
 
 {
-  "id": "33223",
-  "recipient": {
-    "userId": "13015"
-  },
-  "resourcesFolderUrl": "https://graph.microsoft.com/v1.0/drives/b!8-QjN2tsv0WyGnTv7vOvnQkmGHbbeMNLqYKONmHLVnvCVmBYIGpeT456457AdW9f/items/017NJZI25NOB5XZNLABF7646XAMDZTQQ6T",
-  "status": "working",
-  "submittedBy": {
-    "user": {
-      "displayName": "Susana Rocha",
-      "id": "14012"
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions/$entity",
+    "status": "returned",
+    "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+    "unsubmittedDateTime": null,
+    "returnedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "reassignedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "resourcesFolderUrl": null,
+    "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+    "recipient": {
+        "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+        "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+    },
+    "submittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+            "displayName": null
+        }
+    },
+    "unsubmittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "returnedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
+    },
+    "reassignedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
     }
-  },
-  "submittedDateTime": "2014-01-01T00:00:00Z"
+}
+```
+
+### Example 2: Request with optional Prefer header
+#### Request
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "get_educationsubmission_prefer"
+}-->
+```http
+GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5
+Prefer: include-unknown-enum-members
+```
+---
+
+#### Response
+The following is an example of the response. 
+
+>**Notes:** 
+>The response object shown here might be shortened for readability. 
+>
+>If [setUpResourcesFolder](educationsubmission-setupResourcesFolder.md) has not been called on this [educationSubmission](../resources/educationsubmission.md) resource yet, the **resourcesFolderUrl** property is `null`.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.educationSubmission"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 712
+
+{
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions/$entity",
+    "status": "reassigned",
+    "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+    "unsubmittedDateTime": null,
+    "returnedDateTime": null,
+    "reassignedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "resourcesFolderUrl": null,
+    "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+    "recipient": {
+        "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+        "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+    },
+    "submittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+            "displayName": null
+        }
+    },
+    "unsubmittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "returnedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "reassignedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
+    }
+}
+```
+
+### Example 3: Get submission with $expand options
+#### Request
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "get_submission_expand"
+}-->
+```http
+GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5?$expand=*
+```
+---
+
+#### Response
+The following is an example of the response. 
+
+>**Note:** The response object shown here might be shortened for readability.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.educationSubmission"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 4492
+
+{
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions(outcomes(),resources(),submittedResources())/$entity",
+    "status": "returned",
+    "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+    "unsubmittedDateTime": null,
+    "returnedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "reassignedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "resourcesFolderUrl": null,
+    "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+    "recipient": {
+        "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+        "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+    },
+    "submittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+            "displayName": null
+        }
+    },
+    "unsubmittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "returnedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
+    },
+    "reassignedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
+    },
+    "outcomes@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/outcomes",
+    "outcomes": [
+        {
+            "@odata.type": "#microsoft.graph.educationFeedbackOutcome",
+            "lastModifiedDateTime": null,
+            "id": "ca05367a-b292-42d5-aff7-5d279feeace8",
+            "lastModifiedBy": null,
+            "feedback": null,
+            "publishedFeedback": null
+        },
+        {
+            "@odata.type": "#microsoft.graph.educationPointsOutcome",
+            "lastModifiedDateTime": null,
+            "id": "ea1351f6-ba33-4940-b2cb-6a7254af2dc8",
+            "lastModifiedBy": null,
+            "points": null,
+            "publishedPoints": null
+        },
+        {
+            "@odata.type": "#microsoft.graph.educationRubricOutcome",
+            "lastModifiedDateTime": "2021-11-10T01:03:25.7712076Z",
+            "id": "65a46d78-1a2b-4a7e-bcf8-78a22ac2611b",
+            "lastModifiedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "rubricQualityFeedback": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "feedback": null
+                }
+            ],
+            "rubricQualitySelectedLevels": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "columnId": null
+                }
+            ],
+            "publishedRubricQualityFeedback": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "feedback": null
+                }
+            ],
+            "publishedRubricQualitySelectedLevels": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "columnId": null
+                }
+            ]
+        }
+    ],
+    "resources@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/resources",
+    "resources": [],
+    "submittedResources@odata.context": "https://graph.microsoft.com/beta/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/submittedResources",
+    "submittedResources": []
 }
 ```
 

--- a/api-reference/beta/api/educationsubmission-reassign.md
+++ b/api-reference/beta/api/educationsubmission-reassign.md
@@ -79,10 +79,6 @@ POST /education/classes/72a7baec-c3e9-4213-a850-f62de0adad5f/assignments/7192332
 [!INCLUDE [sample-code](../includes/snippets/java/educationsubmission-reassign-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/educationsubmission-reassign-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
 
@@ -176,10 +172,6 @@ Prefer: include-unknown-enum-members
 
 # [Java](#tab/java)
 [!INCLUDE [sample-code](../includes/snippets/java/educationsubmission-prefer-reassign-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/educationsubmission-prefer-reassign-go-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
 ---

--- a/api-reference/beta/resources/educationsubmission.md
+++ b/api-reference/beta/resources/educationsubmission.md
@@ -1,7 +1,7 @@
 ---
 title: "educationSubmission resource type"
 description: "Represents the resources that an individual (or group) submit for an assignment and the outcomes (such as grades or feedback) associated with the submission."
-author: "dipakboyed"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: resourcePageType
@@ -42,7 +42,7 @@ If [setUpResourcesFolder](../api/educationsubmission-setupResourcesFolder.md) ha
 |returnedBy|[identitySet](identityset.md)|User who moved the status of this submission to returned.|
 |returnedDateTime|DateTimeOffset|Moment in time when the submission was returned. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`|
 |resourcesFolderUrl|String|Folder where all file resources for this submission need to be stored.|
-|status|string| Read-only. Possible values are: `working`, `submitted`, `released`, `returned`, and `reassigned`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value(s) in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `reassigned`.|
+|status|educationSubmissionStatus| Read-only. Possible values are: `working`, `submitted`, `released`, `returned`, `unknownFutureValue` and `reassigned`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value(s) in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `reassigned`.|
 |submittedBy|[identitySet](identityset.md)|User who moved the resource into the submitted state.|
 |submittedDateTime|DateTimeOffset|Moment in time when the submission was moved into the submitted state. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`|
 |unsubmittedBy|[identitySet](identityset.md)|User who moved the resource from submitted into the working state.|

--- a/api-reference/v1.0/api/educationassignment-get.md
+++ b/api-reference/v1.0/api/educationassignment-get.md
@@ -1,7 +1,7 @@
 ---
 title: "Get educationAssignment"
 description: "Get the properties and relationships of an assignment."
-author: "sharad-sharma-msft"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: apiPageType
@@ -32,6 +32,8 @@ GET /education/classes/{id}/assignments/{id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+
+The available `$expand` options for this method are: `categories`, `resources`, `rubric`, `submissions` and `*` which includes all the previous options.
 
 ## Request headers
 | Header       | Value |
@@ -73,10 +75,6 @@ GET https://graph.microsoft.com/v1.0/education/classes/f4a941ff-9da6-4707-ba5b-0
 [!INCLUDE [sample-code](../includes/snippets/java/get-educationassignment-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-educationassignment-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
 ### Response
@@ -92,6 +90,7 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+Content-length: 279
 
 {
     "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('f4a941ff-9da6-4707-ba5b-0eae93cad0b4')/assignments/$entity",

--- a/api-reference/v1.0/api/educationsubmission-get.md
+++ b/api-reference/v1.0/api/educationsubmission-get.md
@@ -1,7 +1,7 @@
 ---
 title: "Get educationSubmission"
 description: "Retrieve a particular submission. A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. Only the student the submission is assigned to can see and modify the submission. A teacher or application with application permissions has full access to all submissions. "
-author: "sharad-sharma-msft"
+author: "cristobal-buenrostro"
 ms.localizationpriority: medium
 ms.prod: "education"
 doc_type: apiPageType
@@ -11,13 +11,13 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Retrieve a particular submission.
+Retrieve a particular [submission](../resources/educationsubmission.md).
 
-A submission object represents a student's work for an assignment. Resources associated with the submission represent this work. 
+A **submission** object represents a student's work for an [assignment](../resources/educationassignment.md). Resources associated with the **submission** represent this work.
 
-Only the **assignedTo** student can see and modify the submission. A teacher or application with application permissions has full access to all submissions.
+Only the **assignedTo** student can see and modify the **submission**. A teacher or application with application permissions has full access to all **submissions**.
 
-The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers or applications with application permissions can add or change grades and feedback. Students will not see the grade or feedback until the assignment has been released.
+The grade and feedback from a teacher are part of the [educationOutcome](../resources/educationoutcome.md) associated with this object. Only teachers or applications with application permissions can add or change grades and feedback. Students will not see the grade or feedback until the **assignment** has been released.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -31,10 +31,12 @@ One of the following permissions is required to call this API. To learn more, in
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http
-GET /education/classes/acdefc6b-2dc6-4e71-b1e9-6d9810ab1793/assignments/cf6005fc-9e13-44a2-a6ac-a53322006454/submissions/d1bee293-d8bb-48d4-af3e-c8cb0e3c7fe7
+GET /education/classes/{class-id}/assignments/{assignment-id}/submissions/{submission-id}
 ```
 ## Optional query parameters
 This method supports the [OData Query Parameters](/graph/query-parameters) to help customize the response.
+
+The following are the available `$expand` options for this method: `outcomes`, `resources`, `submittedResources`, and `*`, which includes all the previous options. For details, see the examples section.
 
 ## Request headers
 | Header       | Value |
@@ -45,8 +47,10 @@ This method supports the [OData Query Parameters](/graph/query-parameters) to he
 Don't supply a request body for this method.
 ## Response
 If successful, this method returns a `200 OK` response code and an [educationSubmission](../resources/educationsubmission.md) object in the response body.
-## Example
-### Request
+
+## Examples
+### Example 1: Get submission
+#### Request
 The following is an example of the request.
 
 # [HTTP](#tab/http)
@@ -55,7 +59,7 @@ The following is an example of the request.
   "name": "get_educationsubmission"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/education/classes/11010/assignments/ad8afb28-c138-4ad7-b7f5-a6986c2655a8/submissions/33223
+GET https://graph.microsoft.com/v1.0/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-educationsubmission-csharp-snippets.md)]
@@ -73,14 +77,9 @@ GET https://graph.microsoft.com/v1.0/education/classes/11010/assignments/ad8afb2
 [!INCLUDE [sample-code](../includes/snippets/java/get-educationsubmission-java-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
 
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/get-educationsubmission-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 ---
 
-
-### Response
+#### Response
 The following is an example of the response. 
 
 >**Notes:** 
@@ -96,22 +95,221 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+Content-length: 712
 
 {
-      "id": "33223",
-      "recipient": {
-        "userId": "13015"
-      },
-      "resourcesFolderUrl": "https://graph.microsoft.com/v1.0/drives/b!8-QjN2tsv0WyGnTv7vOvnQkmGHbbeMNLqYKONmHLVnvCVmBYIGpeT456457AdW9f/items/017NJZI25NOB5XZNLABF7646XAMDZTQQ6T",
-      "status": "working",
-      "submittedBy": {
-          "user": {
-            "displayName": "Shawn Hughes",
-            "id": "14012"
-          },
-        },
-      "submittedDateTime": "2014-01-01T00:00:00Z"
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions/$entity",
+    "status": "returned",
+    "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+    "unsubmittedDateTime": null,
+    "returnedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "resourcesFolderUrl": null,
+    "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+    "recipient": {
+        "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+        "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+    },
+    "submittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+            "displayName": null
+        }
+    },
+    "unsubmittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "returnedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
     }
+}
+```
+
+### Example 2: Get submission with $expand options
+#### Request
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "get_submission_expand"
+}-->
+```http
+GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5?$expand=*
+```
+---
+
+#### Response
+The following is an example of the response. 
+
+>**Note:** The response object shown here might be shortened for readability.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.educationSubmission"
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+Content-length: 4492
+
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions(outcomes(),resources(),submittedResources())/$entity",
+    "status": "returned",
+    "submittedDateTime": "2021-11-10T00:57:17.0495233Z",
+    "unsubmittedDateTime": null,
+    "returnedDateTime": "2021-11-10T01:03:25.7812455Z",
+    "resourcesFolderUrl": null,
+    "id": "869369de-3e5a-89eb-6f2d-83cd88f860b5",
+    "recipient": {
+        "@odata.type": "#microsoft.graph.educationSubmissionIndividualRecipient",
+        "userId": "723e2402-f503-4825-a4d5-5143fbe6f53d"
+    },
+    "submittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "723e2402-f503-4825-a4d5-5143fbe6f53d",
+            "displayName": null
+        }
+    },
+    "unsubmittedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": null,
+            "displayName": null
+        }
+    },
+    "returnedBy": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "afc58f1f-7c9e-4770-a448-e53ba43463a5",
+            "displayName": null
+        }
+    },
+    "outcomes@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/outcomes",
+    "outcomes": [
+        {
+            "@odata.type": "#microsoft.graph.educationFeedbackOutcome",
+            "lastModifiedDateTime": null,
+            "id": "ca05367a-b292-42d5-aff7-5d279feeace8",
+            "lastModifiedBy": null,
+            "feedback": null,
+            "publishedFeedback": null
+        },
+        {
+            "@odata.type": "#microsoft.graph.educationPointsOutcome",
+            "lastModifiedDateTime": null,
+            "id": "ea1351f6-ba33-4940-b2cb-6a7254af2dc8",
+            "lastModifiedBy": null,
+            "points": null,
+            "publishedPoints": null
+        },
+        {
+            "@odata.type": "#microsoft.graph.educationRubricOutcome",
+            "lastModifiedDateTime": "2021-11-10T01:03:25.7712076Z",
+            "id": "65a46d78-1a2b-4a7e-bcf8-78a22ac2611b",
+            "lastModifiedBy": {
+                "application": null,
+                "device": null,
+                "user": {
+                    "id": null,
+                    "displayName": null
+                }
+            },
+            "rubricQualityFeedback": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "feedback": null
+                }
+            ],
+            "rubricQualitySelectedLevels": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "columnId": null
+                }
+            ],
+            "publishedRubricQualityFeedback": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "feedback": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "feedback": null
+                }
+            ],
+            "publishedRubricQualitySelectedLevels": [
+                {
+                    "qualityId": "a660004a-608d-4cd2-a6dc-4f43812444ee",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "2c5ae75d-d347-426b-be2c-cfc81a6f0b32",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "32fdea06-5cbb-4881-9093-96e59f59b8b8",
+                    "columnId": null
+                },
+                {
+                    "qualityId": "66137bd8-b9c2-40e1-a360-40b7ee75eaef",
+                    "columnId": null
+                }
+            ]
+        }
+    ],
+    "resources@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/resources",
+    "resources": [],
+    "submittedResources@odata.context": "https://graph.microsoft.com/v1.0/$metadata#education/classes('59069eb2-2a09-4d90-bb19-2089cc69d613')/assignments('80da1069-a635-4913-813f-d775a5470a8f')/submissions('869369de-3e5a-89eb-6f2d-83cd88f860b5')/submittedResources",
+    "submittedResources": []
+}
 ```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79

--- a/api-reference/v1.0/api/educationsubmission-get.md
+++ b/api-reference/v1.0/api/educationsubmission-get.md
@@ -140,7 +140,6 @@ Content-length: 712
 #### Request
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "get_submission_expand"

--- a/api-reference/v1.0/api/educationsubmission-get.md
+++ b/api-reference/v1.0/api/educationsubmission-get.md
@@ -145,7 +145,7 @@ The following is an example of the request.
   "name": "get_submission_expand"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5?$expand=*
+GET https://graph.microsoft.com/v1.0/education/classes/59069eb2-2a09-4d90-bb19-2089cc69d613/assignments/80da1069-a635-4913-813f-d775a5470a8f/submissions/869369de-3e5a-89eb-6f2d-83cd88f860b5?$expand=*
 ```
 ---
 


### PR DESCRIPTION
the purpose of the PR is;

to mention the prefer request header in both pages.
show example of how to use $expand options in GetSubmission.