### PR TITLE
EM assignment request fix property name inconsistency completedDateTime

### DIFF
--- a/api-reference/v1.0/api/accesspackageassignmentrequest-get.md
+++ b/api-reference/v1.0/api/accesspackageassignmentrequest-get.md
@@ -109,7 +109,7 @@ Content-Type: application/json
   "state": "delivered",
   "status": "Delivered",
   "createdDateTime": "2019-10-25T22:55:11.623Z",
-  "completedDate": "2019-10-26T22:55:11.623Z",
+  "completedDateTime": "2019-10-26T22:55:11.623Z",
   "schedule": {
     "@odata.type": "microsoft.graph.entitlementManagementSchedule"
   }

--- a/api-reference/v1.0/api/entitlementmanagement-list-assignmentrequests.md
+++ b/api-reference/v1.0/api/entitlementmanagement-list-assignmentrequests.md
@@ -119,7 +119,7 @@ Content-Type: application/json
       "state": "delivered",
       "status": "Delivered",
       "createdDateTime": "2019-10-25T22:55:11.623Z",
-      "completedDate": "2019-10-26T22:55:11.623Z",
+      "completedDateTime": "2019-10-26T22:55:11.623Z",
       "schedule": {
         "@odata.type": "microsoft.graph.entitlementManagementSchedule"
       }

--- a/api-reference/v1.0/resources/accesspackageassignmentrequest.md
+++ b/api-reference/v1.0/resources/accesspackageassignmentrequest.md
@@ -26,7 +26,7 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|completedDate|DateTimeOffset|The date of the end of processing, either successful or failure, of a request. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
+|completedDateTime|DateTimeOffset|The date of the end of processing, either successful or failure, of a request. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
 |createdDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
 |id|String|Read-only.|
 |requestType|accessPackageRequestType|The type of the request. The possible values are: `notSpecified`, `userAdd`, `userUpdate`, `userRemove`, `adminAdd`, `adminUpdate`, `adminRemove`, `systemAdd`, `systemUpdate`, `systemRemove`, `onBehalfAdd`, `unknownFutureValue`. A request from the user themselves would have requestType of `UserAdd` or `UserRemove`. This property cannot be changed once set.|
@@ -58,7 +58,7 @@ The following is a JSON representation of the resource.
   "state": "String",
   "status": "String",
   "createdDateTime": "String (timestamp)",
-  "completedDate": "String (timestamp)",
+  "completedDateTime": "String (timestamp)",
   "schedule": {
     "@odata.type": "microsoft.graph.entitlementManagementSchedule"
   }


### PR DESCRIPTION
The v1.0 documentation had been using an older name for the property, update to match the metadata

```xml
      <EntityType Name="accessPackageAssignmentRequest" BaseType="graph.entity">
        <Property Name="completedDateTime" Type="Edm.DateTimeOffset" />
```
