### PR TITLE
Fix incorrect example in user-list.md

### DIFF
--- a/api-reference/v1.0/api/user-list.md
+++ b/api-reference/v1.0/api/user-list.md
@@ -410,7 +410,7 @@ Content-type: application/json
 }
 ```
 
-### Example 7: Use $search to get users with display names that contain the letters 'wa' or the letters 'to' including a count of returned objects
+### Example 7: Use $search to get users with display names that contain the letters 'wa' or the letters 'ad' including a count of returned objects
 
 #### Request
 
@@ -421,7 +421,7 @@ The following is an example of the request. This request requires the **Consiste
   "name": "get_to_count"
 } -->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/users?$search="displayName:wa" OR "displayName:to"&$orderbydisplayName&$count=true
+GET https://graph.microsoft.com/v1.0/users?$search="displayName:wa" OR "displayName:ad"&$orderbydisplayName&$count=true
 ConsistencyLevel: eventual
 ```
 
@@ -453,11 +453,11 @@ Content-type: application/json
       "userPrincipalName":"oscarward@contoso.com"
     },
     {
-      "displayName":"contoso1",
-      "mail":"'contoso1@gmail.com",
-      "mailNickname":"contoso1_gmail.com#EXT#",
-      "proxyAddresses":["SMTP:contoso1@gmail.com"], 
-      "userPrincipalName":"contoso1_gmail.com#EXT#@microsoft.onmicrosoft.com"
+      "displayName":"contosoAdmin1",
+      "mail":"'contosoadmin1@gmail.com",
+      "mailNickname":"contosoadmin1_gmail.com#EXT#",
+      "proxyAddresses":["SMTP:contosoadmin1@gmail.com"], 
+      "userPrincipalName":"contosoadmin1_gmail.com#EXT#@microsoft.onmicrosoft.com"
     }
   ]
 }


### PR DESCRIPTION
Example (7) was incorrect. We do not match real contains in $search, we do a tokenized starts with.

displayName: ContosoAdmin1 is broken into: "ContosoAdmin1", "Contoso", "Admin" and "1". The input search string is also tokenized and we do a startswith match on each of these tokens.
This was reported in: https://stackoverflow.com/questions/70165966/microsoft-graph-api-search-function-doesnt-work-as-expected