### PR TITLE
Fix role issue in CreateJob for printerShare

### DIFF
--- a/api-reference/beta/api/printershare-post-jobs.md
+++ b/api-reference/beta/api/printershare-post-jobs.md
@@ -18,7 +18,7 @@ Create a new [printJob](../resources/printJob.md) for a [printerShare](../resour
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-In addition to the following permissions, the user or app's tenant must have an active Universal Print subscription and have a permission that grants [Get printerShare](printerShare-get.md) access. The signed in user must be a [Printer Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#printer-administrator).
+In addition to the following permissions, the user or app's tenant must have an active Universal Print subscription and have a permission that grants [Get printerShare](printerShare-get.md) access.
 
 |Permission type | Permissions (from least to most privileged) |
 |:---------------|:--------------------------------------------|

--- a/api-reference/v1.0/api/printershare-post-jobs.md
+++ b/api-reference/v1.0/api/printershare-post-jobs.md
@@ -17,7 +17,7 @@ Also creates a new [printDocument](../resources/printDocument.md) associated wit
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
-In addition to the following permissions, the user or app's tenant must have an active Universal Print subscription and have a permission that grants [Get printerShare](printerShare-get.md) access. The signed in user must be a [Printer Administrator](/azure/active-directory/users-groups-roles/directory-assign-admin-roles#printer-administrator).
+In addition to the following permissions, the user or app's tenant must have an active Universal Print subscription and have a permission that grants [Get printerShare](printerShare-get.md) access.
 
 |Permission type | Permissions (from least to most privileged) |
 |:---------------|:--------------------------------------------|


### PR DESCRIPTION
Printer administrator role is not required for createJob for a printerShare, however, the documentation says otherwise.