### PR TITLE
EM improve consistency of property lists of resources in beta

### DIFF
--- a/api-reference/beta/resources/accesspackagecatalog.md
+++ b/api-reference/beta/resources/accesspackagecatalog.md
@@ -51,6 +51,7 @@ In [Azure AD entitlement management](entitlementmanagement-overview.md), an acce
 |:-------------|:------------|:------------|
 |accessPackages|[accessPackage](accesspackage.md) collection| The access packages in this catalog. Read-only. Nullable. Supports `$expand`.|
 |accessPackageResources|[accessPackageResource](accesspackageresource.md) collection| Read-only. Nullable.|
+|accessPackageResourceRoles|[accessPackageResourceRole](accesspackageresourcerole.md) collection|The roles of each resource in a catalog. Read-only.|
 
 ## JSON representation
 

--- a/api-reference/beta/resources/accesspackagecatalog.md
+++ b/api-reference/beta/resources/accesspackagecatalog.md
@@ -51,7 +51,8 @@ In [Azure AD entitlement management](entitlementmanagement-overview.md), an acce
 |:-------------|:------------|:------------|
 |accessPackages|[accessPackage](accesspackage.md) collection| The access packages in this catalog. Read-only. Nullable. Supports `$expand`.|
 |accessPackageResources|[accessPackageResource](accesspackageresource.md) collection| Read-only. Nullable.|
-|accessPackageResourceRoles|[accessPackageResourceRole](accesspackageresourcerole.md) collection|The roles of each resource in a catalog. Read-only.|
+|accessPackageResourceRoles|[accessPackageResourceRole](accesspackageresourcerole.md) collection|The roles in each resource in a catalog. Read-only.|
+|accessPackageResourceScopes|[accessPackageResourceScope](accesspackageresourcescope.md) collection|Read-only.|
 
 ## JSON representation
 

--- a/api-reference/beta/resources/accesspackageresource.md
+++ b/api-reference/beta/resources/accesspackageresource.md
@@ -25,7 +25,6 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 
 | Property     | Type        | Description |
 |:-------------|:------------|:------------|
-|accessPackageResourceEnvironment|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md)|Contains the environment information for the resource. This can be set using either the `@odata.bind` annotation or the environment's *originId*.|
 |attributes|[accessPackageResourceAttribute](../resources/accesspackageresourceattribute.md) collection| Contains information about the attributes to be collected from the requestor and sent to the resource application. |
 |addedBy|String|The name of the user or application that first added this resource. Read-only.|
 |addedOn|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`|
@@ -42,7 +41,7 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 
 | Relationship | Type        | Description |
 |:-------------|:------------|:------------|
-|accessPackageResourceEnvironment|[accessPackageResourceEnvironment](accesspackageresourceenvironment.md)| Nullable. Supports `$expand`.|
+|accessPackageResourceEnvironment|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md)|Contains the environment information for the resource. This can be set using either the `@odata.bind` annotation or the environment's *originId*.Supports `$expand`.|
 |accessPackageResourceRoles|[accessPackageResourceRole](accesspackageresourcerole.md) collection| Read-only. Nullable. Supports `$expand`.|
 |accessPackageResourceScopes|[accessPackageResourceScope](accesspackageresourcescope.md) collection| Read-only. Nullable. Supports `$expand`.|
 

--- a/api-reference/beta/resources/connectedorganization.md
+++ b/api-reference/beta/resources/connectedorganization.md
@@ -43,7 +43,7 @@ In [Azure AD entitlement management](entitlementmanagement-overview.md), a conne
 |modifiedBy|String|UPN of the user who last modified this resource. Read-only.|
 |modifiedDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
 |state|connectedOrganizationState|The state of a connected organization defines whether assignment policies with requestor scope type `AllConfiguredConnectedOrganizationSubjects` are applicable or not. Possible values are: `configured`, `proposed`.|
-|identitySources|[identitySource](identitySource.md) collection| The identity sources in this connected organization, one of [azureActiveDirectoryTenant](azureactivedirectorytenant.md), [domainIdentitySource](domainidentitysource.md) or [externalDomainFederation](externaldomainfederation.md). Read-only. Nullable. Supports `$select` and `$filter`(`eq`). To filter by the derived types, you must declare the resource using its full OData cast, for example, `microsoft.graph.azureActiveDirectoryTenant.`|
+|identitySources|[identitySource](identitySource.md) collection| The identity sources in this connected organization, one of [azureActiveDirectoryTenant](azureactivedirectorytenant.md), [domainIdentitySource](domainidentitysource.md) or [externalDomainFederation](externaldomainfederation.md). Read-only. Nullable. Supports `$select` and `$filter`(`eq`). To filter by the derived types, you must declare the resource using its full OData cast, for example, `$filter=identitySources/any(is:is/microsoft.graph.azureActiveDirectoryTenant/tenantId eq 'bcfdfff4-cbc3-43f2-9000-ba7b7515054f')`.|
 
 ## Relationships
 

--- a/api-reference/beta/resources/connectedorganization.md
+++ b/api-reference/beta/resources/connectedorganization.md
@@ -43,12 +43,12 @@ In [Azure AD entitlement management](entitlementmanagement-overview.md), a conne
 |modifiedBy|String|UPN of the user who last modified this resource. Read-only.|
 |modifiedDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
 |state|connectedOrganizationState|The state of a connected organization defines whether assignment policies with requestor scope type `AllConfiguredConnectedOrganizationSubjects` are applicable or not. Possible values are: `configured`, `proposed`.|
+|identitySources|[identitySource](identitySource.md) collection| The identity sources in this connected organization, one of [azureActiveDirectoryTenant](azureactivedirectorytenant.md), [domainIdentitySource](domainidentitysource.md) or [externalDomainFederation](externaldomainfederation.md). Read-only. Nullable. Supports `$select` and `$filter`(`eq`). To filter by the derived types, you must declare the resource using its full OData cast, for example, `microsoft.graph.azureActiveDirectoryTenant.`|
 
 ## Relationships
 
 |Relationship|Type|Description|
 |:---|:---|:---|
-|identitySources|[identitySource](identitySource.md) collection| The identity sources in this connected organization, one of [azureActiveDirectoryTenant](azureactivedirectorytenant.md), [domainIdentitySource](domainidentitysource.md) or [externalDomainFederation](externaldomainfederation.md). Read-only. Nullable. Supports `$select` and `$filter`(`eq`). To filter by the derived types, you must declare the resource using its full OData cast, for example, `microsoft.graph.azureActiveDirectoryTenant.`|
 |internalSponsors| [directoryObject](directoryobject.md) collection| Nullable.|
 |externalSponsors| [directoryObject](directoryobject.md) collection| Nullable.|
 


### PR DESCRIPTION
This PR does not introduce any new features or APIs, just cleans up the documentation to match the metadata for entitlement management in graph beta. A different PR covers EM in v1.0.

- accesspackageresourceroles was not listed as a relationship in catalog, though there was a API doc for it
- accesspackageresourceenvironment was listed twice in resource
- move identitysources from navigation to property in connected organization (already had been corrected in v1.0)