### PR TITLE
Update resourceaccess.md

### DIFF
--- a/api-reference/v1.0/resources/resourceaccess.md
+++ b/api-reference/v1.0/resources/resourceaccess.md
@@ -17,7 +17,7 @@ Object used to specify an OAuth 2.0 permission scope or an app role that an appl
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
 |id|GUID|The unique identifier for one of the [oauth2PermissionScopes](permissionscope.md) or [appRole](approle.md) instances that the resource application exposes.|
-|type|String|Specifies whether the **id** property references an [oauth2PermissionScopes](permissionscope.md) or an [appRole](approle.md). The possible values are: `Scope` (for OAuth 2.0 permission scopes) or `Role` (for app roles).|
+|type|String|Specifies whether the **id** property references an [oauth2PermissionScope](permissionscope.md) or an [appRole](approle.md). The possible values are: `Scope` (for OAuth 2.0 permission scopes) or `Role` (for app roles).|
 
 ## JSON representation
 

--- a/api-reference/v1.0/resources/resourceaccess.md
+++ b/api-reference/v1.0/resources/resourceaccess.md
@@ -16,8 +16,8 @@ Object used to specify an OAuth 2.0 permission scope or an app role that an appl
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|id|GUID|The unique identifier for one of the [oauth2PermissionScope](permissionscope.md) or [appRole](approle.md) instances that the resource application exposes.|
-|type|String|Specifies whether the **id** property references an [oauth2PermissionScope](permissionscope.md) or an [appRole](approle.md). The possible values are: `Scope` (for OAuth 2.0 permission scopes) or `Role` (for app roles).|
+|id|Guid|The unique identifier of an [app role](approle.md) or [delegated permission](permissionScope.md) exposed by the resource application. For delegated permissions, this should match the **id** property of one of the [delegated permissions](permissionscope.md) in the **oauth2PermissionScopes** collection of the resource application's [service principal](serviceprincipal.md). For app roles (application permissions), this should match the **id** property of an [app role](approle.md) in the **appRoles** collection of the resource application's [service principal](serviceprincipal.md).|
+|type|String|Specifies whether the **id** property references a [delegated permission](permissionscope.md) or an [app role](approle.md) (application permission). The possible values are: `Scope` (for delegated permissions) or `Role` (for app roles).|
 
 ## JSON representation
 

--- a/api-reference/v1.0/resources/resourceaccess.md
+++ b/api-reference/v1.0/resources/resourceaccess.md
@@ -16,7 +16,7 @@ Object used to specify an OAuth 2.0 permission scope or an app role that an appl
 ## Properties
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|id|GUID|The unique identifier for one of the [oauth2PermissionScopes](permissionscope.md) or [appRole](approle.md) instances that the resource application exposes.|
+|id|GUID|The unique identifier for one of the [oauth2PermissionScope](permissionscope.md) or [appRole](approle.md) instances that the resource application exposes.|
 |type|String|Specifies whether the **id** property references an [oauth2PermissionScope](permissionscope.md) or an [appRole](approle.md). The possible values are: `Scope` (for OAuth 2.0 permission scopes) or `Role` (for app roles).|
 
 ## JSON representation


### PR DESCRIPTION
Update https://docs.microsoft.com/en-us/graph/api/resources/resourceaccess?view=graph-rest-1.0

Per https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0, `appRoles` property contains `appRole` collection:

![image](https://user-images.githubusercontent.com/4003950/149506049-04894f40-f21a-4598-ae4d-7ea9d489bdb1.png)

so `oauth2PermissionScope` should also use its singular form.