### PR TITLE
Corrected scope name for Microsoft Graph

### DIFF
--- a/concepts/permissions-reference.md
+++ b/concepts/permissions-reference.md
@@ -1745,7 +1745,7 @@ For more complex scenarios involving multiple permissions, see [Permission scena
 ### Remarks
 
 > [!CAUTION]
-> Permissions that allow granting authorization, such as _RoleManagement.ReadWrite.All_, allow an application to grant itself, other applications, or any user, additional privileges. Use caution when granting any of these permissions.
+> Permissions that allow granting authorization, such as _RoleManagement.ReadWrite.Directory_, allow an application to grant itself, other applications, or any user, additional privileges. Use caution when granting any of these permissions.
 
 With the _RoleManagement.Read.Directory_ permission an application can read directoryRoles and directoryRoleTemplates. This includes reading membership information for directory roles.
 


### PR DESCRIPTION
As far as I know, there is no Graph scope named 'RoleManagement.ReadWrite.All', not many hits on Google for this value - I only found two articles on docs.microsoft.com and I'm submitting a PR for both of them.

I believe the correct scope name is 'RoleManagement.ReadWrite.Directory'

#ATCP