### PR TITLE
Making Note to requests using UPN that UPN is not same as user email.

### DIFF
--- a/api-reference/beta/api/channel-post-members.md
+++ b/api-reference/beta/api/channel-post-members.md
@@ -216,6 +216,8 @@ Content-type: application/json
     "user@odata.bind": "https://graph.microsoft.com/beta/users('jacob@contoso.com')"
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/channel-add-member-3-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/channel-post.md
+++ b/api-reference/beta/api/channel-post.md
@@ -391,6 +391,8 @@ Content-type: application/json
      ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-private-channel-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/chat-post-members.md
+++ b/api-reference/beta/api/chat-post-members.md
@@ -279,6 +279,8 @@ content-type: application/json
     "roles": ["owner"]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-conversation-member-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/chat-post.md
+++ b/api-reference/beta/api/chat-post.md
@@ -342,6 +342,8 @@ Content-Type: application/json
   ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/chat-sendactivitynotification.md
+++ b/api-reference/beta/api/chat-sendactivitynotification.md
@@ -252,6 +252,8 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 
 
 #### Response

--- a/api-reference/beta/api/conversationmembers-add.md
+++ b/api-reference/beta/api/conversationmembers-add.md
@@ -270,6 +270,8 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/bulkaddmembers-team-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/team-post-members.md
+++ b/api-reference/beta/api/team-post-members.md
@@ -143,6 +143,8 @@ Content-type: application/json
     "user@odata.bind": "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')"
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-conversationmember-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/team-post.md
+++ b/api-reference/beta/api/team-post.md
@@ -715,6 +715,8 @@ Content-Type: application/json
    ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-team-post-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/beta/api/team-sendactivitynotification.md
+++ b/api-reference/beta/api/team-sendactivitynotification.md
@@ -263,6 +263,7 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
 
 
 #### Response

--- a/api-reference/v1.0/api/channel-post-members.md
+++ b/api-reference/v1.0/api/channel-post-members.md
@@ -200,6 +200,8 @@ Content-type: application/json
     "user@odata.bind": "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')"
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/channel-add-member-3-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/channel-post.md
+++ b/api-reference/v1.0/api/channel-post.md
@@ -328,6 +328,8 @@ Content-type: application/json
      ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-private-channel-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/chat-post-members.md
+++ b/api-reference/v1.0/api/chat-post-members.md
@@ -271,6 +271,8 @@ content-type: application/json
     "roles": ["owner"]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-conversation-member-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/chat-post.md
+++ b/api-reference/v1.0/api/chat-post.md
@@ -253,6 +253,8 @@ Content-Type: application/json
   ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-chat-oneonone-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/chat-sendactivitynotification.md
+++ b/api-reference/v1.0/api/chat-sendactivitynotification.md
@@ -223,6 +223,8 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/chat-sendactivitynotification-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/conversationmembers-add.md
+++ b/api-reference/v1.0/api/conversationmembers-add.md
@@ -271,6 +271,8 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/bulkaddmembers-team-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/team-post-members.md
+++ b/api-reference/v1.0/api/team-post-members.md
@@ -145,6 +145,8 @@ Content-type: application/json
     "user@odata.bind": "https://graph.microsoft.com/v1.0/users('jacob@contoso.com')"
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-conversationmember-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/team-post.md
+++ b/api-reference/v1.0/api/team-post.md
@@ -717,6 +717,8 @@ Content-Type: application/json
    ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/create-team-post-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]

--- a/api-reference/v1.0/api/team-sendactivitynotification.md
+++ b/api-reference/v1.0/api/team-sendactivitynotification.md
@@ -240,6 +240,8 @@ Content-Type: application/json
     ]
 }
 ```
+>**Note:** User principal name is not the same as email.
+
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/team-sendactivitynotification-upn-csharp-snippets.md)]
 [!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]


### PR DESCRIPTION
Adding Warning Notes to Examples with UPN that "User principal name does not equal to email"