### PR TITLE
EM beta app permission update to POST resourcerequest

### DIFF
--- a/api-reference/beta/api/accesspackageresourceenvironment-get.md
+++ b/api-reference/beta/api/accesspackageresourceenvironment-get.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All|
 
 ## HTTP request
 

--- a/api-reference/beta/api/entitlementmanagement-list-accesspackageresourceenvironment.md
+++ b/api-reference/beta/api/entitlementmanagement-list-accesspackageresourceenvironment.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported|
-|Application|Not supported|
+|Application|EntitlementManagement.Read.All, EntitlementManagement.ReadWrite.All|
 
 ## HTTP request
 

--- a/api-reference/beta/api/entitlementmanagement-post-accesspackageresourcerequests.md
+++ b/api-reference/beta/api/entitlementmanagement-post-accesspackageresourcerequests.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | EntitlementManagement.ReadWrite.All  |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Not supported. |
+| Application                            | EntitlementManagement.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/beta/resources/accesspackageresource.md
+++ b/api-reference/beta/resources/accesspackageresource.md
@@ -27,7 +27,7 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 |:-------------|:------------|:------------|
 |accessPackageResourceEnvironment|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md)|Contains the environment information for the resource. This can be set using either the `@odata.bind` annotation or the environment's *originId*.|
 |attributes|[accessPackageResourceAttribute](../resources/accesspackageresourceattribute.md) collection| Contains information about the attributes to be collected from the requestor and sent to the resource application. |
-|addedBy|String|Read-only.|
+|addedBy|String|The name of the user or application which first added this resource. Read-only.|
 |addedOn|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`|
 |description|String|A description for the resource.|
 |displayName|String|The display name of the resource, such as the application name, group name or site name.|

--- a/api-reference/beta/resources/accesspackageresource.md
+++ b/api-reference/beta/resources/accesspackageresource.md
@@ -27,7 +27,7 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 |:-------------|:------------|:------------|
 |accessPackageResourceEnvironment|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md)|Contains the environment information for the resource. This can be set using either the `@odata.bind` annotation or the environment's *originId*.|
 |attributes|[accessPackageResourceAttribute](../resources/accesspackageresourceattribute.md) collection| Contains information about the attributes to be collected from the requestor and sent to the resource application. |
-|addedBy|String|The name of the user or application which first added this resource. Read-only.|
+|addedBy|String|The name of the user or application that first added this resource. Read-only.|
 |addedOn|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`|
 |description|String|A description for the resource.|
 |displayName|String|The display name of the resource, such as the application name, group name or site name.|

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -7,14 +7,15 @@
           "ApiChange": "Permission",
           "ChangedApiName": "EntitlementManagement.ReadWrite.All",
           "ChangeType": "Addition",
-          "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to [add a resource to a catalog in entitlement management](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta).",
+          "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to the [Create accessPackageResourceRequest
+](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta) operation.",
           "Target": "accessPackageResourceRequest"
         }
       ],
       "Id": "1663575c-e085-40b5-8a3e-34312515f17c",
       "Cloud": "prd",
       "Version": "beta",
-      "CreatedDateTime": "2022-02-09T00:00:01Z",
+      "CreatedDateTime": "2022-02-10T00:00:01Z",
       "WorkloadArea": "Identity and access",
       "SubArea": "Governance"
     },

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -3,6 +3,24 @@
     {
       "ChangeList": [
         {
+          "Id": "1663575c-e085-40b5-8a3e-34312515f17c",
+          "ApiChange": "Permission",
+          "ChangedApiName": "EntitlementManagement.ReadWrite.All",
+          "ChangeType": "Addition",
+          "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to [add a resource to a catalog in entitlement management](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta).",
+          "Target": "entitlementManagement"
+        }
+      ],
+      "Id": "1663575c-e085-40b5-8a3e-34312515f17c",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2022-02-09T00:00:01Z",
+      "WorkloadArea": "Identity and access",
+      "SubArea": "Governance"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "762ccb17-76e5-41b3-b0e7-e37591f954a1",
           "ApiChange": "Resource",
           "ChangedApiName": "tenantRelationshipAccessPolicyBase",

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -7,8 +7,7 @@
           "ApiChange": "Permission",
           "ChangedApiName": "EntitlementManagement.ReadWrite.All",
           "ChangeType": "Addition",
-          "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to the [Create accessPackageResourceRequest
-](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta) operation.",
+          "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to the [Create accessPackageResourceRequest](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta) operation.",
           "Target": "accessPackageResourceRequest"
         }
       ],

--- a/changelog/Microsoft.DirectoryServices.json
+++ b/changelog/Microsoft.DirectoryServices.json
@@ -8,7 +8,7 @@
           "ChangedApiName": "EntitlementManagement.ReadWrite.All",
           "ChangeType": "Addition",
           "Description": "Added support for the `EntitlementManagement.ReadWrite.All` application permission to [add a resource to a catalog in entitlement management](https://docs.microsoft.com/en-us/graph/api/entitlementmanagement-post-accesspackageresourcerequests?view=graph-rest-beta).",
-          "Target": "entitlementManagement"
+          "Target": "accessPackageResourceRequest"
         }
       ],
       "Id": "1663575c-e085-40b5-8a3e-34312515f17c",


### PR DESCRIPTION
When we added app perms to entitlement management beta last year, one API was not ready for app permissions - add a resource to a catalog.  This is because the authorization check for what an app can do when there is no user present is different than the check for delegated permissions for a user.  This feature has just been deployed for beta, so adding the EM.RW.All app permission to POST a accessPackageResourceRequest.  Also when making this change, realized had forgotten to document another permission - resource environments are readable by app as well as by users.