### PR TITLE
Remove USGov support warning from NamedLocation doc

### DIFF
--- a/api-reference/beta/resources/countrynamedlocation.md
+++ b/api-reference/beta/resources/countrynamedlocation.md
@@ -32,7 +32,7 @@ Inherits from [namedLocation](../resources/namedLocation.md)
 | Property     | Type        | Description |
 |:-------------|:------------|:------------|
 |countriesAndRegions|String collection|List of countries and/or regions in two-letter format specified by ISO 3166-2.|
-|countryLookupMethod|countryLookupMethodType|Determines what method is used to decide which country the user is located in. Possible values are `clientIpAddress` (default) and `authenticatorAppGps`. Note: `authenticatorAppGps` is not yet supported in the Microsoft Cloud for US Government.|
+|countryLookupMethod|countryLookupMethodType|Determines what method is used to decide which country the user is located in. Possible values are `clientIpAddress` (default) and `authenticatorAppGps`.|
 |createdDateTime|DateTimeOffset|The Timestamp type represents creation date and time of the location using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. Inherited from [namedLocation](../resources/namedLocation.md).|
 |displayName|String|Human-readable name of the location. Required. Inherited from [namedLocation](../resources/namedLocation.md).|
 |id|String|Identifier of a namedLocation object. Read-only. Inherited from [namedLocation](../resources/namedLocation.md).|


### PR DESCRIPTION
As this feature was fully enabled on USGov, we should remove this note from the docs.