### PR TITLE
LinkFix: microsoft-graph-docs (2022-01) - 1

### DIFF
--- a/api-reference/v1.0/api/serviceprincipal-update.md
+++ b/api-reference/v1.0/api/serviceprincipal-update.md
@@ -43,7 +43,7 @@ In the request body, supply the values for relevant fields that should be update
 |:---------------|:--------|:----------|
 |accountEnabled|Boolean| **true** if the service principal account is enabled; otherwise, **false**.|
 |addIns| [addIn](../resources/addin.md) | Defines custom behavior that a consuming service can use to call an app in specific contexts. For example, applications that can render file streams [may set the addIns property](/onedrive/developer/file-handlers/?view=odsp-graph-online) for its "FileHandler" functionality. This will let services like Microsoft 365 call the application in the context of a document the user is working on.|
-|alternativeNames|String collection| Used to retrieve service principals by subscription, identify resource group and full resource ids for [managed identities](https://aka.ms/azuremanagedidentity).|
+|alternativeNames|String collection| Used to retrieve service principals by subscription, identify resource group and full resource ids for [managed identities](/azure/active-directory/managed-identities-azure-resources/overview).|
 |appRoleAssignmentRequired|Boolean|Specifies whether an **appRoleAssignment** to a user or group is required before Azure AD will issue a user or access token to the application. Not nullable. |
 |appRoles|[appRole](../resources/approle.md) collection|The application roles exposed by the associated application. For more information see the **appRoles** property definition on the [application](../resources/application.md) resource. Not nullable. |
 |displayName|String|The display name for the service principal.|
@@ -123,4 +123,3 @@ HTTP/1.1 204 No Content
   ]
 }
 -->
-

--- a/api-reference/v1.0/api/team-get-installedapps.md
+++ b/api-reference/v1.0/api/team-get-installedapps.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | TeamsAppInstallation.Read.Group*, TeamsAppInstallation.ReadWriteSelfForTeam.All, TeamsAppInstallation.ReadForTeam.All, TeamsAppInstallation.ReadWriteForTeam.All, Group.Read.All**, Group.ReadWrite.All**, Directory.Read.All**, Directory.ReadWrite.All** |
 
