### PR TITLE
Add Certificate Based Authentication APIs, resources, and changelog

### DIFF
--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
@@ -1,7 +1,7 @@
 ---
 title: "Disable x509CertificateAuthenticationMethodConfiguration"
 description: "Disable a x509CertificateAuthenticationMethodConfiguration object and restores all the other properties to their default settings"
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: apiPageType

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
@@ -61,22 +61,6 @@ If successful, this method returns a `204 No Content` response code.
 ``` http
 DELETE https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
 ```
-# [C#](#tab/csharp)
-[!INCLUDE [sample-code](../includes/snippets/csharp/delete-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/delete-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Objective-C](#tab/objc)
-[!INCLUDE [sample-code](../includes/snippets/objc/delete-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Java](#tab/java)
-[!INCLUDE [sample-code](../includes/snippets/java/delete-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 
 ### Response
 >**Note:** The response object shown here might be shortened for readability.

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
@@ -1,18 +1,18 @@
 ---
-title: "Delete x509CertificateAuthenticationMethodConfiguration"
-description: "Deletes a x509CertificateAuthenticationMethodConfiguration object."
+title: "Disable x509CertificateAuthenticationMethodConfiguration"
+description: "Disable a x509CertificateAuthenticationMethodConfiguration object and restores all the other properties to their default settings"
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: apiPageType
 ---
 
-# Delete x509CertificateAuthenticationMethodConfiguration
+# Disable x509CertificateAuthenticationMethodConfiguration
 Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Deletes a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+Disable and restore the [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object to its default configuration.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -63,7 +63,6 @@ DELETE https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/aut
 ```
 
 ### Response
->**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
@@ -1,0 +1,91 @@
+---
+title: "Delete x509CertificateAuthenticationMethodConfiguration"
+description: "Deletes a x509CertificateAuthenticationMethodConfiguration object."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: apiPageType
+---
+
+# Delete x509CertificateAuthenticationMethodConfiguration
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Deletes a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+|Permission type|Permissions (from least to most privileged)|
+|:---|:---|
+|Delegated (work or school account)|Policy.ReadWrite.AuthenticationMethod|
+|Delegated (personal Microsoft account)|Not supported.|
+|Application|Not supported.|
+
+For delegated scenarios, the administrator needs one of the following [Azure AD roles](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#available-roles):
+
+* Authentication Policy Administrator
+* Global Administrator
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+DELETE /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+```
+
+## Request headers
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required.|
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `204 No Content` response code.
+
+## Examples
+
+### Request
+<!-- {
+  "blockType": "request",
+  "name": "delete_x509certificateauthenticationmethodconfiguration"
+}
+-->
+``` http
+DELETE https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+```
+# [C#](#tab/csharp)
+[!INCLUDE [sample-code](../includes/snippets/csharp/delete-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [JavaScript](#tab/javascript)
+[!INCLUDE [sample-code](../includes/snippets/javascript/delete-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Objective-C](#tab/objc)
+[!INCLUDE [sample-code](../includes/snippets/objc/delete-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Java](#tab/java)
+[!INCLUDE [sample-code](../includes/snippets/java/delete-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+
+### Response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true
+}
+-->
+``` http
+HTTP/1.1 204 No Content
+```
+

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-delete.md
@@ -1,18 +1,18 @@
 ---
-title: "Disable x509CertificateAuthenticationMethodConfiguration"
-description: "Disable a x509CertificateAuthenticationMethodConfiguration object and restores all the other properties to their default settings"
+title: "Delete x509CertificateAuthenticationMethodConfiguration"
+description: "Delete a x509CertificateAuthenticationMethodConfiguration object and restores all the other properties to their default settings"
 author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: apiPageType
 ---
 
-# Disable x509CertificateAuthenticationMethodConfiguration
+# Delete x509CertificateAuthenticationMethodConfiguration
 Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Disable and restore the [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object to its default configuration.
+Restore the [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object to its default configuration.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
@@ -1,7 +1,7 @@
 ---
 title: "Get x509CertificateAuthenticationMethodConfiguration"
 description: "Read the properties and relationships of a x509CertificateAuthenticationMethodConfiguration object."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: apiPageType

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
@@ -12,7 +12,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Read the properties and relationships of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+Read the configuration details for the [X.509 certificate authentication method](../resources/x509certificateauthenticationmethodconfiguration.md) in the [authentication methods policy](../resources/authenticationmethodspolicy.md).
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -40,7 +40,7 @@ GET /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x50
 ```
 
 ## Optional query parameters
-This method supports some of the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+This method does not support the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
 
 ## Request headers
 |Name|Description|
@@ -79,19 +79,29 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "value": {
-    "@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
-    "id": "16c76b20-d9da-0fc9-c1ac-3fdb602db203",
-    "state": "String",
-    "certificateUserBindings": [
-      {
-        "@odata.type": "microsoft.graph.x509CertificateUserBinding"
-      }
-    ],
-    "authenticationModeConfiguration": {
-      "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
-    }
-  }
+	"@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+	"id": "X509Certificate",
+	"state": "disabled",
+	"certificateUserBindings": [{
+			"x509CertificateField": "PrincipalName",
+			"userProperty": "onPremisesUserPrincipalName",
+			"priority": 1
+		},
+		{
+			"x509CertificateField": "RFC822Name",
+			"userProperty": "userPrincipalName",
+			"priority": 2
+		}
+	],
+	"authenticationModeConfiguration": {
+		"x509CertificateAuthenticationDefaultMode": "x509CertificateSingleFactor",
+		"rules": []
+	},
+	"includeTargets": [{
+		"targetType": "group",
+		"id": "all_users",
+		"isRegistrationRequired": false
+	}]
 }
 ```
 

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
@@ -65,22 +65,6 @@ If successful, this method returns a `200 OK` response code and a [x509Certifica
 ``` http
 GET https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
 ```
-# [C#](#tab/csharp)
-[!INCLUDE [sample-code](../includes/snippets/csharp/get-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/get-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Objective-C](#tab/objc)
-[!INCLUDE [sample-code](../includes/snippets/objc/get-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Java](#tab/java)
-[!INCLUDE [sample-code](../includes/snippets/java/get-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 
 ### Response
 >**Note:** The response object shown here might be shortened for readability.

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-get.md
@@ -1,0 +1,113 @@
+---
+title: "Get x509CertificateAuthenticationMethodConfiguration"
+description: "Read the properties and relationships of a x509CertificateAuthenticationMethodConfiguration object."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: apiPageType
+---
+
+# Get x509CertificateAuthenticationMethodConfiguration
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Read the properties and relationships of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+|Permission type|Permissions (from least to most privileged)|
+|:---|:---|
+|Delegated (work or school account)|Policy.ReadWrite.AuthenticationMethod|
+|Delegated (personal Microsoft account)|Not supported.|
+|Application|Not supported.|
+
+For delegated scenarios, the administrator needs one of the following [Azure AD roles](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#available-roles):
+
+* Global Reader
+* Authentication Policy Administrator
+* Global Administrator
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+GET /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+```
+
+## Optional query parameters
+This method supports some of the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+
+## Request headers
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required.|
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object in the response body.
+
+## Examples
+
+### Request
+<!-- {
+  "blockType": "request",
+  "name": "get_x509certificateauthenticationmethodconfiguration"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+```
+# [C#](#tab/csharp)
+[!INCLUDE [sample-code](../includes/snippets/csharp/get-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [JavaScript](#tab/javascript)
+[!INCLUDE [sample-code](../includes/snippets/javascript/get-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Objective-C](#tab/objc)
+[!INCLUDE [sample-code](../includes/snippets/objc/get-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Java](#tab/java)
+[!INCLUDE [sample-code](../includes/snippets/java/get-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+
+### Response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.x509CertificateAuthenticationMethodConfiguration"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "value": {
+    "@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+    "id": "16c76b20-d9da-0fc9-c1ac-3fdb602db203",
+    "state": "String",
+    "certificateUserBindings": [
+      {
+        "@odata.type": "microsoft.graph.x509CertificateUserBinding"
+      }
+    ],
+    "authenticationModeConfiguration": {
+      "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
+    }
+  }
+}
+```
+

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -1,0 +1,113 @@
+---
+title: "Update x509CertificateAuthenticationMethodConfiguration"
+description: "Update the properties of a x509CertificateAuthenticationMethodConfiguration object."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: apiPageType
+---
+
+# Update x509CertificateAuthenticationMethodConfiguration
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Update the properties of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+|Permission type|Permissions (from least to most privileged)|
+|:---|:---|
+|Delegated (work or school account)|Policy.ReadWrite.AuthenticationMethod|
+|Delegated (personal Microsoft account)|Not supported.|
+|Application|Not supported.|
+
+For delegated scenarios, the administrator needs one of the following [Azure AD roles](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#available-roles):
+
+* Authentication Policy Administrator
+* Global Administrator
+
+## HTTP request
+
+<!-- {
+  "blockType": "ignored"
+}
+-->
+``` http
+PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+```
+
+## Request headers
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required.|
+|Content-Type|application/json. Required.|
+
+## Request body
+In the request body, supply a JSON representation of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509CertificateAuthenticationMethodConfiguration.md) object with the values of fields that should be updated. Existing properties that are not included in the request body will maintain their previous values or be recalculated based on changes to other property values. For best performance, don't include existing values that haven't changed.
+
+For the list of properties that can be updated, see [x509CertificateAuthenticationMethodConfiguration](../resources/x509CertificateAuthenticationMethodConfiguration.md).
+
+>**Note:** The `@odata.type` property with a value of `#microsoft.graph.x509CertificateAuthenticationMethodConfiguration` must be included in the body.
+
+
+## Response
+
+If successful, this method returns a `204 No Content` response code and an updated [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object in the response body.
+
+## Examples
+
+### Request
+<!-- {
+  "blockType": "request",
+  "name": "update_x509certificateauthenticationmethodconfiguration"
+}
+-->
+``` http
+PATCH https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
+Content-Type: application/json
+Content-length: 362
+
+{
+  "@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+  "state": "String",
+  "certificateUserBindings": [
+    {
+      "@odata.type": "microsoft.graph.x509CertificateUserBinding"
+    }
+  ],
+  "authenticationModeConfiguration": {
+    "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
+  }
+}
+```
+# [C#](#tab/csharp)
+[!INCLUDE [sample-code](../includes/snippets/csharp/update-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [JavaScript](#tab/javascript)
+[!INCLUDE [sample-code](../includes/snippets/javascript/update-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Objective-C](#tab/objc)
+[!INCLUDE [sample-code](../includes/snippets/objc/update-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Java](#tab/java)
+[!INCLUDE [sample-code](../includes/snippets/java/update-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+
+### Response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true
+}
+-->
+``` http
+HTTP/1.1 204 No Content
+Content-Type: application/json
+```
+

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -101,7 +101,7 @@ Content-Type: application/json
 ```
 
 ### Response
->**Note:** The response object shown here might be shortened for readability.
+
 <!-- {
   "blockType": "response",
   "truncated": true

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -82,22 +82,6 @@ Content-length: 362
   }
 }
 ```
-# [C#](#tab/csharp)
-[!INCLUDE [sample-code](../includes/snippets/csharp/update-x509Certificateauthenticationmethodconfiguration-csharp-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/update-x509Certificateauthenticationmethodconfiguration-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Objective-C](#tab/objc)
-[!INCLUDE [sample-code](../includes/snippets/objc/update-x509Certificateauthenticationmethodconfiguration-objc-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Java](#tab/java)
-[!INCLUDE [sample-code](../includes/snippets/java/update-x509Certificateauthenticationmethodconfiguration-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
 
 ### Response
 >**Note:** The response object shown here might be shortened for readability.

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -12,7 +12,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Update the properties of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md) object.
+Update the properties of the [X.509 certificate authentication method](../resources/x509certificateauthenticationmethodconfiguration.md).
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -45,9 +45,13 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x
 |Content-Type|application/json. Required.|
 
 ## Request body
-In the request body, supply a JSON representation of a [x509CertificateAuthenticationMethodConfiguration](../resources/x509CertificateAuthenticationMethodConfiguration.md) object with the values of fields that should be updated. Existing properties that are not included in the request body will maintain their previous values or be recalculated based on changes to other property values. For best performance, don't include existing values that haven't changed.
-
-For the list of properties that can be updated, see [x509CertificateAuthenticationMethodConfiguration](../resources/x509CertificateAuthenticationMethodConfiguration.md).
+[!INCLUDE [table-intro](../../includes/update-property-table-intro.md)]
+The following properties can be updated.
+|Property|Type|Description|
+|:---|:---|:---|
+|state|authenticationMethodState|The possible values are: `enabled`, `disabled`. Inherited from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).|
+|certificateUserBindings|[x509CertificateUserBinding](../resources/x509certificateuserbinding.md) collection|Defines fields in the X.509 certificate that map to attributes of the Azure AD user object in order to bind the certificate to the user. The **priority** of the object determines the order in which the binding is carried out. The first binding that matches will be used and the rest ignored. |
+|authenticationModeConfiguration|[x509CertificateAuthenticationModeConfiguration](../resources/x509certificateauthenticationmodeconfiguration.md)|Defines strong authentication configurations. This configuration includes the default authentication mode and the different rules for strong authentication bindings. |
 
 >**Note:** The `@odata.type` property with a value of `#microsoft.graph.x509CertificateAuthenticationMethodConfiguration` must be included in the body.
 
@@ -67,19 +71,31 @@ If successful, this method returns a `204 No Content` response code and an updat
 ``` http
 PATCH https://graph.microsoft.com/beta/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x509Certificate
 Content-Type: application/json
-Content-length: 362
 
 {
-  "@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
-  "state": "String",
-  "certificateUserBindings": [
-    {
-      "@odata.type": "microsoft.graph.x509CertificateUserBinding"
-    }
-  ],
-  "authenticationModeConfiguration": {
-    "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
-  }
+	"@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+	"id": "X509Certificate",
+	"state": "disabled",
+	"certificateUserBindings": [{
+			"x509CertificateField": "PrincipalName",
+			"userProperty": "onPremisesUserPrincipalName",
+			"priority": 1
+		},
+		{
+			"x509CertificateField": "RFC822Name",
+			"userProperty": "userPrincipalName",
+			"priority": 2
+		}
+	],
+	"authenticationModeConfiguration": {
+		"x509CertificateAuthenticationDefaultMode": "x509CertificateSingleFactor",
+		"rules": []
+	},
+	"includeTargets": [{
+		"targetType": "group",
+		"id": "all_users",
+		"isRegistrationRequired": false
+	}]
 }
 ```
 

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -1,7 +1,7 @@
 ---
 title: "Update x509CertificateAuthenticationMethodConfiguration"
 description: "Update the properties of a x509CertificateAuthenticationMethodConfiguration object."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: apiPageType

--- a/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
+++ b/api-reference/beta/api/x509certificateauthenticationmethodconfiguration-update.md
@@ -47,6 +47,7 @@ PATCH /policies/authenticationMethodsPolicy/authenticationMethodConfigurations/x
 ## Request body
 [!INCLUDE [table-intro](../../includes/update-property-table-intro.md)]
 The following properties can be updated.
+
 |Property|Type|Description|
 |:---|:---|:---|
 |state|authenticationMethodState|The possible values are: `enabled`, `disabled`. Inherited from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).|

--- a/api-reference/beta/resources/authenticationmethodspolicies-overview.md
+++ b/api-reference/beta/resources/authenticationmethodspolicies-overview.md
@@ -31,7 +31,7 @@ The authentication method policies APIs are used to manage policy settings. For 
 |[emailauthenticationmethodconfiguration](emailauthenticationmethodconfiguration.md)|Define users who can use email OTP on the Azure AD tenant.|
 |[passwordlessmicrosoftauthenticatorauthenticationmethodconfiguration](passwordlessmicrosoftauthenticatorauthenticationmethodconfiguration.md) (deprecated)|Define users who can use Passwordless Phone Sign-in to sign in to Azure AD.|
 |[temporaryaccesspassauthenticationmethodconfiguration](temporaryaccesspassauthenticationmethodconfiguration.md)|Define users who can use Temporary Access Pass to sign in to Azure AD.|
-|[x509CertificateAuthenticationMethodConfiguration](x509CertificateAuthenticationMethodConfiguration.md)|Define users who can use X.509 certiificate to sign in to Azure AD.|
+|[x509CertificateAuthenticationMethodConfiguration](x509CertificateAuthenticationMethodConfiguration.md)|Define users who can use X.509 certificate to sign in to Azure AD.|
 
 ## Policies available to push users to set up authentication methods:
 |Policy       | Description |

--- a/api-reference/beta/resources/authenticationmethodspolicies-overview.md
+++ b/api-reference/beta/resources/authenticationmethodspolicies-overview.md
@@ -31,6 +31,7 @@ The authentication method policies APIs are used to manage policy settings. For 
 |[emailauthenticationmethodconfiguration](emailauthenticationmethodconfiguration.md)|Define users who can use email OTP on the Azure AD tenant.|
 |[passwordlessmicrosoftauthenticatorauthenticationmethodconfiguration](passwordlessmicrosoftauthenticatorauthenticationmethodconfiguration.md) (deprecated)|Define users who can use Passwordless Phone Sign-in to sign in to Azure AD.|
 |[temporaryaccesspassauthenticationmethodconfiguration](temporaryaccesspassauthenticationmethodconfiguration.md)|Define users who can use Temporary Access Pass to sign in to Azure AD.|
+|[x509CertificateAuthenticationMethodConfiguration](x509CertificateAuthenticationMethodConfiguration.md)|Define users who can use X.509 certiificate to sign in to Azure AD.|
 
 ## Policies available to push users to set up authentication methods:
 |Policy       | Description |

--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -923,6 +923,20 @@ Namespace: microsoft.graph
 |block|
 |unknownFutureValue|
 
+### x509CertificateAuthenticationMode values
+|Member|
+|:---|
+|x509CertificateSingleFactor|
+|x509CertificateMultiFactor|
+|unknownFutureValue|
+
+### x509CertificateRuleType values
+|Member|
+|:---|
+|issuerSubject|
+|policyOID|
+|unknownFutureValue|
+
 ### anniversaryType values
 
 |Member|

--- a/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
@@ -1,6 +1,6 @@
 ---
 title: "x509CertificateAuthenticationMethodConfiguration resource type"
-description: "A configuration entity that represents whether Azure AD native Certificate Based Authentication is enabled or disabled for the tenant and which users and groups can register and use it. (The id is 'Certificate')"
+description: "Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it."
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-A configuration entity that represents whether Azure AD native Certificate Based Authentication is enabled or disabled for the tenant and which users and groups can register and use it.
+Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it
 
 Inherits from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).
 
@@ -22,17 +22,16 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 |:---|:---|:---|
 |[Get x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-get.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Read the properties and relationships of a x509CertificateAuthenticationMethodConfiguration object.|
 |[Update x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-update.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Update the properties of a x509CertificateAuthenticationMethodConfiguration object.|
-|[Delete x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-delete.md)|None|Reverts the x509CertificateAuthenticationMethodConfiguration object to its default configuration.|
+|[Disable x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-delete.md)|None|Disables and restores the x509CertificateAuthenticationMethodConfiguration object to its default configuration.|
 
 
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|id|String|The authentication method policy identifier.|
-|state|authenticationMethodState|Possible values are: `enabled`, `disabled`.|
-|certificateUserBindings|[x509CertificateUserBinding](../resources/x509certificateuserbinding.md) collection|Controls which X.509 cert fields map to which directory user object attributes to bind the certificate to the user.  Order is significant.  The first binding that matches will be used and the rest ignored. |
-|authenticationModeConfiguration|[x509CertificateAuthenticationModeConfiguration](../resources/x509certificateauthenticationmodeconfiguration.md)|Defines strong auth configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings. |
-
+|id|String|The identifier for the authentication method policy. The value is always `X509Certificate`. Inherited from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).|
+|state|authenticationMethodState|The possible values are: `enabled`, `disabled`. Inherited from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).|
+|certificateUserBindings|[x509CertificateUserBinding](../resources/x509certificateuserbinding.md) collection|Defines fields in the X.509 certificate that map to attributes of the Azure AD user object in order to bind the certificate to the user. The **priority** of the object determines the order in which the binding is carried out. The first binding that matches will be used and the rest ignored. |
+|authenticationModeConfiguration|[x509CertificateAuthenticationModeConfiguration](../resources/x509certificateauthenticationmodeconfiguration.md)|Defines strong authentication configurations. This configuration includes the default authentication mode and the different rules for strong authentication bindings. |
 
 
 ## Relationships

--- a/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
@@ -1,6 +1,6 @@
 ---
 title: "x509CertificateAuthenticationMethodConfiguration resource type"
-description: "Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it."
+description: "Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant, including whether the authentication method is enabled or disabled and the users and groups who can register and use it."
 author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it
+Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant, including whether the authentication method is enabled or disabled and the users and groups who can register and use it.
 
 Inherits from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).
 

--- a/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
@@ -1,0 +1,68 @@
+---
+title: "x509CertificateAuthenticationMethodConfiguration resource type"
+description: "A configuration entity that represents whether Azure AD native Certificate Based Authentication is enabled or disabled for the tenant and which users and groups can register and use it. (The id is 'Certificate')"
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: resourcePageType
+---
+
+# x509CertificateAuthenticationMethodConfiguration resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+A configuration entity that represents whether Azure AD native Certificate Based Authentication is enabled or disabled for the tenant and which users and groups can register and use it.
+
+Inherits from [authenticationMethodConfiguration](../resources/authenticationmethodconfiguration.md).
+
+## Methods
+|Method|Return type|Description|
+|:---|:---|:---|
+|[Get x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-get.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Read the properties and relationships of a x509CertificateAuthenticationMethodConfiguration object.|
+|[Update x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-update.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Update the properties of a x509CertificateAuthenticationMethodConfiguration object.|
+|[Delete x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-delete.md)|None|Reverts the x509CertificateAuthenticationMethodConfiguration object to its default configuration.|
+
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|id|String|The authentication method policy identifier.|
+|state|authenticationMethodState|Possible values are: `enabled`, `disabled`.|
+|certificateUserBindings|[x509CertificateUserBinding](../resources/x509certificateuserbinding.md) collection|Controls which X.509 cert fields map to which directory user object attributes to bind the certificate to the user.  Order is significant.  The first binding that matches will be used and the rest ignored. |
+|authenticationModeConfiguration|[x509CertificateAuthenticationModeConfiguration](../resources/x509certificateauthenticationmodeconfiguration.md)|Defines strong auth configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings. |
+
+
+
+## Relationships
+|Relationship|Type|Description|
+|:---|:---|:---|
+|includeTargets|[authenticationMethodTarget](../resources/authenticationmethodtarget.md) collection|A collection of users or groups who are enabled to use the authentication method.|
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+  "baseType": "microsoft.graph.authenticationMethodConfiguration",
+  "openType": false
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.x509CertificateAuthenticationMethodConfiguration",
+  "id": "String (identifier)",
+  "state": "String",
+  "certificateUserBindings": [
+    {
+      "@odata.type": "microsoft.graph.x509CertificateUserBinding"
+    }
+  ],
+  "authenticationModeConfiguration": {
+    "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
+  }
+}
+```
+

--- a/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
@@ -22,7 +22,7 @@ Inherits from [authenticationMethodConfiguration](../resources/authenticationmet
 |:---|:---|:---|
 |[Get x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-get.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Read the properties and relationships of a x509CertificateAuthenticationMethodConfiguration object.|
 |[Update x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-update.md)|[x509CertificateAuthenticationMethodConfiguration](../resources/x509certificateauthenticationmethodconfiguration.md)|Update the properties of a x509CertificateAuthenticationMethodConfiguration object.|
-|[Disable x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-delete.md)|None|Disables and restores the x509CertificateAuthenticationMethodConfiguration object to its default configuration.|
+|[Delete x509CertificateAuthenticationMethodConfiguration](../api/x509certificateauthenticationmethodconfiguration-delete.md)|None| Restore the x509CertificateAuthenticationMethodConfiguration object to its default configuration.|
 
 
 ## Properties

--- a/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmethodconfiguration.md
@@ -1,7 +1,7 @@
 ---
 title: "x509CertificateAuthenticationMethodConfiguration resource type"
 description: "Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: resourcePageType

--- a/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
@@ -1,0 +1,45 @@
+---
+title: "x509CertificateAuthenticationModeConfiguration resource type"
+description: "A complex type that defines the X.509 certificate strong authentication configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: resourcePageType
+---
+
+# x509CertificateAuthenticationModeConfiguration resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Defines strong auth configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings. 
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|rules|[x509CertificateRule](../resources/x509certificaterule.md) collection|Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication.|
+|x509CertificateAuthenticationDefaultMode|x509CertificateAuthenticationMode|The type of strong authentication mode, possible values are: `x509CertificateSingleFactor` and `x509CertificateMultiFactor`.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.x509CertificateAuthenticationModeConfiguration"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.x509CertificateAuthenticationModeConfiguration",
+  "x509CertificateAuthenticationDefaultMode": "String",
+  "rules": [
+    {
+      "@odata.type": "microsoft.graph.x509CertificateRule"
+    }
+  ]
+}
+```
+

--- a/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
@@ -1,6 +1,6 @@
 ---
 title: "x509CertificateAuthenticationModeConfiguration resource type"
-description: "A complex type that defines the X.509 certificate strong authentication configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings."
+description: "Defines the strong authentication configurations for the X.509 certificate. This configuration includes the default authentication mode and the different rules of strong authentication bindings."
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
@@ -13,13 +13,13 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Defines strong auth configurations. This configuration includes the default authentication mode and the different rules of strong auth bindings. 
+Defines the strong authentication configurations for the X.509 certificate. This configuration includes the default authentication mode and the different rules of strong authentication bindings.
 
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|rules|[x509CertificateRule](../resources/x509certificaterule.md) collection|Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication.|
-|x509CertificateAuthenticationDefaultMode|x509CertificateAuthenticationMode|The type of strong authentication mode, possible values are: `x509CertificateSingleFactor` and `x509CertificateMultiFactor`.|
+|rules|[x509CertificateRule](../resources/x509certificaterule.md) collection| Rules are configured in addition to the authentication mode to bind a specific **x509CertificateRuleType** to an **x509CertificateAuthenticationMode**. For example, bing the `policyOID` with identifier `1.32.132.343` to `x509CertificateMultiFactor` authentication mode.|
+|x509CertificateAuthenticationDefaultMode|x509CertificateAuthenticationMode| The type of strong authentication mode. The possible values are: `x509CertificateSingleFactor`, `x509CertificateMultiFactor`, `unknownFutureValue`.|
 
 ## Relationships
 None.

--- a/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
@@ -1,7 +1,7 @@
 ---
 title: "x509CertificateAuthenticationModeConfiguration resource type"
 description: "Defines the strong authentication configurations for the X.509 certificate. This configuration includes the default authentication mode and the different rules of strong authentication bindings."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: resourcePageType

--- a/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
+++ b/api-reference/beta/resources/x509certificateauthenticationmodeconfiguration.md
@@ -18,7 +18,7 @@ Defines the strong authentication configurations for the X.509 certificate. This
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|rules|[x509CertificateRule](../resources/x509certificaterule.md) collection| Rules are configured in addition to the authentication mode to bind a specific **x509CertificateRuleType** to an **x509CertificateAuthenticationMode**. For example, bing the `policyOID` with identifier `1.32.132.343` to `x509CertificateMultiFactor` authentication mode.|
+|rules|[x509CertificateRule](../resources/x509certificaterule.md) collection| Rules are configured in addition to the authentication mode to bind a specific **x509CertificateRuleType** to an **x509CertificateAuthenticationMode**. For example, bind the `policyOID` with identifier `1.32.132.343` to `x509CertificateMultiFactor` authentication mode.|
 |x509CertificateAuthenticationDefaultMode|x509CertificateAuthenticationMode| The type of strong authentication mode. The possible values are: `x509CertificateSingleFactor`, `x509CertificateMultiFactor`, `unknownFutureValue`.|
 
 ## Relationships

--- a/api-reference/beta/resources/x509certificaterule.md
+++ b/api-reference/beta/resources/x509certificaterule.md
@@ -1,0 +1,43 @@
+---
+title: "x509CertificateRule resource type"
+description: "A complex type that defines the X.509 certificate strong authentication configuration rules. Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: resourcePageType
+---
+
+# x509CertificateRule resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+A complex type that defines the X.509 certificate strong authentication configuration rules. Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication.
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|identifier|String|The identifier of the X.509 certificate.|
+|x509CertificateAuthenticationMode|x509CertificateAuthenticationMode|The type of strong authentication mode, possible values are: `x509CertificateSingleFactor` and `x509CertificateMultiFactor`.|
+|x509CertificateRuleType|x509CertificateRuleType|The type of the X.509 certificate mode configuration rule,  possible values are: `issuerSubject` and `policyOID`.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.x509CertificateRule"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.x509CertificateRule",
+  "x509CertificateRuleType": "String",
+  "identifier": "String",
+  "x509CertificateAuthenticationMode": "String"
+}
+```
+

--- a/api-reference/beta/resources/x509certificaterule.md
+++ b/api-reference/beta/resources/x509certificaterule.md
@@ -1,6 +1,6 @@
 ---
 title: "x509CertificateRule resource type"
-description: "A complex type that defines the X.509 certificate strong authentication configuration rules. Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication."
+description: "Defines the strong authentication configuration rules for the X.509 certificate. Rules are configured in addition to the authentication mode."
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
@@ -13,14 +13,14 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-A complex type that defines the X.509 certificate strong authentication configuration rules. Rules are configured in addition to the authentication mode. Configure authentication rule to bind a specific Issuer Subject or Policy OID to one particular authentication mode, i.e., Binds Policy OID "1.32.132.343" to "Multi-factor" Authentication.
+Defines the strong authentication configuration rules for the X.509 certificate. Rules are configured in addition to the authentication mode.
 
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|identifier|String|The identifier of the X.509 certificate.|
-|x509CertificateAuthenticationMode|x509CertificateAuthenticationMode|The type of strong authentication mode, possible values are: `x509CertificateSingleFactor` and `x509CertificateMultiFactor`.|
-|x509CertificateRuleType|x509CertificateRuleType|The type of the X.509 certificate mode configuration rule,  possible values are: `issuerSubject` and `policyOID`.|
+|identifier|String| The identifier of the X.509 certificate. Required.|
+|x509CertificateAuthenticationMode|x509CertificateAuthenticationMode| The type of strong authentication mode. The possible values are: `x509CertificateSingleFactor`, `x509CertificateMultiFactor`, `unknownFutureValue`. Required.|
+|x509CertificateRuleType|x509CertificateRuleType| The type of the X.509 certificate mode configuration rule. The possible values are: `issuerSubject`, `policyOID`, `unknownFutureValue`. Required.|
 
 ## Relationships
 None.

--- a/api-reference/beta/resources/x509certificaterule.md
+++ b/api-reference/beta/resources/x509certificaterule.md
@@ -1,7 +1,7 @@
 ---
 title: "x509CertificateRule resource type"
 description: "Defines the strong authentication configuration rules for the X.509 certificate. Rules are configured in addition to the authentication mode."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: resourcePageType

--- a/api-reference/beta/resources/x509certificateuserbinding.md
+++ b/api-reference/beta/resources/x509certificateuserbinding.md
@@ -1,7 +1,7 @@
 ---
 title: "x509CertificateUserBinding resource type"
 description: "Defines the fields in the X.509 certificate that map to attributes of the Azure AD user object in order to bind the certificate to the user account."
-author: "Vimala"
+author: "charlenezheng"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
 doc_type: resourcePageType

--- a/api-reference/beta/resources/x509certificateuserbinding.md
+++ b/api-reference/beta/resources/x509certificateuserbinding.md
@@ -1,6 +1,6 @@
 ---
 title: "x509CertificateUserBinding resource type"
-description: "A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used to bind the certificate to the user."
+description: "Defines the fields in the X.509 certificate that map to attributes of the Azure AD user object in order to bind the certificate to the user account."
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"
@@ -13,15 +13,14 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used
-to bind the certificate to the user.
+Defines the fields in the X.509 certificate that map to attributes of the Azure AD user object in order to bind the certificate to the user account.
 
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|priority|Int32|The priority of the binding.  Azure AD uses the binding with the highest priority where the X509CertificateField is present in the certificate. Value must be non-negative and unique in the list.|
-|userProperty|String|Which user property on the Azure AD user object to use.  Value must be one of userPrincipalName, onPremisesUserPrincipalName, mail.|
-|x509CertificateField|String|Which certificate field.  Value must be one of: principalName, RFC822Name.|
+|priority|Int32|The priority of the binding. Azure AD uses the binding with the highest priority. This value must be a non-negative integer and unique in the collection of objects in the **certificateUserBindings** property of an **x509CertificateAuthenticationMethodConfiguration** object. Required|
+|userProperty|String|Defines the Azure AD user property of the user object to use for the binding. The possible values are: **userPrincipalName**, `onPremisesUserPrincipalName`, `email`. Required.|
+|x509CertificateField|String|The field on the X.509 certificate to use for the binding. The possible values are: `PrincipalName`, `RFC822Name`.|
 
 ## Relationships
 None.

--- a/api-reference/beta/resources/x509certificateuserbinding.md
+++ b/api-reference/beta/resources/x509certificateuserbinding.md
@@ -1,7 +1,6 @@
 ---
 title: "x509CertificateUserBinding resource type"
-description: "A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used
-to bind the certificate to the user."
+description: "A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used to bind the certificate to the user."
 author: "Vimala"
 ms.localizationpriority: medium
 ms.prod: "identity-and-sign-in"

--- a/api-reference/beta/resources/x509certificateuserbinding.md
+++ b/api-reference/beta/resources/x509certificateuserbinding.md
@@ -1,0 +1,45 @@
+---
+title: "x509CertificateUserBinding resource type"
+description: "A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used
+to bind the certificate to the user."
+author: "Vimala"
+ms.localizationpriority: medium
+ms.prod: "identity-and-sign-in"
+doc_type: resourcePageType
+---
+
+# x509CertificateUserBinding resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+A complex type that defines the mapping from X.509 certificate field to directory user attribute to bind the certificate to the user account. This controls which certificate fields and which Azure AD user attributes are used
+to bind the certificate to the user.
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|priority|Int32|The priority of the binding.  Azure AD uses the binding with the highest priority where the X509CertificateField is present in the certificate. Value must be non-negative and unique in the list.|
+|userProperty|String|Which user property on the Azure AD user object to use.  Value must be one of userPrincipalName, onPremisesUserPrincipalName, mail.|
+|x509CertificateField|String|Which certificate field.  Value must be one of: principalName, RFC822Name.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.x509CertificateUserBinding"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.x509CertificateUserBinding",
+  "x509CertificateField": "String",
+  "userProperty": "String",
+  "priority": "Integer"
+}
+```
+

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -11934,7 +11934,7 @@ items:
                 href: api/fido2authenticationmethodconfiguration-update.md
               - name: Delete
                 href: api/fido2authenticationmethodconfiguration-delete.md
-            - name: X509Certificate
+            - name: X509 certificate
               href: resources/x509Certificateauthenticationmethodconfiguration.md
               items:
               - name: Get

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -11934,6 +11934,15 @@ items:
                 href: api/fido2authenticationmethodconfiguration-update.md
               - name: Delete
                 href: api/fido2authenticationmethodconfiguration-delete.md
+            - name: X509Certificate
+              href: resources/x509Certificateauthenticationmethodconfiguration.md
+              items:
+              - name: Get
+                href: api/x509certificateauthenticationmethodconfiguration-get.md
+              - name: Update
+                href: api/x509certificateauthenticationmethodconfiguration-update.md
+              - name: Delete
+                href: api/x509certificateauthenticationmethodconfiguration-delete.md
             - name: Microsoft Authenticator policy
               href: resources/microsoftauthenticatorauthenticationmethodconfiguration.md
               items:

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -9909,6 +9909,68 @@
       "CreatedDateTime": "2021-11-15T20:42:47.116895Z",
       "WorkloadArea": "Identity and access",
       "SubArea": "Identity and sign-in"
+    },
+    {
+      "changelog": [
+        {
+          "ChangeList": [
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "EnumType",
+              "ChangedApiName": "x509CertificateAuthenticationMode",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) resource",
+              "Target": "x509CertificateAuthenticationMode"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "EnumType",
+              "ChangedApiName": "x509CertificateRuleType",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) resource",
+              "Target": "x509CertificateRuleType"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateAuthenticationModeConfiguration",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationModeConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationModeConfiguration?view=graph-rest-beta) resource",
+              "Target": "x509CertificateAuthenticationModeConfiguration"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateRule",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateRule](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateRule?view=graph-rest-beta) resource",
+              "Target": "x509CertificateRule"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateUserBinding",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateUserBinding](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateUserBinding?view=graph-rest-beta) resource",
+              "Target": "x509CertificateUserBinding"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource",
+              "Target": "x509CertificateAuthenticationMethodConfiguration"
+            }
+          ],
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "Cloud": "Prod",
+          "Version": "beta",
+          "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
+          "WorkloadArea": "Identity and access",
+          "SubArea": "Identity and sign-in"
+        }
+      ]
     }
   ]
 }

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -6,7 +6,7 @@
           "ApiChange": "Enum type",
           "ChangedApiName": "x509CertificateAuthenticationMode",
           "ChangeType": "Addition",
-          "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+          "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type.",
           "Target": "x509CertificateAuthenticationMode"
         },
         {
@@ -14,7 +14,7 @@
           "ApiChange": "Enum type",
           "ChangedApiName": "x509CertificateRuleType",
           "ChangeType": "Addition",
-          "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+          "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type.",
           "Target": "x509CertificateRuleType"
         },
         {
@@ -46,14 +46,14 @@
           "ApiChange": "Resource",
           "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
           "ChangeType": "Addition",
-          "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource. . Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it.",
+          "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource and related methods. Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it.",
           "Target": "x509CertificateAuthenticationMethodConfiguration"
         }
       ],
       "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
       "Cloud": "Prod",
       "Version": "beta",
-      "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
+      "CreatedDateTime": "2022-02-03T00:00:00.8027648Z",
       "WorkloadArea": "Identity and access",
       "SubArea": "Identity and sign-in"
     },

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -1,6 +1,68 @@
 {
   "changelog": [
+    {
+      "changelog": [
         {
+          "ChangeList": [
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Enum type",
+              "ChangedApiName": "x509CertificateAuthenticationMode",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+              "Target": "x509CertificateAuthenticationMode"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Enum type",
+              "ChangedApiName": "x509CertificateRuleType",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+              "Target": "x509CertificateRuleType"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateAuthenticationModeConfiguration",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationModeConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationModeConfiguration?view=graph-rest-beta) resource. Use this resource to define the strong authentication configurations for the X.509 certificate.",
+              "Target": "x509CertificateAuthenticationModeConfiguration"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateRule",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateRule](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateRule?view=graph-rest-beta) resource. Use this resource to define the strong authentication configuration rules for the X.509 certificate.",
+              "Target": "x509CertificateRule"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateUserBinding",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateUserBinding](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateUserBinding?view=graph-rest-beta) resource. Use this resource to map the fields in the X.509 certificate to attributes of the Azure AD user object in order to bind the certificate to the user account.",
+              "Target": "x509CertificateUserBinding"
+            },
+            {
+              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+              "ApiChange": "Resource",
+              "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
+              "ChangeType": "Addition",
+              "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource. . Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it.",
+              "Target": "x509CertificateAuthenticationMethodConfiguration"
+            }
+          ],
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "Cloud": "Prod",
+          "Version": "beta",
+          "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
+          "WorkloadArea": "Identity and access",
+          "SubArea": "Identity and sign-in"
+        }
+      ]
+    },
+    {
       "ChangeList": [
         {
           "Id": "0f3be1ec-d352-4eb8-ad76-c8e1e1a615eb",
@@ -9909,68 +9971,6 @@
       "CreatedDateTime": "2021-11-15T20:42:47.116895Z",
       "WorkloadArea": "Identity and access",
       "SubArea": "Identity and sign-in"
-    },
-    {
-      "changelog": [
-        {
-          "ChangeList": [
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "EnumType",
-              "ChangedApiName": "x509CertificateAuthenticationMode",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) resource",
-              "Target": "x509CertificateAuthenticationMode"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "EnumType",
-              "ChangedApiName": "x509CertificateRuleType",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) resource",
-              "Target": "x509CertificateRuleType"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateAuthenticationModeConfiguration",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationModeConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationModeConfiguration?view=graph-rest-beta) resource",
-              "Target": "x509CertificateAuthenticationModeConfiguration"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateRule",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateRule](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateRule?view=graph-rest-beta) resource",
-              "Target": "x509CertificateRule"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateUserBinding",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateUserBinding](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateUserBinding?view=graph-rest-beta) resource",
-              "Target": "x509CertificateUserBinding"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource",
-              "Target": "x509CertificateAuthenticationMethodConfiguration"
-            }
-          ],
-          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-          "Cloud": "Prod",
-          "Version": "beta",
-          "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
-          "WorkloadArea": "Identity and access",
-          "SubArea": "Identity and sign-in"
-        }
-      ]
     }
   ]
 }

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -1,66 +1,61 @@
 {
   "changelog": [
     {
-      "changelog": [
-        {
-          "ChangeList": [
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Enum type",
-              "ChangedApiName": "x509CertificateAuthenticationMode",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
-              "Target": "x509CertificateAuthenticationMode"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Enum type",
-              "ChangedApiName": "x509CertificateRuleType",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
-              "Target": "x509CertificateRuleType"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateAuthenticationModeConfiguration",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationModeConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationModeConfiguration?view=graph-rest-beta) resource. Use this resource to define the strong authentication configurations for the X.509 certificate.",
-              "Target": "x509CertificateAuthenticationModeConfiguration"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateRule",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateRule](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateRule?view=graph-rest-beta) resource. Use this resource to define the strong authentication configuration rules for the X.509 certificate.",
-              "Target": "x509CertificateRule"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateUserBinding",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateUserBinding](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateUserBinding?view=graph-rest-beta) resource. Use this resource to map the fields in the X.509 certificate to attributes of the Azure AD user object in order to bind the certificate to the user account.",
-              "Target": "x509CertificateUserBinding"
-            },
-            {
-              "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-              "ApiChange": "Resource",
-              "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
-              "ChangeType": "Addition",
-              "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource. . Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it.",
-              "Target": "x509CertificateAuthenticationMethodConfiguration"
-            }
-          ],
+      "ChangeList": [{
           "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
-          "Cloud": "Prod",
-          "Version": "beta",
-          "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
-          "WorkloadArea": "Identity and access",
-          "SubArea": "Identity and sign-in"
+          "ApiChange": "Enum type",
+          "ChangedApiName": "x509CertificateAuthenticationMode",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateAuthenticationMode](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+          "Target": "x509CertificateAuthenticationMode"
+        },
+        {
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "ApiChange": "Enum type",
+          "ChangedApiName": "x509CertificateRuleType",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateRuleType](https://docs.microsoft.com/en-us/?view=graph-rest-beta) enumeration type",
+          "Target": "x509CertificateRuleType"
+        },
+        {
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "ApiChange": "Resource",
+          "ChangedApiName": "x509CertificateAuthenticationModeConfiguration",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateAuthenticationModeConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationModeConfiguration?view=graph-rest-beta) resource. Use this resource to define the strong authentication configurations for the X.509 certificate.",
+          "Target": "x509CertificateAuthenticationModeConfiguration"
+        },
+        {
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "ApiChange": "Resource",
+          "ChangedApiName": "x509CertificateRule",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateRule](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateRule?view=graph-rest-beta) resource. Use this resource to define the strong authentication configuration rules for the X.509 certificate.",
+          "Target": "x509CertificateRule"
+        },
+        {
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "ApiChange": "Resource",
+          "ChangedApiName": "x509CertificateUserBinding",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateUserBinding](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateUserBinding?view=graph-rest-beta) resource. Use this resource to map the fields in the X.509 certificate to attributes of the Azure AD user object in order to bind the certificate to the user account.",
+          "Target": "x509CertificateUserBinding"
+        },
+        {
+          "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+          "ApiChange": "Resource",
+          "ChangedApiName": "x509CertificateAuthenticationMethodConfiguration",
+          "ChangeType": "Addition",
+          "Description": "Added the [x509CertificateAuthenticationMethodConfiguration](https://docs.microsoft.com/en-us/graph/api/resources/x509CertificateAuthenticationMethodConfiguration?view=graph-rest-beta) resource. . Represents the details of the Azure AD native Certificate-Based Authentication (CBA) in the tenant including whether the authentication method is enabled or disabled and the users and groups who can register and use it.",
+          "Target": "x509CertificateAuthenticationMethodConfiguration"
         }
-      ]
+      ],
+      "Id": "34b0a990-a3c9-4b70-92ac-a8ac93bf4860",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2022-01-13T12:23:06.8027648Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Identity and sign-in"
     },
     {
       "ChangeList": [


### PR DESCRIPTION
Certificate Based Authentication is approaching the public preview. Publishing related APIs and resources are required. This PR is to introduce a new admin authentication method as X509Certificate authentication to MS Graph docs.

Schema update PR: 5077313