### PR TITLE
Update description externalItemContent type

### DIFF
--- a/api-reference/beta/resources/externalconnectors-externalitemcontent.md
+++ b/api-reference/beta/resources/externalconnectors-externalitemcontent.md
@@ -20,7 +20,7 @@ The content of an [externalItem](externalconnectors-externalitem.md) indexed via
 | Property | Type   | Description                                                                                 |
 |:---------|:-------|:--------------------------------------------------------------------------------------------|
 | value    | String | The content for the externalItem. Required.                                                 |
-| type     | String | The type of content in the value property. Possible values are `text` and `html`. Required. |
+| type     | String | The type of content in the value property. Possible values are `text` and `html`. These are the content types that the indexer supports, and not the file extension types allowed. Required. |
 
 ## Relationships
 

--- a/api-reference/v1.0/resources/externalconnectors-externalitemcontent.md
+++ b/api-reference/v1.0/resources/externalconnectors-externalitemcontent.md
@@ -16,7 +16,7 @@ The content of an [externalItem](externalconnectors-externalitem.md) indexed via
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|type|microsoft.graph.externalConnectors.externalItemContentType|The type of content in the value property. Possible values are: `text`, `html`, `unknownFutureValue`.|
+|type|microsoft.graph.externalConnectors.externalItemContentType|The type of content in the value property. Possible values are: `text`, `html`, `unknownFutureValue`. These are the content types that the indexer supports, and not the file extension types allowed.|
 |value|String|The content for the externalItem. Required.|
 
 ## Relationships

--- a/concepts/connecting-external-content-manage-items.md
+++ b/concepts/connecting-external-content-manage-items.md
@@ -36,7 +36,7 @@ The properties component is used to add item metadata that is useful in Microsof
 
 The content component is used to add the bulk of the item that needs to be full text indexed. Examples include ticket description, parsed text from a file body, or a wiki page body.
 
-Content is one of the key fields influencing [relevance](./connecting-external-content-manage-schema.md#relevance) across Microsoft experiences. The content types `text` and `HTML` are supported. If your data source has other content types such as binary files, videos or images, you can parse them to text before adding them to Microsoft Graph. For instance, using optical character recognition to extract searchable text from images.
+Content is one of the key fields influencing [relevance](./connecting-external-content-manage-schema.md#relevance) across Microsoft experiences. The content types `text` and `html` are supported. If your data source has other content types, such as binary files, videos, or images, you can parse them to text before adding them to Microsoft Graph. For example, you can use optical character recognition to extract searchable text from images.
 
 ![An example content component](./images/connectors-images/connecting-external-content-manage-items-2.png)
 

--- a/concepts/connecting-external-content-manage-items.md
+++ b/concepts/connecting-external-content-manage-items.md
@@ -36,7 +36,7 @@ The properties component is used to add item metadata that is useful in Microsof
 
 The content component is used to add the bulk of the item that needs to be full text indexed. Examples include ticket description, parsed text from a file body, or a wiki page body.
 
-Content is one of the key fields influencing [relevance](./connecting-external-content-manage-schema.md#relevance) across Microsoft experiences. The content types `text` and `HTML` are supported. If your data source has binary files, you can parse them to text before adding them to Microsoft Graph.
+Content is one of the key fields influencing [relevance](./connecting-external-content-manage-schema.md#relevance) across Microsoft experiences. The content types `text` and `HTML` are supported. If your data source has other content types such as binary files, videos or images, you can parse them to text before adding them to Microsoft Graph. For instance, using optical character recognition to extract searchable text from images.
 
 ![An example content component](./images/connectors-images/connecting-external-content-manage-items-2.png)
 


### PR DESCRIPTION
Addressing feedback from a customer (OpenText) that they assumed only HTML and Text files were supported. Updating the description for the 'type' property of externalItemContent to reduce the confusion.