-> **Note**: Permissions marked with * use [resource-specific consent](https://aka.ms/teams-rsc). Permissions marked with ** are deprecated and should not be used.
+> **Note**: Permissions marked with * use [resource-specific consent](/microsoftteams/platform/graph-api/rsc/resource-specific-consent). Permissions marked with ** are deprecated and should not be used.
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/team-get-members.md
+++ b/api-reference/v1.0/api/team-get-members.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application| TeamMember.Read.Group*, TeamMember.Read.All, TeamMember.ReadWrite.All |
 
-> **Note**: Permissions marked with * use [resource-specific consent](https://aka.ms/teams-rsc).
+> **Note**: Permissions marked with * use [resource-specific consent](/microsoftteams/platform/graph-api/rsc/resource-specific-consent).
 
 > [!NOTE]
 > Before calling this API with application permissions, you must request access. For details, see [Protected APIs in Microsoft Teams](/graph/teams-protected-apis).
@@ -132,4 +132,3 @@ Content-type: application/json
 ## See also
 
 - [Get member of channel](channel-get-members.md)
-

--- a/api-reference/v1.0/api/team-sendactivitynotification.md
+++ b/api-reference/v1.0/api/team-sendactivitynotification.md
@@ -22,7 +22,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account)|Not Supported.|
 |Application|TeamsActivity.Send.Group*, TeamsActivity.Send|
 
->**Note:** Permissions marked with * use [resource-specific consent](https://aka.ms/teams-rsc).
+>**Note:** Permissions marked with * use [resource-specific consent](/microsoftteams/platform/graph-api/rsc/resource-specific-consent).
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/team-update.md
+++ b/api-reference/v1.0/api/team-update.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | TeamSettings.ReadWrite.Group*, TeamSettings.ReadWrite.All, Group.ReadWrite.All**, Directory.ReadWrite.All** |
 
-> **Note**: Permissions marked with * use [resource-specific consent](https://aka.ms/teams-rsc). Permissions marked with ** are deprecated and should not be used.
+> **Note**: Permissions marked with * use [resource-specific consent](/microsoftteams/platform/graph-api/rsc/resource-specific-consent). Permissions marked with ** are deprecated and should not be used.
 
 > **Note**: This API supports admin permissions. Global admins and Microsoft Teams service admins can access teams that they are not a member of.
 
@@ -116,4 +116,3 @@ HTTP/1.1 204 No Content
   "suppressions": [
   ]
 }-->
-

--- a/api-reference/v1.0/resources/security-api-overview.md
+++ b/api-reference/v1.0/resources/security-api-overview.md
@@ -107,11 +107,10 @@ Need more ideas? See [how some of our partners are using Microsoft Graph](https:
 
 Explore other options to connect with the Microsoft Graph Security API:
 
-- [Microsoft Graph Security connectors for Logic Apps, Flow and Power Apps](https://aka.ms/graphsecurityconnectors)
+- [Microsoft Graph Security connectors for Logic Apps, Flow and Power Apps](/azure/connectors/connectors-integrate-security-operations-create-api-microsoft-graph-security)
 - [Jupyter Notebook samples](https://aka.ms/graphsecurityjupyternotebooks)
 
 Engage with the community:
 
 - [Join the tech community](https://techcommunity.microsoft.com/t5/microsoft-graph-security-api/bd-p/SecurityGraphAPI)
 - [Discuss on StackOverflow](https://stackoverflow.com/questions/tagged/microsoft-graph-security)
-

--- a/api-reference/v1.0/resources/serviceprincipal.md
+++ b/api-reference/v1.0/resources/serviceprincipal.md
@@ -80,7 +80,7 @@ This resource supports using [delta query](/graph/delta-query-overview) to track
 |:---------------|:--------|:----------|
 | accountEnabled |Boolean| `true` if the service principal account is enabled; otherwise, `false`. Supports `$filter` (`eq`, `ne`, `not`, `in`).|
 | addIns | [addIn](addin.md) collection | Defines custom behavior that a consuming service can use to call an app in specific contexts. For example, applications that can render file streams [may set the addIns property](/onedrive/developer/file-handlers/?view=odsp-graph-online&preserve-view=true) for its "FileHandler" functionality. This will let services like Microsoft 365 call the application in the context of a document the user is working on.|
-|alternativeNames|String collection| Used to retrieve service principals by subscription, identify resource group and full resource ids for [managed identities](https://aka.ms/azuremanagedidentity). Supports `$filter` (`eq`, `not`, `ge`, `le`, `startsWith`).|
+|alternativeNames|String collection| Used to retrieve service principals by subscription, identify resource group and full resource ids for [managed identities](/azure/active-directory/managed-identities-azure-resources/overview). Supports `$filter` (`eq`, `not`, `ge`, `le`, `startsWith`).|
 |appDescription|String|The description exposed by the associated application.|
 |appDisplayName|String|The display name exposed by the associated application.|
 |appId|String|The unique identifier for the associated application (its **appId** property). Supports `$filter` (`eq`, `ne`, `not`, `in`, `startsWith`).|

--- a/concepts/assignments-submissions-states-transition.md
+++ b/concepts/assignments-submissions-states-transition.md
@@ -113,4 +113,4 @@ The following limits apply to all API calls:
 
 * The maximum number of assignments and submissions resources are 10 for the teacher and plus 10 for the student.
 * The maximum size allowed for resources is 50 MB overall or 10 resources.
-* Throttling limits apply; for details, see [Microsoft Graph throttling guidance](https://docs.microsoft.com/graph/throttling).
+* Throttling limits apply; for details, see [Microsoft Graph throttling guidance](/graph/throttling).

--- a/concepts/data-connect-pam.md
+++ b/concepts/data-connect-pam.md
@@ -8,7 +8,7 @@ ms.prod: "data-connect"
 
 # Microsoft Graph Data Connect integration with Privileged Access Management
 
-Microsoft Graph Data Connect relies on Privileged Access Management (PAM) to allow Microsoft 365 administrators to approve data movement requests. Data Connect pipelines must be approved by a member of the data access request approver specified by the Microsoft 365 administrator during enablement. To set up the approver group, see [Set up your Microsoft 365 tenant and enable Microsoft Graph Data Connect](https://docs.microsoft.com/graph/data-connect-quickstart?tabs=Microsoft365&tutorial-step=1).
+Microsoft Graph Data Connect relies on Privileged Access Management (PAM) to allow Microsoft 365 administrators to approve data movement requests. Data Connect pipelines must be approved by a member of the data access request approver specified by the Microsoft 365 administrator during enablement. To set up the approver group, see [Set up your Microsoft 365 tenant and enable Microsoft Graph Data Connect](/graph/data-connect-quickstart?tabs=Microsoft365&tutorial-step=1).
 
 Approval request emails will be sent to each member of the approver group to notify them when copy activities request access to extract Microsoft 365 data. Approvers can approve or deny these requests, specify a user group that should be scrubbed out of extracted data, or revoke a previously approved request. Approvals persist for 6 months, and one approval is needed per copy activity in the Azure Data Factory pipeline.
 

--- a/concepts/index.yml
+++ b/concepts/index.yml
@@ -27,7 +27,7 @@ highlightedContent:
       url: ./whats-new-overview.md
     - title: Microsoft Graph REST API
       itemType: reference
-      url: https://docs.microsoft.com/graph/api/overview?view=graph-rest-1.0
+      url: /graph/api/overview?view=graph-rest-1.0
 
 conceptualContent:
 # itemType: architecture | concept | deploy | download | get-started | how-to-guide | learn | overview | quickstart | reference | sample | tutorial | video | whats-new
@@ -85,7 +85,7 @@ tools:
     - title: SDKs
       # imageSrc should be square in ratio with no whitespace
       imageSrc: ./images/hub/icon01-sdk.svg
-      url: https://docs.microsoft.com/graph/sdks/sdk-installation
+      url: /graph/sdks/sdk-installation
     # Card
     - title: Quick starts
       imageSrc: ./images/hub/icon02-quickstart.svg
@@ -107,30 +107,30 @@ additionalContent:
         - title: Learning paths
           links:
             - text: Microsoft Graph fundamentals
-              url: https://docs.microsoft.com/learn/paths/m365-msgraph-fundamentals/
+              url: /learn/paths/m365-msgraph-fundamentals/
             - text: Build apps with Microsoft Graph – Associate
-              url: https://docs.microsoft.com/learn/paths/m365-msgraph-associate/
+              url: /learn/paths/m365-msgraph-associate/
             - text: Explore Microsoft Graph scenarios for JavaScript development
-              url: https://docs.microsoft.com/learn/paths/m365-msgraph-scenarios
+              url: /learn/paths/m365-msgraph-scenarios
             - text: Explore Microsoft Graph scenarios for ASP.NET Core development
-              url: https://docs.microsoft.com/learn/paths/m365-msgraph-dotnet-core-scenarios/             
+              url: /learn/paths/m365-msgraph-dotnet-core-scenarios/
             - text: Develop apps with Microsoft Graph Toolkit
-              url: https://docs.microsoft.com/learn/paths/m365-msgraph-toolkit             
+              url: /learn/paths/m365-msgraph-toolkit
         # Card
         - title: How-to
           links:
             - text: "Connectors: Build your first custom connector"
-              url: https://docs.microsoft.com/en-us/graph/connecting-external-content-build-quickstart  
+              url: /graph/connecting-external-content-build-quickstart
             - text: "Microsoft Search: Search content in OneDrive and Sharepoint"
-              url: https://docs.microsoft.com/graph/search-concept-files
+              url: /graph/search-concept-files
             - text: "Identity: Manage access to resources"
-              url: https://docs.microsoft.com/en-us/graph/tutorial-access-package-api
+              url: /graph/tutorial-access-package-api
             - text: "Outlook: Attach large files to a message or event"
-              url: https://docs.microsoft.com/graph/outlook-large-attachments
+              url: /graph/outlook-large-attachments
             - text: "Outlook: Get MIME content of a message"
-              url: https://docs.microsoft.com/graph/outlook-get-mime-message
+              url: /graph/outlook-get-mime-message
             - text: "More tutorials..."
-              url: https://docs.microsoft.com/en-us/graph/tutorials
+              url: /graph/tutorials
         # Card
         - title: Resources and community
           links:
@@ -141,7 +141,7 @@ additionalContent:
             - text: Support
               url: https://developer.microsoft.com/graph/support
             - text: Microsoft Graph on Q&A
-              url: https://docs.microsoft.com/en-us/answers/products/graph
+              url: /answers/products/graph
             - text: Microsoft Graph blog
               url: https://developer.microsoft.com/graph/blogs/
             - text: Videos and podcasts

--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -410,7 +410,7 @@ In certain instances, the `tenantId` / `email` / `displayName` property for the 
 The API call for [me/joinedTeams](/graph/api/user-list-joinedteams) returns only the **id**, **displayName**, and **description** properties of a [team](/graph/api/resources/team). To get all properties, use the [Get team](/graph/api/team-get) operation.
 
 ### Installation of apps that require resource-specific consent permissions is not supported
-The following API calls do not support installing apps that require [resource-specific consent](https://aka.ms/teams-rsc) permissions.
+The following API calls do not support installing apps that require [resource-specific consent](/microsoftteams/platform/graph-api/rsc/resource-specific-consent) permissions.
 - [Add app to team](/graph/api/team-post-installedapps.md)
 - [Upgrade app installed in team](/graph/api/team-teamsappinstallation-upgrade.md)
 - [Add app to chat](/graph/api/chat-post-installedapps.md)

--- a/concepts/teams-licenses.md
+++ b/concepts/teams-licenses.md
@@ -71,7 +71,7 @@ and subscriptions with licensing and payment requirements will not send change n
 ## Required licenses for `model=A` 
 
 The user will need one of the 
-[supported licenses](https://aka.ms/teams-api-license-list). 
+[supported licenses](/office365/servicedescriptions/microsoft-365-service-descriptions/microsoft-365-tenantlevel-services-licensing-guidance/microsoft-365-security-compliance-licensing-guidance#microsoft-graph-apis-for-teams-data-loss-prevention-dlp-and-for-teams-export). 
 Which user needs the license varies by API; 
 for details, see [`model=A` requirements](#modela-requirements).
 

--- a/concepts/toolkit/components/todo.md
+++ b/concepts/toolkit/components/todo.md
@@ -88,7 +88,7 @@ mgt-todo {
 }
 ````
 
-To learn more, see [styling components](https://docs.microsoft.com/graph/toolkit/style.md).
+To learn more, see [styling components](/graph/toolkit/style.md).
 
 ## Events
 

--- a/concepts/windowsupdates-software-updates.md
+++ b/concepts/windowsupdates-software-updates.md
@@ -21,7 +21,7 @@ The deployment service [catalog](/graph/api/resources/windowsupdates-catalog?vie
 
 Effectively, the deployment service currently deploys only feature updates and _security_ quality updates as defined in its catalog. The service currently does not deploy non-security quality updates or driver updates.
 
-To learn more about Windows 10 updates and servicing, see [Quick guide to Windows as a service](https://docs.microsoft.com/windows/deployment/update/waas-quick-start).
+To learn more about Windows 10 updates and servicing, see [Quick guide to Windows as a service](/windows/deployment/update/waas-quick-start).
 
 ## Identifying updates for deployment
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes: 

 

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not 

  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN). 

- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes). 

 

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order: 

 

``` 

By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments. 

``` 