### PR TITLE
[BrokenLinksH2] fixing broken link

### DIFF
--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -296,7 +296,7 @@ The **allowExternalSenders** property can only be accessed on unified groups. Ac
 
 ### Removing a group owner also removes the user as a group member
 
-When [DELETE /groups/{id}/owners](/graph/api/group-delete-owners.md) is called for a group that is associated with a [team](/graph/api/resources/team.md), the user is also removed from the /groups/{id}/members list. To work around this, remove the user from both owners and members, then wait 10 seconds, then add them back to members.
+When [DELETE /groups/{id}/owners](/graph/api/group-delete-owners) is called for a group that is associated with a [team](/graph/api/resources/team.md), the user is also removed from the /groups/{id}/members list. To work around this, remove the user from both owners and members, then wait 10 seconds, then add them back to members.
 
 ## Identity and access
 


### PR DESCRIPTION
**Global effort to fix broken links**

@MSGraphDocsVTeam 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. Please review within five business days and merge, or comment in the PR with any changes you'd like to see. Thanks!