### PR TITLE
update to use new iterator api

### DIFF
--- a/concepts/sdks/paging.md
+++ b/concepts/sdks/paging.md
@@ -141,10 +141,7 @@ options := messages.MessagesRequestBuilderGetOptions{
 result, err := client.Me().Messages().Get(&options)
 
 // Initialize iterator
-pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase,
-    func() serialization.Parsable {
-        return messages.NewMessagesResponse()
-    })
+pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
 
 // Any custom headers sent in original request should also be added
 // to the iterator
@@ -271,10 +268,7 @@ options := messages.MessagesRequestBuilderGetOptions{
 result, err := client.Me().Messages().Get(&options)
 
 // Initialize iterator
-pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase,
-    func() serialization.Parsable {
-        return messages.NewMessagesResponse()
-    })
+pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
 
 // Any custom headers sent in original request should also be added
 // to the iterator

--- a/concepts/sdks/paging.md
+++ b/concepts/sdks/paging.md
@@ -141,7 +141,7 @@ options := messages.MessagesRequestBuilderGetOptions{
 result, err := client.Me().Messages().Get(&options)
 
 // Initialize iterator
-pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
+pageIterator, err := msgraphcore.NewPageIterator(result, adapter, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
 
 // Any custom headers sent in original request should also be added
 // to the iterator
@@ -268,7 +268,7 @@ options := messages.MessagesRequestBuilderGetOptions{
 result, err := client.Me().Messages().Get(&options)
 
 // Initialize iterator
-pageIterator, err := msgraphcore.NewPageIterator(result, adapter.GraphRequestAdapterBase, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
+pageIterator, err := msgraphcore.NewPageIterator(result, adapter, graph.CreateMessageCollectionResponseFromDiscriminatorValue)
 
 // Any custom headers sent in original request should also be added
 // to the iterator


### PR DESCRIPTION
The new page iterator api was updated https://github.com/microsoftgraph/msgraph-sdk-go-core/commit/63efd75fcd80c130dd9d01055d97143c04f5cc06 and the example in the readme is out of date. This updates the readme example to use the current new page iterator api