### PR TITLE
Remove the mention of 'size' in the GET /team/{id}/photo API docs since it's unsupported.

### DIFF
--- a/api-reference/beta/api/team-get-photo.md
+++ b/api-reference/beta/api/team-get-photo.md
@@ -13,16 +13,9 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Get the photo (picture) for a team, or metadata for the photo. In general, it is a best practice to first attempt to retrieve the metadata for the size of the photo you'd like to get to ensure that size is available. Once you have retrieved the metadata, use the `/$value` path to get the binary data for the photo.
+Get the photo (picture) for a team, or metadata for the photo.
 
 This method first attempts to retrieve the specified photo from Microsoft 365. If the photo is not available in Microsoft 365, it attempts to retrieve the photo from Azure Active Directory instead.
-
-The following are the supported sizes of HD photos in Microsoft 365: 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648 pixels. Photos can be any dimension if they are stored in Azure Active Directory.
-
-You can get the metadata of the largest available photo, or optionally specify a size to get the metadata for that photo size. If the size you request is not available, you can still get a smaller size. For example, if the largest photo uploaded is 504x504 pixels, all but the 648x648 size of the photo will be available for download. If the specified size is not available in the Microsoft 365 or in Azure Active Directory, the size 1x1 is returned with the rest of the metadata.
-
-> [!Note]
-> There is a limit of 4 MB on the total size of the REST request. This limits the photo size to less than 4 MB.
 
 ## Permissions
 
@@ -42,7 +35,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ### Get the metadata of the photo
 
-This endpoint will return the metadata of the photo. If no size is specified, the metadata for the largest photo size available will be returned.
+This endpoint will return the metadata of the photo.
 
 <!-- {
   "blockType": "ignored"
@@ -50,12 +43,11 @@ This endpoint will return the metadata of the photo. If no size is specified, th
 
 ```http
 GET /teams/{id}/photo
-GET /teams/{id}/photo/{size}
 ```
 
 ### Get the photo
 
-This endpoint will retrieve the binary data for the photo. If no size is specified, the largest size available will be returned.
+This endpoint will retrieve the binary data for the photo.
 
 <!-- {
   "blockType": "ignored"
@@ -63,16 +55,7 @@ This endpoint will retrieve the binary data for the photo. If no size is specifi
 
 ```http
 GET /beta/teams/{id}/photo/$value
-GET /beta/teams/{id}/photo/{size}/$value
 ```
-
-## Path parameters
-
-This method supports an optional path parameter to specify the size of the photo to be retrieved. You can specify any size up to the largest available size. Get the photo metadata to determine the largest size available.
-
-|**Parameter**|**Type**|**Description**|
-|:-----|:-----|:-----|
-|size  |String  | A photo size. The supported sizes of HD photos on Microsoft 365 are as follows: 48x48, 64x64, 96x96, 120x120, 240x240, 360x360, 432x432, 504x504, and 648x648. Photos can be any dimension if they are stored in Azure Active Directory. Optional.|
 
 ## Request headers
 
@@ -135,9 +118,9 @@ Content-type: application/json
 }
 ```
 
-### Example 2: Get a specific size of the team photo
+### Example 2: Get the team photo's binary data
 
-Here is an example of the request to get the team photo in a specific size.
+Here is an example of the request to get the team photo's binary data.
 
 #### Request
 
@@ -146,12 +129,12 @@ Here is an example of the request to get the team photo in a specific size.
   "name": "get_team_photo"
 }-->
 ```http
-GET https://graph.microsoft.com/beta/teams/{id}/photo/240x240/$value
+GET https://graph.microsoft.com/beta/teams/{id}/photo/$value
 ```
 
 #### Response
 
-Contains the binary data of the requested 240x240 photo. The HTTP response code is 200.
+Contains the binary data of the requested photo. The HTTP response code is 200.
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2015-10-25 14:57:30 UTC -->


### PR DESCRIPTION
Remove the mention of 'size' in the GET /team/{id}/photo API docs since it's unsupported.