### PR TITLE
Adding OrderBy Query Option to Chat.GetMessages Requests

### DIFF
--- a/api-reference/beta/api/chat-list-messages.md
+++ b/api-reference/beta/api/chat-list-messages.md
@@ -44,9 +44,9 @@ GET /chats/{chat-id}/messages
 ## Optional query parameters
 
 | Name      | Description          |
-|:----------|:--------|
-| [$top](/graph/query-parameters#top-parameter)      | Controls the number of items per response. Maximum allowed `$top` value is 50.  |
-| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
+|:----------|:---------------------|
+| [$top](/graph/query-parameters#top-parameter)| Controls the number of items per response. Maximum allowed `$top` value is 50. |
+| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime (default)** and **CreatedDateTime**. |
 
 The other [OData query parameters](/graph/query-parameters) are not currently supported.
 
@@ -68,7 +68,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 ### Request
 
-The following is an example of the request. `$top=2` is passed to retrieve two messages.
+The following is an example of the request. `$top=2` is passed to retrieve two messages and `$orderBy=createdDateTime` is passed to sort messages by createdDateTime.
 
 
 # [HTTP](#tab/http)
@@ -77,7 +77,7 @@ The following is an example of the request. `$top=2` is passed to retrieve two m
   "name": "get_allchatmessages_1"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/beta/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2
+GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$orderBy=createdDateTime
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-allchatmessages-1-csharp-snippets.md)]

--- a/api-reference/beta/api/chat-list-messages.md
+++ b/api-reference/beta/api/chat-list-messages.md
@@ -43,6 +43,8 @@ GET /chats/{chat-id}/messages
 
 ## Optional query parameters
 
