### PR TITLE
Fix title to be in sync with breadcrumb path

### DIFF
--- a/api-reference/beta/api/team-teamsappinstallation-upgrade.md
+++ b/api-reference/beta/api/team-teamsappinstallation-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: "teamsAppInstallation: upgrade"
+title: "Upgrade app installed in team"
 description: "Upgrade an app installation in a team"
 author: "akjo"
 ms.localizationpriority: medium
@@ -7,7 +7,7 @@ ms.prod: "microsoft-teams"
 doc_type: apiPageType
 ---
 
-# teamsAppInstallation: upgrade
+# Upgrade app installed in team
 
 Namespace: microsoft.graph
 

--- a/api-reference/v1.0/api/team-teamsappinstallation-upgrade.md
+++ b/api-reference/v1.0/api/team-teamsappinstallation-upgrade.md
@@ -1,5 +1,5 @@
 ---
-title: "teamsAppInstallation in team: upgrade"
+title: "Upgrade app installed in team"
 description: "Upgrade an app installation in a team"
 author: "akjo"
 ms.localizationpriority: medium
@@ -7,7 +7,7 @@ ms.prod: "microsoft-teams"
 doc_type: apiPageType
 ---
 
-# teamsAppInstallation in team: upgrade
+# Upgrade app installed in team
 
 Namespace: microsoft.graph
 


### PR DESCRIPTION
Getting title of the page to be in sync with the breadcrumb path/side-rail path as in other API documents.
