### PR TITLE
Update externalconnectors-externalitem-create.md

### DIFF
--- a/api-reference/v1.0/api/externalconnectors-externalitem-create.md
+++ b/api-reference/v1.0/api/externalconnectors-externalitem-create.md
@@ -29,7 +29,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 ``` http
-POST /external/connections/{connectionsId}/items
+PUT /external/connections/{connection-id}/items/{item-id}
 ```
 
 ## Request headers


### PR DESCRIPTION
Fix for Missmatch between the request documentation and the http example #15125. 

The HTTP Request section was incorrect. It was defined as a POST but the method supported is actually PUT.