### PR TITLE
Fix Directory.AccessAsUser.All for delete directoryObject

### DIFF
--- a/api-reference/beta/api/directoryobject-delete.md
+++ b/api-reference/beta/api/directoryobject-delete.md
@@ -13,18 +13,42 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Delete directoryObject.
+Delete a directory object, for example, a group, user, application, or service principal.
+
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
+### Delete a user
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Directory.AccessAsUser.All    |
+|Delegated (work or school account) | User.ReadWrite.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Not supported. |
+|Application | User.ReadWrite.All |
 
-**NOTE:** Users, groups, and contacts are types of directory object. As a result,if you need to delete users, the following permission can and should be used: User.ReadWrite.All
+### Delete a group
+
+| Permission type                        | Permissions (from least to most privileged)                                                 |
+| :------------------------------------- | :------------------------------------------------------------------------------------------ |
+| Delegated (work or school account)     | Group.ReadWrite.All |
+| Delegated (personal Microsoft account) | Not supported.                                                                              |
+| Application                            | Group.ReadWrite.All                             |
+
+### Delete a application
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Application.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | Application.ReadWrite.All |
+
+### Delete a service principal
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Application.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | Application.ReadWrite.All |
 
 ## HTTP request
 

--- a/api-reference/beta/api/directoryobject-delete.md
+++ b/api-reference/beta/api/directoryobject-delete.md
@@ -34,15 +34,7 @@ One of the following permissions is required to call this API. To learn more, in
 | Delegated (personal Microsoft account) | Not supported.                                                                              |
 | Application                            | Group.ReadWrite.All                             |
 
-### Delete a application
-
-|Permission type      | Permissions (from least to most privileged)              |
-|:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Application.ReadWrite.All    |
-|Delegated (personal Microsoft account) | Not supported.    |
-|Application | Application.ReadWrite.All |
-
-### Delete a service principal
+### Delete an application or service principal
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|

--- a/api-reference/v1.0/api/directoryobject-delete.md
+++ b/api-reference/v1.0/api/directoryobject-delete.md
@@ -11,7 +11,7 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Deletes a directoryObject.
+Delete a directory object, for example, a group, user, application, or service principal.
 
 ## Permissions
 

--- a/api-reference/v1.0/api/directoryobject-delete.md
+++ b/api-reference/v1.0/api/directoryobject-delete.md
@@ -33,15 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 | Delegated (personal Microsoft account) | Not supported.                                                                              |
 | Application                            | Group.ReadWrite.All                             |
 
-### Delete a application
-
-|Permission type      | Permissions (from least to most privileged)              |
-|:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Application.ReadWrite.All    |
-|Delegated (personal Microsoft account) | Not supported.    |
-|Application | Application.ReadWrite.All |
-
-### Delete a service principal
+### Delete an application or service principal
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|

--- a/api-reference/v1.0/api/directoryobject-delete.md
+++ b/api-reference/v1.0/api/directoryobject-delete.md
@@ -17,12 +17,37 @@ Deletes a directoryObject.
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
+### Delete a user
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Directory.AccessAsUser.All    |
+|Delegated (work or school account) | User.ReadWrite.All    |
 |Delegated (personal Microsoft account) | Not supported.    |
-|Application | Not supported. |
+|Application | User.ReadWrite.All |
+
+### Delete a group
+
+| Permission type                        | Permissions (from least to most privileged)                                                 |
+| :------------------------------------- | :------------------------------------------------------------------------------------------ |
+| Delegated (work or school account)     | Group.ReadWrite.All |
+| Delegated (personal Microsoft account) | Not supported.                                                                              |
+| Application                            | Group.ReadWrite.All                             |
+
+### Delete a application
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Application.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | Application.ReadWrite.All |
+
+### Delete a service principal
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | Application.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | Application.ReadWrite.All |
 
 ## HTTP request
 
@@ -56,7 +81,7 @@ If successful, this method returns `204 No Content` response code. It does not r
   "name": "delete_directoryobject"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/directoryObjects/{id}
+DELETE https://graph.microsoft.com/v1.0/directoryObjects/ffab4dce-9b82-49a6-b7c7-1a143106598c
 ```
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/delete-directoryobject-csharp-snippets.md)]


### PR DESCRIPTION
Excluded devices from the list because only _Directory.AccessAsUser.All_ is supported by the API. Waiting to get confirmation from the PG before documenting it

cc @Jackson-Woods for visibility.