### PR TITLE
Minor fixes on participant invite and stop hold music docs

### DIFF
--- a/api-reference/beta/api/participant-invite.md
+++ b/api-reference/beta/api/participant-invite.md
@@ -1,7 +1,7 @@
 ---
 title: "participant: invite"
 description: "Invite participants to the active call."
-author: "ananmishr"
+author: "mkhribech"
 ms.localizationpriority: medium
 ms.prod: "cloud-communications"
 doc_type: apiPageType
@@ -17,7 +17,7 @@ Invite participants to the active call.
 
 For more information about how to handle operations, see [commsoperation](../resources/commsoperation.md).
 
->**Note:** This API is only supported for group calls.
+>**Note:** Inviting multiple participants in one request is only supported for group calls.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -51,7 +51,7 @@ In the request body, provide a JSON object with the following parameters.
 |clientContext|String|Unique Client Context string. Max limit is 256 chars.|
 
 ## Response
-If succsessful, this method returns a `200 OK` response code and a Location header with a URI to the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created for this request. The body of the response contains the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created.
+If successful, this method returns a `200 OK` response code and a Location header with a URI to the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created for this request. The body of the response contains the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created.
 
 >**Note:** When this API returns a successful response, all participants will receive a roster update.
 
@@ -61,7 +61,7 @@ The following examples show how to call this API.
 
 > **Note:** The response objects might be shortened for readability. All the properties will be returned from an actual call.
 
-### Example 1: Invite one participant to an existing group call
+### Example 1: Invite one participant to an existing call
 
 #### Request
 

--- a/api-reference/beta/api/participant-stopholdmusic.md
+++ b/api-reference/beta/api/participant-stopholdmusic.md
@@ -115,38 +115,8 @@ Location: https://graph.microsoft.com/beta/communications/calls/e141b67c-90fd-45
 {
   "@odata.type": "#microsoft.graph.stopHoldMusicOperation",
   "id": "0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-  "status": "running",
-  "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c"
-}
-```
-
-### Notification sent to the application after the stopHoldMusicOperation finishes
-
-```http
-POST https://bot.contoso.com/api/calls
-Content-Type: application/json
-```
-
-<!-- {
-  "blockType": "example",
-  "@odata.type": "microsoft.graph.commsNotifications"
-}-->
-```json
-{
-  "@odata.type": "#microsoft.graph.commsNotifications",
-  "value": [
-    {
-      "@odata.type": "#microsoft.graph.commsNotification",
-      "changeType": "deleted",
-      "resourceUrl": "communications/calls/e141b67c-90fd-455d-858b-b48a40b9cc8d/operations/0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-      "resourceData": {
-        "@odata.type": "#microsoft.graph.stopHoldMusicOperation",
-        "@odata.id": "communications/calls/e141b67c-90fd-455d-858b-b48a40b9cc8d/operations/0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-        "@odata.etag": "W/\"54451\"",
-        "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c",
-        "status": "completed"
-      }
-    }
-  ]
+  "status": "completed",
+  "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c",
+  "resultInfo": null
 }
 ```

--- a/api-reference/v1.0/api/participant-invite.md
+++ b/api-reference/v1.0/api/participant-invite.md
@@ -1,7 +1,7 @@
 ---
 title: "participant: invite"
 description: "Invite participants to the active call."
-author: "ananmishr"
+author: "mkhribech"
 ms.localizationpriority: medium
 ms.prod: "cloud-communications"
 doc_type: apiPageType
@@ -15,7 +15,7 @@ Invite participants to the active call.
 
 For more information about how to handle operations, see [commsoperation](../resources/commsoperation.md).
 
->**Note:** This API is only supported for group calls.
+>**Note:** Inviting multiple participants in one request is only supported for group calls.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -47,7 +47,7 @@ In the request body, provide a JSON object with the following parameters.
 |clientContext|String|Unique Client Context string. Max limit is 256 chars.|
 
 ## Response
-If succsessful, this method returns a `200 OK` response code and a location header with a URI to the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created for this request. 
+If successful, this method returns a `200 OK` response code and a location header with a URI to the [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md) created for this request. 
 
 The body of the response contains the created [inviteParticipantsOperation](../resources/inviteparticipantsoperation.md).
 
@@ -59,7 +59,7 @@ The following examples show how to call this API.
 
 > **Note:** The response objects might be shortened for readability. All the properties will be returned from an actual call.
 
-### Example 1: Invite one participant to an existing group call
+### Example 1: Invite one participant to an existing call
 
 ##### Request
 

--- a/api-reference/v1.0/api/participant-stopholdmusic.md
+++ b/api-reference/v1.0/api/participant-stopholdmusic.md
@@ -113,38 +113,8 @@ Location: https://graph.microsoft.com/v1.0/communications/calls/e141b67c-90fd-45
 {
   "@odata.type": "#microsoft.graph.stopHoldMusicOperation",
   "id": "0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-  "status": "running",
-  "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c"
-}
-```
-
-### Notification sent to the application after the stopHoldMusicOperation finishes
-
-```http
-POST https://bot.contoso.com/api/calls
-Content-Type: application/json
-```
-
-<!-- {
-  "blockType": "example",
-  "@odata.type": "microsoft.graph.commsNotifications"
-}-->
-```json
-{
-  "@odata.type": "#microsoft.graph.commsNotifications",
-  "value": [
-    {
-      "@odata.type": "#microsoft.graph.commsNotification",
-      "changeType": "deleted",
-      "resourceUrl": "communications/calls/e141b67c-90fd-455d-858b-b48a40b9cc8d/operations/0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-      "resourceData": {
-        "@odata.type": "#microsoft.graph.stopHoldMusicOperation",
-        "@odata.id": "communications/calls/e141b67c-90fd-455d-858b-b48a40b9cc8d/operations/0fe0623f-d628-42ed-b4bd-8ac290072cc5",
-        "@odata.etag": "W/\"54451\"",
-        "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c",
-        "status": "completed"
-      }
-    }
-  ]
+  "status": "completed",
+  "clientContext": "d45324c1-fcb5-430a-902c-f20af696537c",
+  "resultInfo": null
 }
 ```


### PR DESCRIPTION
- Clarify note on participant invite doc to indicate it can now be used on peer to peer calls
- Fix stop hold music examples by deleting a notification the service does not send