### PR TITLE
Adding Conversation Member Role Validation for Tenant Gust User

### DIFF
--- a/api-reference/beta/api/chat-post.md
+++ b/api-reference/beta/api/chat-post.md
@@ -48,7 +48,7 @@ The following table lists the properties that are required to create a chat obje
 |:---|:---|:---|
 |topic|(Optional) String|The title of the chat. The chat title can be provided only if the chat is of `group` type.|
 |chatType|[chatType](../resources/chat.md#chattype-values)| Specifies the type of chat. Possible values are: `group` and `oneOnOne`. |
-|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every user, including the user who initiates the create request, who will participate in the chat must be specified in this list. Each member must be assigned a role of `owner` or `guest`. Guest tenant users must be assigned the `guest` role.|
+|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every user who will participate in the chat, including the user who initiates the create request, must be specified in this list. Each member must be assigned a role of `owner` or `guest`. Guest tenant users must be assigned the `guest` role.|
 |installedApps| [teamsApp](../resources/teamsapp.md) collection|List of apps that should be installed in the chat.|
 
 > **Note:** Currently, only one app installation is supported. If multiple app installations are listed in the request, the response will be a `Bad Request` error.

--- a/api-reference/beta/api/chat-post.md
+++ b/api-reference/beta/api/chat-post.md
@@ -93,43 +93,6 @@ Content-Type: application/json
   ]
 }
 ```
-
-### Example 2: Create a group chat with a guest tenant user
-
-#### Request
-
-# [HTTP](#tab/http)
-<!-- {
-  "blockType": "request",
-  "name": "create_chat_oneOnOne"
-}
--->
-``` http
-POST https://graph.microsoft.com/beta/chats
-Content-Type: application/json
-
-{
-  "chatType": "group",
-  "members": [
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["owner"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')"
-    },
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["owner"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')"
-    }
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["guest"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98')"
-    }
-  ]
-}
-```
-
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
@@ -427,6 +390,94 @@ Content-Type: application/json
     "lastUpdatedDateTime": "2020-12-04T23:10:28.51Z",
     "chatType": "oneOnOne",
     "webUrl": "https://teams.microsoft.com/l/chat/19%3A82fe7758-5bb3-4f0d-a43f-e555fd399c6f_8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca@unq.gbl.spaces/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
+}
+```
+
+### Example 5: Create a group chat with tenant guest user
+
+#### Request
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "create_chat_group"
+}
+-->
+``` http
+POST https://graph.microsoft.com/beta/chats
+Content-Type: application/json
+
+{
+  "chatType": "group",
+  "topic": "Group chat title",
+  "members": [
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["guest"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')"
+    }
+  ]
+}
+```
+# [C#](#tab/csharp)
+[!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-group-csharp-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [JavaScript](#tab/javascript)
+[!INCLUDE [sample-code](../includes/snippets/javascript/create-chat-group-javascript-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Objective-C](#tab/objc)
+[!INCLUDE [sample-code](../includes/snippets/objc/create-chat-group-objc-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Java](#tab/java)
+[!INCLUDE [sample-code](../includes/snippets/java/create-chat-group-java-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Go](#tab/go)
+[!INCLUDE [sample-code](../includes/snippets/go/create-chat-group-go-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [PowerShell](#tab/powershell)
+[!INCLUDE [sample-code](../includes/snippets/powershell/create-chat-group-powershell-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+---
+
+
+---
+
+#### Response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.chat"
+}
+-->
+``` http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#chats/$entity",
+    "id": "19:1c5b01696d2e4a179c292bc9cf04e63b@thread.v2",
+    "topic": "Group chat title",
+    "createdDateTime": "2020-12-04T23:11:16.175Z",
+    "lastUpdatedDateTime": "2020-12-04T23:11:16.175Z",
+    "chatType": "group",
+    "webUrl": "https://teams.microsoft.com/l/chat/19%3A1c5b01696d2e4a179c292bc9cf04e63b@thread.v2/0?tenantId=b33cbe9f-8ebe-4f2a-912b-7e2a427f477f"
 }
 ```
 

--- a/api-reference/beta/api/chat-post.md
+++ b/api-reference/beta/api/chat-post.md
@@ -48,7 +48,7 @@ The following table lists the properties that are required to create a chat obje
 |:---|:---|:---|
 |topic|(Optional) String|The title of the chat. The chat title can be provided only if the chat is of `group` type.|
 |chatType|[chatType](../resources/chat.md#chattype-values)| Specifies the type of chat. Possible values are: `group` and `oneOnOne`. |
-|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every single user, including the user initiating the create request, who will participate in the chat must be specified in this list.|
+|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every single user, including the user initiating the create request, who will participate in the chat must be specified in this list. Each member must be assigned with corresponding role as `owner` or `guest`. Guest tenant user must be assigned with  `guest` role.|
 |installedApps| [teamsApp](../resources/teamsapp.md) collection|List of apps that should be installed in the chat.|
 
 > **Note:** Currently, only one app installation is supported. If multiple app installations are listed in the request, the response will be a `Bad Request` error.
@@ -93,6 +93,43 @@ Content-Type: application/json
   ]
 }
 ```
+
+### Example 2: Create a group chat with a guest tenant user
+
+#### Request
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "create_chat_oneOnOne"
+}
+-->
+``` http
+POST https://graph.microsoft.com/beta/chats
+Content-Type: application/json
+
+{
+  "chatType": "group",
+  "members": [
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')"
+    }
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["guest"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98')"
+    }
+  ]
+}
+```
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/chat-post.md
+++ b/api-reference/v1.0/api/chat-post.md
@@ -46,11 +46,11 @@ The following table lists the properties that are required to create a chat obje
 |:---|:---|:---|
 |topic|(Optional) String|The title of the chat. The chat title can be provided only if the chat is of `group` type.|
 |chatType|[chatType](../resources/chat.md#chattype-values)| Specifies the type of chat. Possible values are: `group` and `oneOnOne`. |
-|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every user, including the user who initiates the create request, who will participate in the chat must be specified in this list. Each member must be assigned a role of `owner` or `guest`. Guest tenant users must be assigned the `guest` role.|
+|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every user who will participate in the chat, including the user who initiates the create request, must be specified in this list. Each member must be assigned a role of `owner` or `guest`. Guest tenant users must be assigned the `guest` role.|
 
 ## Response
 
-If successful, this method returns a 201 Created response code and the newly created **chat** resource in the response body.
+If successful, this method returns a `201 Created` response code and the newly created **chat** resource in the response body.
 
 ## Examples
 

--- a/api-reference/v1.0/api/chat-post.md
+++ b/api-reference/v1.0/api/chat-post.md
@@ -46,7 +46,7 @@ The following table lists the properties that are required to create a chat obje
 |:---|:---|:---|
 |topic|(Optional) String|The title of the chat. The chat title can be provided only if the chat is of `group` type.|
 |chatType|[chatType](../resources/chat.md#chattype-values)| Specifies the type of chat. Possible values are: `group` and `oneOnOne`. |
-|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every single user, including the user initiating the create request, who will participate in the chat must be specified in this list.|
+|members|[conversationMember](../resources/conversationmember.md) collection|List of conversation members that should be added. Every single user, including the user initiating the create request, who will participate in the chat must be specified in this list. Each member must be assigned with corresponding role as `owner` or `guest`. Guest tenant user must be assigned with  `guest` role.|
 
 ## Response
 
@@ -85,6 +85,43 @@ Content-Type: application/json
   ]
 }
 ```
+
+### Example 2: Create a group chat with a guest tenant user
+
+#### Request
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "create_chat_oneOnOne"
+}
+-->
+``` http
+POST https://graph.microsoft.com/v1.0/chats
+Content-Type: application/json
+
+{
+  "chatType": "group",
+  "members": [
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')"
+    }
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["guest"],
+      "user@odata.bind": "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98')"
+    }
+  ]
+}
+```
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/chat-post.md
+++ b/api-reference/v1.0/api/chat-post.md
@@ -85,43 +85,6 @@ Content-Type: application/json
   ]
 }
 ```
-
-### Example 2: Create a group chat with a guest tenant user
-
-#### Request
-
-# [HTTP](#tab/http)
-<!-- {
-  "blockType": "request",
-  "name": "create_chat_oneOnOne"
-}
--->
-``` http
-POST https://graph.microsoft.com/v1.0/chats
-Content-Type: application/json
-
-{
-  "chatType": "group",
-  "members": [
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["owner"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('8b081ef6-4792-4def-b2c9-c363a1bf41d5')"
-    },
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["owner"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('82af01c5-f7cc-4a2e-a728-3a5df21afd9d')"
-    }
-    {
-      "@odata.type": "#microsoft.graph.aadUserConversationMember",
-      "roles": ["guest"],
-      "user@odata.bind": "https://graph.microsoft.com/beta/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98')"
-    }
-  ]
-}
-```
-
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
@@ -340,3 +303,89 @@ Content-Type: application/json
 }
 ```
 
+### Example 4: Create a group chat with tenant guest user
+
+#### Request
+
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "create_chat_group"
+}
+-->
+``` http
+POST https://graph.microsoft.com/v1.0/chats
+Content-Type: application/json
+
+{
+  "chatType": "group",
+  "topic": "Group chat title",
+  "members": [
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/v1.0/users('8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["owner"],
+      "user@odata.bind": "https://graph.microsoft.com/v1.0/users('82fe7758-5bb3-4f0d-a43f-e555fd399c6f')"
+    },
+    {
+      "@odata.type": "#microsoft.graph.aadUserConversationMember",
+      "roles": ["guest"],
+      "user@odata.bind": "https://graph.microsoft.com/v1.0/users('8ba98gf6-7fc2-4eb2-c7f2-aef9f21fd98g')"
+    }
+  ]
+}
+```
+# [C#](#tab/csharp)
+[!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-group-csharp-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [JavaScript](#tab/javascript)
+[!INCLUDE [sample-code](../includes/snippets/javascript/create-chat-group-javascript-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Objective-C](#tab/objc)
+[!INCLUDE [sample-code](../includes/snippets/objc/create-chat-group-objc-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Java](#tab/java)
+[!INCLUDE [sample-code](../includes/snippets/java/create-chat-group-java-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [Go](#tab/go)
+[!INCLUDE [sample-code](../includes/snippets/go/create-chat-group-go-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+# [PowerShell](#tab/powershell)
+[!INCLUDE [sample-code](../includes/snippets/powershell/create-chat-group-powershell-snippets.md)]
+[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
+
+---
+
+
+
+#### Response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.chat"
+}
+-->
+``` http
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#chats/$entity",
+    "id": "19:1c5b01696d2e4a179c292bc9cf04e63b@thread.v2",
+    "topic": "Group chat title",
+    "createdDateTime": "2020-12-04T23:11:16.175Z",
+    "lastUpdatedDateTime": "2020-12-04T23:11:16.175Z",
+    "chatType": "group"
+}
+```

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4,42 +4,6 @@
     {
       "ChangeList": [
         {
-          "Id": "7b074c21-a487-4436-93c6-16ecccac77bb",
-          "ApiChange": "",
-          "ChangedApiName": "Create",
-          "ChangeType": "",
-          "Description": "Added validaiton for conversation member role of guest tenant user.",
-          "Target": "chat"
-        }
-      ],
-      "Id": "7b074c21-a487-4436-93c6-16ecccac77bb",
-      "Cloud": "prd",
-      "Version": "v1.0",
-      "CreatedDateTime": "2022-02-15T13:04:49.407Z",
-      "WorkloadArea": "Teamwork",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
-          "Id": "03a7500b-eb79-4bdb-bc6d-aa68e3dd7aff",
-          "ApiChange": "",
-          "ChangedApiName": "Create",
-          "ChangeType": "",
-          "Description": "Added validaiton for conversation member role of guest tenant user.",
-          "Target": "chat"
-        }
-      ],
-      "Id": "03a7500b-eb79-4bdb-bc6d-aa68e3dd7aff",
-      "Cloud": "prd",
-      "Version": "beta",
-      "CreatedDateTime": "2022-02-15T13:04:49.407Z",
-      "WorkloadArea": "Teamwork",
-      "SubArea": ""
-    },
-    {
-      "ChangeList": [
-        {
           "Id": "f55c7c44-403f-4fb6-baf3-2d9bc723556b",
           "ApiChange": "Permission",
           "ChangedApiName": "teamworkTag",

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4,6 +4,42 @@
     {
       "ChangeList": [
         {
+          "Id": "7b074c21-a487-4436-93c6-16ecccac77bb",
+          "ApiChange": "",
+          "ChangedApiName": "Create",
+          "ChangeType": "",
+          "Description": "Added validaiton for conversation member role of guest tenant user.",
+          "Target": "chat"
+        }
+      ],
+      "Id": "7b074c21-a487-4436-93c6-16ecccac77bb",
+      "Cloud": "prd",
+      "Version": "v1.0",
+      "CreatedDateTime": "2022-02-15T13:04:49.407Z",
+      "WorkloadArea": "Teamwork",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "03a7500b-eb79-4bdb-bc6d-aa68e3dd7aff",
+          "ApiChange": "",
+          "ChangedApiName": "Create",
+          "ChangeType": "",
+          "Description": "Added validaiton for conversation member role of guest tenant user.",
+          "Target": "chat"
+        }
+      ],
+      "Id": "03a7500b-eb79-4bdb-bc6d-aa68e3dd7aff",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2022-02-15T13:04:49.407Z",
+      "WorkloadArea": "Teamwork",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "f55c7c44-403f-4fb6-baf3-2d9bc723556b",
           "ApiChange": "Permission",
           "ChangedApiName": "teamworkTag",
@@ -4331,7 +4367,7 @@
     },
     {
       "ChangeList": [
-        {           
+        {
           "Id": "5a1d17b0-c9a6-4c4f-ad7f-f57703ea9518",
           "ApiChange": "EnumType",
           "ChangedApiName": "teamworkConnectionStatus",


### PR DESCRIPTION
Adding Conversation Member Role Validation for Tenant Guest User when Chat is created.
Request will fail when tenant guest user is marked as "owner".