### PR TITLE
Update query-parameters.md

### DIFF
--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -175,11 +175,12 @@ GET https://graph.microsoft.com/v1.0/users?$filter=imAddresses/any(s:s eq 'admin
 ```
 
 The **assignedLicenses** property of the user resource contains a collection of **assignedLicense** objects, a complex type with two properties, **skuId** and **disabledPlans**. The following query retrieves only users with an assigned license identified by the **skuId** `184efa21-98c3-4e5d-95ab-d07053a96e67`.
-Ensure to add &$count=true as parameter and ConsistencyLevel: eventual in the header as this is an advanced query and will fail otherwise if too many results are found.
+
+>**Note:** Be sure to add the `&$count=true` parameter and the `ConsistencyLevel: eventual` header. This is an advanced query and will fail if too many results are found.
 
 ```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/users?$filter=assignedLicenses/any(s:s/skuId eq 184efa21-98c3-4e5d-95ab-d07053a96e67))&$count=true
-Header ConsistencyLevel: eventual
+ConsistencyLevel: eventual
 ```
 
 To negate the result of the expression inside the `any` clause, use the `not` operator, not the `ne` operator. For example, the following query retrieves only users who are not assigned the **imAddress** of `admin@contoso.com`.

--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -175,9 +175,11 @@ GET https://graph.microsoft.com/v1.0/users?$filter=imAddresses/any(s:s eq 'admin
 ```
 
 The **assignedLicenses** property of the user resource contains a collection of **assignedLicense** objects, a complex type with two properties, **skuId** and **disabledPlans**. The following query retrieves only users with an assigned license identified by the **skuId** `184efa21-98c3-4e5d-95ab-d07053a96e67`.
+Ensure to add &$count=true as parameter and ConsistencyLevel: eventual in the header as this is an advanced query and will fail otherwise if too many results are found.
 
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/users?$filter=assignedLicenses/any(s:s/skuId eq 184efa21-98c3-4e5d-95ab-d07053a96e67)
+GET https://graph.microsoft.com/v1.0/users?$filter=assignedLicenses/any(s:s/skuId eq 184efa21-98c3-4e5d-95ab-d07053a96e67))&$count=true
+Header ConsistencyLevel: eventual
 ```
 
 To negate the result of the expression inside the `any` clause, use the `not` operator, not the `ne` operator. For example, the following query retrieves only users who are not assigned the **imAddress** of `admin@contoso.com`.

--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -176,7 +176,7 @@ GET https://graph.microsoft.com/v1.0/users?$filter=imAddresses/any(s:s eq 'admin
 
 The **assignedLicenses** property of the user resource contains a collection of **assignedLicense** objects, a complex type with two properties, **skuId** and **disabledPlans**. The following query retrieves only users with an assigned license identified by the **skuId** `184efa21-98c3-4e5d-95ab-d07053a96e67`.
 
->**Note:** Be sure to add the `&$count=true` parameter and the `ConsistencyLevel: eventual` header. This is an advanced query and will fail if too many results are found.
+>**Note:** Be sure to add the `&$count=true` parameter and the `ConsistencyLevel: eventual` header. This is an [advanced query](/graph/aad-advanced-queries) and will fail if too many results are found.
 
 ```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/users?$filter=assignedLicenses/any(s:s/skuId eq 184efa21-98c3-4e5d-95ab-d07053a96e67))&$count=true


### PR DESCRIPTION
extended the example of SkuID search with the needed parameters ConsistencyLevel: eventual in header and &$count=true in the query. As this is an advanced query and will fail when more results are found. Like described here https://docs.microsoft.com/en-us/graph/aad-advanced-queries