### PR TITLE
[BrokenLinksH2] fixing broken link

### DIFF
--- a/concepts/permissions-reference.md
+++ b/concepts/permissions-reference.md
@@ -224,7 +224,7 @@ Currently the only catalog is the list of applications in [Microsoft Teams](team
 ### Example usage
 
 #### Delegated
-* _AppCatalog.ReadWrite.All_: [List all applications in catalog](/graph/api/teamsapp-list?view=graph-rest-beta&preserve-view=true) (`GET /beta/appCatalogs/teamsApps`)
+* _AppCatalog.ReadWrite.All_: [List all applications in catalog](/graph/api/appcatalogs-list-teamsapps) (`GET /beta/appCatalogs/teamsApps`)
 * _AppCatalog.ReadWrite.All_: [Publish an app](/graph/api/teamsapp-publish?view=graph-rest-beta&preserve-view=true) (`POST /beta/appCatalogs/teamsApps`)
 * _AppCatalog.ReadWrite.All_: [Update a published app](/graph/api/teamsapp-update?view=graph-rest-beta&preserve-view=true) (`PATCH /beta/appCatalogs/teamsApps/{id}`)
 * _AppCatalog.ReadWrite.All_: [Remove a published app](/graph/api/teamsapp-delete?view=graph-rest-beta&preserve-view=true) (`DELETE /beta/appCatalogs/teamsApps/{id}`)


### PR DESCRIPTION
**Global effort to fix broken links**

@jackson-woods 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. Please review within five business days and merge, or comment in the PR with any changes you'd like to see. Thanks!