### PR TITLE
fix unified role management resource link for EM

### DIFF
--- a/api-reference/v1.0/resources/rbacapplication.md
+++ b/api-reference/v1.0/resources/rbacapplication.md
@@ -11,7 +11,7 @@ doc_type: "resourcePageType"
 
 Namespace: microsoft.graph
 
-Role management container for unified role definitions and role assignments for Microsoft 365 role-based access control (RBAC) providers. The role assignments support only a single principal and a single scope. Currently **directory** is the only RBAC provider supported.
+Role management container for unified role definitions and role assignments for Microsoft 365 role-based access control (RBAC) providers. The role assignments support only a single principal and a single scope. Currently **directory** and **entitlementManagement** are the two RBAC providers supported.
 
 ## Methods
 

--- a/api-reference/v1.0/resources/rolemanagement.md
+++ b/api-reference/v1.0/resources/rolemanagement.md
@@ -11,10 +11,11 @@ doc_type: "resourcePageType"
 
 Namespace: microsoft.graph
 
-Represents a Microsoft 365 role-based access control (RBAC) role management entity. This resource provides access to role definitions and role assignments surfaced from RBAC providers. **directory** (Azure Active Directory) and **deviceManagement** (Intune) providers are currently supported.
+Represents a Microsoft 365 role-based access control (RBAC) role management entity. This resource provides access to role definitions and role assignments surfaced from RBAC providers. **directory** (Azure Active Directory), **entitlementManagement**  and **deviceManagement** (Intune) providers are currently supported.
 
 For more information, see: 
 * [Administrator role permissions in Azure Active Directory](/azure/active-directory/roles/custom-overview).
+* [Delegation and roles in Azure AD entitlement management](/azure/active-directory/governance/entitlement-management-delegate).
 * [Role-based access control (RBAC) with Microsoft Intune](/mem/intune/fundamentals/role-based-access-control)
 
 ## Methods
@@ -30,7 +31,7 @@ None.
 | Relationship | Type        | Description |
 |:-------------|:------------|:------------|
 |directory|[rbacApplication](rbacapplication.md)| Read-only. Nullable.|
-|entitlementManagement|[entitlementManagement](entitlementmanagement.md)| Container for all entitlement management resources in Azure AD identity governance.|
+|entitlementManagement|[rbacApplication](rbacapplication.md)| Container for roles and assignments for [entitlement management](entitlementmanagement.md) resources.|
 
 ## JSON representation
 

--- a/api-reference/v1.0/resources/rolemanagement.md
+++ b/api-reference/v1.0/resources/rolemanagement.md
@@ -11,7 +11,7 @@ doc_type: "resourcePageType"
 
 Namespace: microsoft.graph
 
-Represents a Microsoft 365 role-based access control (RBAC) role management entity. This resource provides access to role definitions and role assignments surfaced from RBAC providers. **directory** (Azure Active Directory), **entitlementManagement**  and **deviceManagement** (Intune) providers are currently supported.
+Represents a Microsoft 365 role-based access control (RBAC) role management entity. This resource provides access to role definitions and role assignments surfaced from RBAC providers. **directory** (Azure Active Directory), **entitlementManagement**,  and **deviceManagement** (Intune) providers are currently supported.
 
 For more information, see: 
 * [Administrator role permissions in Azure Active Directory](/azure/active-directory/roles/custom-overview).


### PR DESCRIPTION
The role management resource article links to entitlement management topic, but in the wrong field, as the data type rather than as the description of the scenario. Entitlement Management uses `rbacApplication`, like directory. 

This PR just fixes the resources article; a later separate PR will update the role management API articles to add examples and permission references for the entitlement management scenario (currently those just document the /directory/ scenario.) This later PR will be based on content previously developed for adding entitlement management to the beta unified role management API articles.