### PR TITLE
add stub of POST /assignmentrequests to EM

### DIFF
--- a/api-reference/v1.0/api/entitlementmanagement-post-assignmentrequests.md
+++ b/api-reference/v1.0/api/entitlementmanagement-post-assignmentrequests.md
@@ -1,0 +1,109 @@
+---
+title: "Create accessPackageAssignmentRequest"
+description: "Create a new accessPackageAssignmentRequest."
+author: "markwahl-msft"
+ms.localizationpriority: medium
+ms.prod: "governance"
+doc_type: apiPageType
+---
+# Create accessPackageAssignmentRequest
+
+Namespace: microsoft.graph
+
+
+In [Azure AD Entitlement Management](../resources/entitlementmanagement-root.md), create a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.
+
+
+## Permissions
+
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+| Permission type                        | Permissions (from least to most privileged) |
+|:---------------------------------------|:--------------------------------------------|
+| Delegated (work or school account)     | EntitlementManagement.ReadWrite.All |
+| Delegated (personal Microsoft account) | Not supported. |
+| Application                            | EntitlementManagement.ReadWrite.All |
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+POST /identityGovernance/entitlementManagement/assignmentRequests
+```
+
+## Request headers
+
+| Name          | Description   |
+|:--------------|:--------------|
+| Authorization | Bearer \{token\}. Required. |
+| Content-Type  | application/json. Required. |
+
+## Request body
+
+In the request body, supply a JSON representation of [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object.
+
+For an administrator to request to remove an assignment, the value of the **requestType** property is `AdminRemove`, and the **assignment** property contains the **id** property identifying the [accessPackageAssignment](../resources/accesspackageassignment.md) being removed.
+
+## Response
+
+If successful, this method returns a 200-series response code and a new [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) object in the response body.
+
+## Examples
+
+### Example 1: Remove an assignment
+
+To remove assignments, create a new accessPackageAssignmentRequest object with the following settings:
+
++ The value of the **requestType** property set to `AdminRemove`.
++ In the assignment property, include an object with the identifier of the accessPackageAssignment object to delete.
+
+#### Request
+
+The following example shows how to remove an assignment.
+
+<!-- {
+  "blockType": "request",
+  "name": "create_accesspackageassignmentrequest_from_accesspackageassignmentrequests"
+}-->
+
+```http
+POST https://graph.microsoft.com/v1.0/identityGovernance/entitlementManagement/assignmentRequests
+Content-type: application/json
+
+{
+    "requestType": "AdminRemove",
+    "assignment":{
+     "id": "a6bb6942-3ae1-4259-9908-0133aaee9377"
+    }
+}
+```
+
+#### Response
+
+The following is an example of the response.
+
+> **Note:** The response object shown here might be shortened for readability. All the properties will be returned from an actual call.
+
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.accessPackageAssignmentRequest"
+} -->
+
+```http
+HTTP/1.1 201 Created
+Content-type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#accessPackageAssignmentRequests/$entity",
+
+    "id": "78eaee8c-e6cf-48c9-8f99-aae44c35e379",
+    "requestType": "AdminRemove",
+    "requestState": "Submitted",
+    "requestStatus": "Accepted"
+}
+```
+

--- a/api-reference/v1.0/resources/accesspackageassignmentrequest.md
+++ b/api-reference/v1.0/resources/accesspackageassignmentrequest.md
@@ -17,6 +17,7 @@ In [Azure AD Entitlement Management](entitlementmanagement-root.md), an access p
 |Method|Return type|Description|
 |:---|:---|:---|
 |[List accessPackageAssignmentRequests](../api/entitlementmanagement-list-assignmentrequests.md)|[accessPackageAssignmentRequest](accesspackageassignmentrequest.md) collection|Retrieve a list of **accesspackageassignmentrequest** objects. |
+| [Create accessPackageAssignmentRequest](../api/entitlementmanagement-post-assignmentrequests.md) | [accessPackageAssignmentRequest](accesspackageassignmentrequest.md) | Creates a new **accessPackageAssignmentRequest** object. |
 |[Get accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-get.md)|[accessPackageAssignmentRequest](accesspackageassignmentrequest.md)|Read properties and relationships of an **accessPackageAssignmentRequest** object. |
 |[Delete accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-delete.md)|None|Delete an **accessPackageAssignmentRequest**. |
 |[filterByCurrentUser](../api/accesspackageassignmentrequest-filterbycurrentuser.md)|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Retrieve the list of **accessPackageAssignmentRequest** objects filtered on the signed-in user.|

--- a/api-reference/v1.0/resources/entitlementmanagement-root.md
+++ b/api-reference/v1.0/resources/entitlementmanagement-root.md
@@ -43,6 +43,7 @@ The following table lists the methods that you can use to interact with entitlem
 | [Delete accessPackage](../api/accesspackage-delete.md) | | Delete **accessPackage**. |
 | [FilterByCurrentUser](../api/accesspackage-filterbycurrentuser.md) | [accessPackage](accesspackage.md) collection | Retrieve a list of **accessPackage** objects filtered on the signed-in user. |
 | [List accessPackageAssignmentRequests](../api/entitlementmanagement-list-assignmentrequests.md) | [accessPackageAssignmentRequest](accesspackageassignmentrequest.md) collection | Retrieve a list of **accessPackageAssignmentRequest** objects. |
+| [Create accessPackageAssignmentRequest](../api/entitlementmanagement-post-assignmentrequests.md) | [accessPackageAssignmentRequest](accesspackageassignmentrequest.md) | Creates a new **accessPackageAssignmentRequest** object. |
 | [Get accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-get.md) | [accessPackageAssignmentRequest](accesspackageassignmentrequest.md) | Read properties and relationships of an **accessPackageAssignmentRequest** object. |
 | [Delete accessPackageAssignmentRequest](../api/accesspackageassignmentrequest-delete.md) |None | Delete an **accessPackageAssignmentRequest**. |
 |[FilterByCurrentUser](../api/accesspackageassignmentrequest-filterbycurrentuser.md)|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Retrieve the list of **accessPackageAssignmentRequest** objects filtered on the signed-in user.|

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -5279,6 +5279,8 @@ items:
             items:
             - name: List
               href: api/entitlementmanagement-list-assignmentrequests.md
+            - name: Create
+              href: api/entitlementmanagement-post-assignmentrequests.md
             - name: Get
               href: api/accesspackageassignmentrequest-get.md
             - name: Delete

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -7,8 +7,8 @@
           "ApiChange": "Method",
           "ChangedApiName": "POST",
           "ChangeType": "Addition",
-          "Description": "Added support for creating an [access package assignment request](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-assignmentrequests).",
-          "Target": "entitlementmanagement"
+          "Description": "Added the [POST](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-assignmentrequests) operation to the [accessPackageAssignmentRequest](https://docs.microsoft.com/en-us/graph/api/resources/accesspackageassignmentrequest?view=graph-rest-1.0) resource. This operation allows adding, updating, and removing access package assignment requests by or on behalf of a user.",
+          "Target": "accessPackageAssignmentRequest"
         }
       ],
         "Id": "68e26d5b-6671-460f-9783-1139f53cc92c",

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -2,6 +2,24 @@
   "changelog": [
     {
       "ChangeList": [
+        { 
+          "Id": "68e26d5b-6671-460f-9783-1139f53cc92c",
+          "ApiChange": "Method",
+          "ChangedApiName": "POST",
+          "ChangeType": "Addition",
+          "Description": "Added support for creating an [access package assignment request](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-assignmentrequests).",
+          "Target": "entitlementmanagement"
+        }
+      ],
+        "Id": "68e26d5b-6671-460f-9783-1139f53cc92c",
+        "Cloud": "prd",
+        "Version": "v1.0",
+        "CreatedDateTime": "2021-12-03T00:00:00.000Z",
+        "WorkloadArea": "Identity and Access",
+        "SubArea": "Governance"
+    },
+    {
+      "ChangeList": [
         {
           "Id": "0bc50a14-e154-4dd9-b0d1-018477ff60e5",
           "ApiChange": "Resource",

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -14,7 +14,7 @@
         "Id": "68e26d5b-6671-460f-9783-1139f53cc92c",
         "Cloud": "prd",
         "Version": "v1.0",
-        "CreatedDateTime": "2021-12-03T00:00:00.000Z",
+        "CreatedDateTime": "2021-12-06T00:00:00.000Z",
         "WorkloadArea": "Identity and Access",
         "SubArea": "Governance"
     },


### PR DESCRIPTION
While being able to retrieve policies is necessary for a customer to be able to construct a valid payload to create an assignment request to add a new assignment, particularly AdminAdd, it is possible to at least use the AdminRemove path with the current assignment request API.  This PR adds the API definition and adds it to the relevant TOCs; a subsequent PR which lights up policy objects will also expand the description and examples of the API article.