### PR TITLE
Clarify which chatMessage webhooks will be monetized

### DIFF
--- a/api-reference/beta/api/channel-getallmessages.md
+++ b/api-reference/beta/api/channel-getallmessages.md
@@ -41,7 +41,9 @@ GET /teams/{team-id}/channels/getAllMessages
 
 ## Optional query parameters
 
-You can use the `model` query parameter, which supports the values `A` and `B`, based on the preferred licensing and payment requirements, as shown in the following examples. 
+You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred [licensing and payment model](/graph/teams-licenses),
+as shown in the following examples.  
+If no `model` is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used.
 
 ```http
 GET /teams/{team-id}/channels/getAllMessages?model=A

--- a/api-reference/beta/api/chats-getallmessages.md
+++ b/api-reference/beta/api/chats-getallmessages.md
@@ -39,7 +39,9 @@ GET /users/{id | user-principal-name}/chats/getAllMessages
 
 ## Optional query parameters
 
-You can use `model` query parameter which supports the values `A` and `B`, based on the preferred licensing and payment requirements. If no `model` is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used. Following are the examples.
+You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred [licensing and payment model](/graph/teams-licenses),
+as shown in the following examples.  
+If no `model` is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used.
 
 ```http
 GET /users/{id | user-principal-name}/chats/getAllMessages?model=A

--- a/api-reference/includes/teams-subscription-notes.md
+++ b/api-reference/includes/teams-subscription-notes.md
@@ -16,8 +16,10 @@ ms.localizationpriority: medium
 You must use the `Prefer: include-unknown-enum-members` request header to get the following values in **chatMessage** **messageType** [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `systemEventMessage` for `/teams/{id}/channels/{id}/messages` and `/chats/{id}/messages` resource.
 
 > [!NOTE]
->`/teams/getAllMessages` and `/chats/getAllMessages` has [licensing and payment requirements](/graph/teams-licenses).
-> `/teams/getAllMessages` and `/chats/getAllMessages` support both `model=A` and `model=B` query parameters.
+>`/teams/getAllMessages`, `/chats/getAllMessages`, `/me/chats/getAllMessages` and `/users/{id}/chats/getAllMessages` 
+> have [licensing and payment requirements](/graph/teams-licenses).
+> `/teams/getAllMessages` and `/chats/getAllMessages` support both `model=A` and `model=B` query parameters,
+> `/me/chats/getAllMessages` and `/users/{id}/chats/getAllMessages` support only `model=B`.
 > If no model is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used.
 
 ### conversationMember

--- a/api-reference/v1.0/api/channel-getallmessages.md
+++ b/api-reference/v1.0/api/channel-getallmessages.md
@@ -39,7 +39,9 @@ GET /teams/{team-id}/channels/getAllMessages
 
 ## Optional query parameters
 
-You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred licensing and payment requirements, as shown in the following examples. 
+You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred [licensing and payment model](/graph/teams-licenses),
+as shown in the following examples.  
+If no `model` is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used.
 
 ```http
 GET /teams/{team-id}/channels/getAllMessages?model=A

--- a/api-reference/v1.0/api/chats-getallmessages.md
+++ b/api-reference/v1.0/api/chats-getallmessages.md
@@ -37,7 +37,9 @@ GET /users/{id | user-principal-name}/chats/getAllMessages
 
 ## Optional query parameters
 
-You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred licensing and payment requirements, as shown in the following examples.  
+You can use `model` query parameter, which supports the values `A` and `B`, based on the preferred [licensing and payment model](/graph/teams-licenses),
+as shown in the following examples.  
+If no `model` is specified, [evaluation mode](/graph/teams-licenses#evaluation-mode-default-requirements) will be used.
 
 ```http
 GET /users/{id | user-principal-name}/chats/getAllMessages?model=A


### PR DESCRIPTION
, and make the wording for the model query parameter more consistent.