### PR TITLE
Accept-Language header support for GET service principals

### DIFF
--- a/api-reference/beta/api/serviceprincipal-get.md
+++ b/api-reference/beta/api/serviceprincipal-get.md
@@ -45,6 +45,9 @@ The use of `$select` to get **keyCredentials** for service principals has a thro
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
+| Accept-Language| Language code. Optional.   |
+
+Providing the Accept-Language header with a supported language code, such as es-ES or de-DE, will return localized values where available. Note that the header is not supported for [list operations](../serviceprincipal-list.md).
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceprincipal-get.md
+++ b/api-reference/beta/api/serviceprincipal-get.md
@@ -47,7 +47,7 @@ The use of `$select` to get **keyCredentials** for service principals has a thro
 | Authorization  | Bearer {token}. Required.  |
 | Accept-Language| Language code. Optional.   |
 
-Providing the Accept-Language header with a supported language code, such as es-ES or de-DE, will return localized values where available. Note that the header is not supported for [list operations](../serviceprincipal-list.md).
+Providing the **Accept-Language** header with a supported language code, such as `es-ES` or `de-DE`, will return localized values where available. Note that the header is not supported for [list operations](serviceprincipal-list.md).
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceprincipal-get.md
+++ b/api-reference/v1.0/api/serviceprincipal-get.md
@@ -40,6 +40,9 @@ The use of `$select` to get **keyCredentials** for service principals has a thro
 | Name           | Description                |
 |:---------------|:---------------------------|
 | Authorization  | Bearer {token}. Required.  |
+| Accept-Language| Language code. Optional.   |
+
+Providing the Accept-Language header with a supported language code, such as es-ES or de-DE, will return localized values where available. Note that the header is not supported for [list operations](../serviceprincipal-list.md).
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceprincipal-get.md
+++ b/api-reference/v1.0/api/serviceprincipal-get.md
@@ -42,7 +42,7 @@ The use of `$select` to get **keyCredentials** for service principals has a thro
 | Authorization  | Bearer {token}. Required.  |
 | Accept-Language| Language code. Optional.   |
 
-Providing the Accept-Language header with a supported language code, such as es-ES or de-DE, will return localized values where available. Note that the header is not supported for [list operations](../serviceprincipal-list.md).
+Providing the **Accept-Language** header with a supported language code, such as `es-ES` or `de-DE`, will return localized values where available. Note that the header is not supported for [list operations](serviceprincipal-list.md).
 
 ## Request body
 Do not supply a request body for this method.


### PR DESCRIPTION
Documented that we support passing the Accept-Language header to retrieve localized values on service principals, if available.