+This method supports the following [OData query parameters](/graph/query-parameters).
+
 | Name      | Description          |
 |:----------|:---------------------|
 | [$top](/graph/query-parameters#top-parameter)| Controls the number of items per response. Maximum allowed `$top` value is 50. |

--- a/api-reference/beta/api/chat-list-messages.md
+++ b/api-reference/beta/api/chat-list-messages.md
@@ -43,7 +43,11 @@ GET /chats/{chat-id}/messages
 
 ## Optional query parameters
 
-You can use the [$top](/graph/query-parameters#top-parameter) query parameter to control the number of items per response. Maximum allowed `$top` value is 50.
+| Name      | Description          |
+|:----------|:--------|
+| [$top](/graph/query-parameters#top-parameter)      | Control the number of items per response. Maximum allowed `$top` value is 50.  |
+| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
+
 The other [OData query parameters](/graph/query-parameters) are not currently supported.
 
 ## Request headers

--- a/api-reference/beta/api/chat-list-messages.md
+++ b/api-reference/beta/api/chat-list-messages.md
@@ -79,7 +79,7 @@ The following is an example of the request. `$top=2` is passed to retrieve two m
   "name": "get_allchatmessages_1"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$orderBy=createdDateTime
+GET https://graph.microsoft.com/beta/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$orderBy=createdDateTime
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-allchatmessages-1-csharp-snippets.md)]

--- a/api-reference/beta/api/chat-list-messages.md
+++ b/api-reference/beta/api/chat-list-messages.md
@@ -45,7 +45,7 @@ GET /chats/{chat-id}/messages
 
 | Name      | Description          |
 |:----------|:--------|
-| [$top](/graph/query-parameters#top-parameter)      | Control the number of items per response. Maximum allowed `$top` value is 50.  |
+| [$top](/graph/query-parameters#top-parameter)      | Controls the number of items per response. Maximum allowed `$top` value is 50.  |
 | [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
 
 The other [OData query parameters](/graph/query-parameters) are not currently supported.

--- a/api-reference/v1.0/api/chat-list-messages.md
+++ b/api-reference/v1.0/api/chat-list-messages.md
@@ -39,11 +39,7 @@ GET /chats/{chat-id}/messages
 
 ## Optional query parameters
 
-| Name      | Description          |
-|:----------|:---------------------|
-| [$top](/graph/query-parameters#top-parameter)| Controls the number of items per response. Maximum allowed `$top` value is 50. |
-| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime (default)** and **CreatedDateTime**. |
-
+You can use the [$top](/graph/query-parameters#top-parameter) query parameter to control the number of items per response. Maximum allowed `$top` value is 50.
 The other [OData query parameters](/graph/query-parameters) are not currently supported.
 
 ## Request headers
@@ -66,7 +62,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 #### Request
 
-The following is an example of the request. `$top=2` is passed to retrieve two messages and `$orderBy=createdDateTime` is passed to sort messages by createdDateTime.
+The following is an example of the request. `$top=2` is passed to retrieve two messages.
 
 
 # [HTTP](#tab/http)
@@ -75,7 +71,7 @@ The following is an example of the request. `$top=2` is passed to retrieve two m
   "name": "get_allchatmessages_1"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$orderBy=createdDateTime
+GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-allchatmessages-1-csharp-snippets.md)]

--- a/api-reference/v1.0/api/chat-list-messages.md
+++ b/api-reference/v1.0/api/chat-list-messages.md
@@ -41,7 +41,7 @@ GET /chats/{chat-id}/messages
 
 | Name      | Description          |
 |:----------|:--------|
-| [$top](/graph/query-parameters#top-parameter)      | Control the number of items per response. Maximum allowed `$top` value is 50.  |
+| [$top](/graph/query-parameters#top-parameter)      | Controls the number of items per response. Maximum allowed `$top` value is 50.  |
 | [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
 
 The other [OData query parameters](/graph/query-parameters) are not currently supported.

--- a/api-reference/v1.0/api/chat-list-messages.md
+++ b/api-reference/v1.0/api/chat-list-messages.md
@@ -39,7 +39,11 @@ GET /chats/{chat-id}/messages
 
 ## Optional query parameters
 
-You can use the [$top](/graph/query-parameters#top-parameter) query parameter to control the number of items per response. Maximum allowed `$top` value is 50.
+| Name      | Description          |
+|:----------|:--------|
+| [$top](/graph/query-parameters#top-parameter)      | Control the number of items per response. Maximum allowed `$top` value is 50.  |
+| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
+
 The other [OData query parameters](/graph/query-parameters) are not currently supported.
 
 ## Request headers

--- a/api-reference/v1.0/api/chat-list-messages.md
+++ b/api-reference/v1.0/api/chat-list-messages.md
@@ -40,9 +40,9 @@ GET /chats/{chat-id}/messages
 ## Optional query parameters
 
 | Name      | Description          |
-|:----------|:--------|
-| [$top](/graph/query-parameters#top-parameter)      | Controls the number of items per response. Maximum allowed `$top` value is 50.  |
-| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime** and **CreatedDateTime**.|
+|:----------|:---------------------|
+| [$top](/graph/query-parameters#top-parameter)| Controls the number of items per response. Maximum allowed `$top` value is 50. |
+| [$orderBy](/graph/query-parameters#orderBy)  | Currently supports **LastModifiedDateTime (default)** and **CreatedDateTime**. |
 
 The other [OData query parameters](/graph/query-parameters) are not currently supported.
 
@@ -66,7 +66,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 
 #### Request
 
-The following is an example of the request. `$top=2` is passed to retrieve two messages.
+The following is an example of the request. `$top=2` is passed to retrieve two messages and `$orderBy=createdDateTime` is passed to sort messages by createdDateTime.
 
 
 # [HTTP](#tab/http)
@@ -75,7 +75,7 @@ The following is an example of the request. `$top=2` is passed to retrieve two m
   "name": "get_allchatmessages_1"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2
+GET https://graph.microsoft.com/v1.0/chats/19:2da4c29f6d7041eca70b638b43d45437@thread.v2/messages?$top=2&$orderBy=createdDateTime
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/get-allchatmessages-1-csharp-snippets.md)]

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4,24 +4,6 @@
     {
       "ChangeList": [
         {
-          "Id": "fd86ec36-9304-48d5-9e92-b7e2415be80e",
-          "ApiChange": "Property",
-          "ChangedApiName": "OrderBy",
-          "ChangeType": "Addition",
-          "Description": "OrderBy query option has been enabled to allow users to choose sorting order between LastModifiedDateTime and CreatedDateTime when retreiving chat messages.",
-          "Target": "chat"
-        }
-      ],
-      "Id": "fd86ec36-9304-48d5-9e92-b7e2415be80e",
-      "Cloud": "prd",
-      "Version": "v1.0",
-      "CreatedDateTime": "2022-01-04T13:04:49.407Z",
-      "WorkloadArea": "Teamwork",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
           "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",
           "ApiChange": "Property",
           "ChangedApiName": "OrderBy",

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -5,8 +5,8 @@
       "ChangeList": [
         {
           "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",
-          "ApiChange": "Property",
-          "ChangedApiName": "OrderBy",
+          "ApiChange": "queryOption",
+          "ChangedApiName": "chatMessage",
           "ChangeType": "Addition",
           "Description": "OrderBy query option has been enabled to allow users to choose sorting order between LastModifiedDateTime and CreatedDateTime when retreiving chat messages.",
           "Target": "chat"

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -2,7 +2,43 @@
 
   "changelog": [
     {
-      "ChangeList":[
+      "ChangeList": [
+        {
+          "Id": "fd86ec36-9304-48d5-9e92-b7e2415be80e",
+          "ApiChange": "Property",
+          "ChangedApiName": "OrderBy",
+          "ChangeType": "Addition",
+          "Description": "OrderBy query option has been enabled to allow users to choose sorting order between LastModifiedDateTime and CreatedDateTime when retreiving chat messages.",
+          "Target": "chat"
+        }
+      ],
+      "Id": "fd86ec36-9304-48d5-9e92-b7e2415be80e",
+      "Cloud": "prd",
+      "Version": "v1.0",
+      "CreatedDateTime": "2022-01-04T13:04:49.407Z",
+      "WorkloadArea": "Teamwork",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",
+          "ApiChange": "Property",
+          "ChangedApiName": "OrderBy",
+          "ChangeType": "Addition",
+          "Description": "OrderBy query option has been enabled to allow users to choose sorting order between LastModifiedDateTime and CreatedDateTime when retreiving chat messages.",
+          "Target": "chat"
+        }
+      ],
+      "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2022-01-04T13:04:49.407Z",
+      "WorkloadArea": "Teamwork",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
         {
           "Id": "659f7727-40cf-4616-92ea-56d9950d8588",
           "ApiChange": "Property",

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -5,11 +5,11 @@
       "ChangeList": [
         {
           "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",
-          "ApiChange": "queryOption",
-          "ChangedApiName": "chatMessage",
+          "ApiChange": "Parameter",
+          "ChangedApiName": "LIST",
           "ChangeType": "Addition",
           "Description": "OrderBy query option has been enabled to allow users to choose sorting order between LastModifiedDateTime and CreatedDateTime when retreiving chat messages.",
-          "Target": "chat"
+          "Target": "chatMessage"
         }
       ],
       "Id": "ebf148a1-9b8d-4c5b-80db-8476f0aa6264",


### PR DESCRIPTION
Updating Documentations/Change logs for Enabling new Query Option, OrderBy, when handling Chat.GetMessages Requests.
Users will be allowed to sort chat messages in order of LastModifiedDateTime or CreatedDateTime.
