### PR TITLE
Remove preview and update to v1.0 endpoints

### DIFF
--- a/concepts/search-concept-custom-types.md
+++ b/concepts/search-concept-custom-types.md
@@ -6,15 +6,15 @@ ms.localizationpriority: medium
 ms.prod: "search"
 ---
 
-# Use the Microsoft Search API to search custom types imported using Microsoft Graph connectors (preview) 
+# Use the Microsoft Search API to search custom types imported using Microsoft Graph connectors
 
-Use the Microsoft Search API to search across content ingested and indexed by [Microsoft Graph connectors](/microsoftsearch/connectors-overview). The content is imported either via [built-in connectors](/microsoftsearch/connectors-gallery) provided by Microsoft, or via custom connectors implemented using the [Microsoft Graph connectors ingestion API](/graph/api/resources/indexing-api-overview?view=graph-rest-beta&preserve-view=true).
+Use the Microsoft Search API to search across content ingested and indexed by [Microsoft Graph connectors](/microsoftsearch/connectors-overview). The content is imported either via [built-in connectors](https://www.microsoft.com/microsoft-search/connectors) provided by Microsoft, or via custom connectors implemented using the [Microsoft Graph connectors ingestion API](/graph/api/resources/indexing-api-overview).
 
 [!INCLUDE [search-schema-updated](../includes/search-schema-updated.md)]
 
 Once the content has been imported and indexed, you can use the search API to query the content.
 
-To search for custom types, specify the following properties in the request body of the [query](/graph/api/search-query?view=graph-rest-beta&preserve-view=true) method:
+To search for custom types, specify the following properties in the request body of the [query](/graph/api/search-query) method:
 
 - The **contentSources** property to include the connection ID that is assigned during the connector setup. You can pass multiple connection IDs to search across multiple connections. Results are returned in a single list, ranked across the multiple connections.
 
@@ -26,7 +26,7 @@ TODOSEARCHAPI - Bug 1653398
 
 - The **fields** property to include the fields in the external item to retrieve. Note that if you do not include any **fields** in the request, the response will contain all the fields marked as *retrievable* in the data schema specified for the specified connections in the **contentSources** property.
 
-In addition, you can aggregate search results based on properties in an [externalItem](/graph/api/resources/externalitem?view=graph-rest-beta&preserve-view=true) that are numeric or string type, and that are set to be refinable in the [schema](/graph/api/resources/schema?view=graph-rest-beta&preserve-view=true). For more information, see [Refine search results using aggregations](search-concept-aggregation.md).
+In addition, you can aggregate search results based on properties in an [externalItem](/graph/api/resources/externalitem) that are numeric or string type, and that are set to be refinable in the [schema](/graph/api/resources/schema). For more information, see [Refine search results using aggregations](search-concept-aggregation.md).
 
 ## Example 1: Retrieve items using Azure SQL built-in connector
 
@@ -35,7 +35,7 @@ In this example, the content of the [AdventureWorks](/sql/samples/adventureworks
 ### Request
 
 ```HTTP
-POST https://graph.microsoft.com/beta/search/query
+POST https://graph.microsoft.com/v1.0/search/query
 Content-Type: application/json
 
 {
@@ -70,7 +70,7 @@ HTTP/1.1 200 OK
 Content-type: application/json
 
 {
-  "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.searchResponse)",
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.searchResponse)",
   "value": [
     {
       "searchTerms": ["yang"],
@@ -121,7 +121,7 @@ Content-type: application/json
 ### Request
 
 ```HTTP
-POST https://graph.microsoft.com/beta/search/query
+POST https://graph.microsoft.com/v1.0/search/query
 Content-Type: application/json
 
 {
@@ -158,7 +158,7 @@ HTTP/1.1 200 OK
 Content-type: application/json
 
 {
-  "@odata.context": "https://graph.microsoft.com/beta/$metadata#Collection(microsoft.graph.searchResponse)",
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#Collection(microsoft.graph.searchResponse)",
 "value": [
       {
         "searchTerms": [
@@ -231,8 +231,8 @@ Content-type: application/json
 }
 ```
 
-For more details, see [Assign property labels](/microsoftsearch/configure-connector#step-5-assign-property-labels).
+For more details, see [Assign property labels](/microsoftsearch/configure-connector#step-6-assign-property-labels).
 
 ## Next steps
 
-- [Use the Microsoft Search API to query data](/graph/api/resources/search-api-overview?view=graph-rest-beta&preserve-view=true)
+- [Use the Microsoft Search API to query data](/graph/api/resources/search-api-overview)


### PR DESCRIPTION
Remove preview label from title.
Update examples to use v1.0 endpoint.
Update docs links to v1.0 versions.
Fix incorrect links to Graph connector gallery and "assign property labels" more info.