### PR TITLE
URL correction for termstore APIs

### DIFF
--- a/api-reference/v1.0/api/termstore-group-list-sets.md
+++ b/api-reference/v1.0/api/termstore-group-list-sets.md
@@ -3,7 +3,7 @@ title: "List sets"
 description: "Get a list of the set objects and their properties."
 author: vishriv
 ms.localizationpriority: medium
-ms.prod: "taxonomy"
+ms.prod: "sites-and-lists"
 doc_type: apiPageType
 ---
 

--- a/api-reference/v1.0/api/termstore-group-list-sets.md
+++ b/api-reference/v1.0/api/termstore-group-list-sets.md
@@ -57,7 +57,7 @@ If successful, this method returns a `200 OK` response code and a collection of 
 }-->
 
 ``` http
-GET https://graph.microsoft.com/v1.0/microsoft.sharepoint.com,b9b0bc03-cbc4-40d2-aba9-2c9dd9821ddf,6a742cee-9216-4db5-8046-13a595684e74/termStore/groups/03577abb-975e-4fb4-9ee0-4102a9108f94/sets
+GET https://graph.microsoft.com/v1.0/sites/microsoft.sharepoint.com,b9b0bc03-cbc4-40d2-aba9-2c9dd9821ddf,6a742cee-9216-4db5-8046-13a595684e74/termStore/groups/03577abb-975e-4fb4-9ee0-4102a9108f94/sets
 ```
 
 ### Response

--- a/api-reference/v1.0/api/termstore-relation-post.md
+++ b/api-reference/v1.0/api/termstore-relation-post.md
@@ -3,7 +3,7 @@ title: "Create relation"
 description: "Create a new relation object."
 author: vishriv
 ms.localizationpriority: medium
-ms.prod: "taxonomy"
+ms.prod: "sites-and-lists"
 doc_type: apiPageType
 ---
 
@@ -66,7 +66,7 @@ If successful, this method returns a `201 Created` response code and a [microsof
 -->
 
 ``` http
-POST https://graph.microsoft.com/v1.0/sites/microsoft.sharepoint.com,b9b0bc03-cbc4-40d2-aba9-2c9dd9821ddf,6a742cee-9216-4db5-8046-13a595684e74/termStore/v1.0/27fd2d26-60d3-485c-9420-0c71f74a0cfd/terms/8861b57a-c777-49e7-826f-47d6afecf80d/relations
+POST https://graph.microsoft.com/v1.0/sites/microsoft.sharepoint.com,b9b0bc03-cbc4-40d2-aba9-2c9dd9821ddf,6a742cee-9216-4db5-8046-13a595684e74/termStore/27fd2d26-60d3-485c-9420-0c71f74a0cfd/terms/8861b57a-c777-49e7-826f-47d6afecf80d/relations
 Content-Type: application/json
 
 {


### PR DESCRIPTION
YAML parser is failing for a couple of URLs. This PR will fix it.