### PR TITLE
Update group-post-groups.md

### DIFF
--- a/api-reference/beta/api/group-post-groups.md
+++ b/api-reference/beta/api/group-post-groups.md
@@ -52,7 +52,7 @@ The following table shows the properties that are required when you create the [
 
 | Property | Type | Description|
 |:---------------|:--------|:----------|
-| displayName | string | The name to display in the address book for the group. Required. |
+| displayName | string | The name to display in the address book for the group. Maximum length is 64 characters. Required. |
 | mailEnabled | boolean | Set to `true` for mail-enabled groups. Required. |
 | mailNickname | string | The mail alias for the group, unique for Microsoft 365 groups in the organization. Maximum length is 64 characters. This property can contain only characters in the [ASCII character set 0 - 127](/office/vba/language/reference/user-interface-help/character-set-0127) except the following: ` @ () \ [] " ; : . <> , SPACE`. Required. |
 | securityEnabled | boolean | Set to `true` for security-enabled groups, including Microsoft 365 groups. Required. **Note:** Groups created using the Microsoft Azure portal always have **securityEnabled** initially set to `true`.|

--- a/api-reference/beta/api/group-post-groups.md
+++ b/api-reference/beta/api/group-post-groups.md
@@ -52,7 +52,7 @@ The following table shows the properties that are required when you create the [
 
 | Property | Type | Description|
 |:---------------|:--------|:----------|
-| displayName | string | The name to display in the address book for the group. Maximum length is 64 characters. Required. |
+| displayName | string | The name to display in the address book for the group. Maximum length is 256 characters. Required. |
 | mailEnabled | boolean | Set to `true` for mail-enabled groups. Required. |
 | mailNickname | string | The mail alias for the group, unique for Microsoft 365 groups in the organization. Maximum length is 64 characters. This property can contain only characters in the [ASCII character set 0 - 127](/office/vba/language/reference/user-interface-help/character-set-0127) except the following: ` @ () \ [] " ; : . <> , SPACE`. Required. |
 | securityEnabled | boolean | Set to `true` for security-enabled groups, including Microsoft 365 groups. Required. **Note:** Groups created using the Microsoft Azure portal always have **securityEnabled** initially set to `true`.|


### PR DESCRIPTION
Added missing maximum length description for the group displayName property. The same information is already available in the corresponding v1.0 topic.