### PR TITLE
Update verbiage on schema update capabilities

### DIFF
--- a/concepts/connecting-external-content-manage-connections.md
+++ b/concepts/connecting-external-content-manage-connections.md
@@ -66,8 +66,8 @@ Before an application can add items to the search index, it must create and conf
 - [Create a connection](/graph/api/external-post-connections?view=graph-rest-beta&preserve-view=true) with a unique ID, display name, and description.
 - [Register a schema](/graph/api/externalconnection-post-schema?view=graph-rest-beta&preserve-view=true) to define the fields that will be included in the index.
 
-> [!IMPORTANT]
-> After a schema has been registered, it cannot be changed for an existing connection.
+> [!NOTE]
+> Please see [Schema update capabilities](./connecting-external-content-manage-schema#schema-update-capabilities) for additional information on updating the schema for an existing connection.
 
 ## Update a connection
 

--- a/concepts/connecting-external-content-manage-connections.md
+++ b/concepts/connecting-external-content-manage-connections.md
@@ -67,7 +67,7 @@ Before an application can add items to the search index, it must create and conf
 - [Register a schema](/graph/api/externalconnection-post-schema?view=graph-rest-beta&preserve-view=true) to define the fields that will be included in the index.
 
 > [!NOTE]
-> Please see [Schema update capabilities](./connecting-external-content-manage-schema#schema-update-capabilities) for additional information on updating the schema for an existing connection.
+> Please see [Schema update capabilities](/graph/connecting-external-content-manage-schema#schema-update-capabilities) for additional information on updating the schema for an existing connection.
 
 ## Update a connection
 
@@ -79,7 +79,7 @@ You can [delete a connection](/graph/api/externalconnection-delete?view=graph-re
 
 ## Next steps
 
-- [Register the connection schema](./connecting-external-content-manage-schema.md)
+- [Register the connection schema](/graph/connecting-external-content-manage-schema.md)
 - [Review the Graph Connectors API reference](/graph/api/resources/indexing-api-overview?view=graph-rest-beta&preserve-view=true)
 - [Overview for Microsoft Graph Connectors](/microsoftsearch/connectors-overview)
 - Download the [sample search connector](https://github.com/microsoftgraph/msgraph-search-connector-sample) from GitHub

--- a/concepts/connecting-external-content-manage-connections.md
+++ b/concepts/connecting-external-content-manage-connections.md
@@ -61,13 +61,13 @@ A connection allows your application to [define a schema](/graph/api/externalcon
 
 ## Create a connection
 
-Before an application can add items to the search index, it must create and configure a connection using the following steps.
+Before an application can add items to the search index, it must create and configure a connection using the following steps:
 
 - [Create a connection](/graph/api/external-post-connections?view=graph-rest-beta&preserve-view=true) with a unique ID, display name, and description.
 - [Register a schema](/graph/api/externalconnection-post-schema?view=graph-rest-beta&preserve-view=true) to define the fields that will be included in the index.
 
 > [!NOTE]
-> Please see [Schema update capabilities](/graph/connecting-external-content-manage-schema#schema-update-capabilities) for additional information on updating the schema for an existing connection.
+> For information about updating the schema for an existing connection, see [Schema update capabilities](/graph/connecting-external-content-manage-schema#schema-update-capabilities).
 
 ## Update a connection
 


### PR DESCRIPTION
Previously schema changes were not possible.  With recent releases to support limited updates to schema, updating verbiage to now link to the article for this information.