### PR TITLE
Doc changes to expose 'teamsAppId' in chat message attachment type

### DIFF
--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -1211,7 +1211,7 @@ Content-type: application/json
 
 The following is an example of the request.
 
-> **Note:** When specifying a Teams app to attribute a card to, the AAD app id of the token used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be found in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
+> **Note:** When specifying a Teams app to attribute a card to, the AAD app id used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
 
 <!-- {
   "blockType": "request",

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -1211,7 +1211,7 @@ Content-type: application/json
 
 The following is an example of the request.
 
-> **Note:** When specifying a Teams app to attribute a card to, the AAD app id of the token used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be found in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [app manifest schema](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema).
+> **Note:** When specifying a Teams app to attribute a card to, the AAD app id of the token used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be found in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
 
 <!-- {
   "blockType": "request",

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -1211,7 +1211,7 @@ Content-type: application/json
 
 The following is an example of the request.
 
-> **Note:** When specifying a Teams app to attribute a card to, the AAD app id used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
+> **Note:** When specifying a Teams app to attribute a card to, the AAD app ID used to make the call must match the AAD app ID of the Teams app. The AAD app ID of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
 >
 > Furthermore, the app specified in the payload must be installed either for the user sending the message or in the chat or channel in which the message is being sent.
 

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -1212,6 +1212,8 @@ Content-type: application/json
 The following is an example of the request.
 
 > **Note:** When specifying a Teams app to attribute a card to, the AAD app id used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
+>
+> Furthermore, the app specified in the payload must be installed either for the user sending the message or in the chat or channel in which the message is being sent.
 
 <!-- {
   "blockType": "request",

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -327,6 +327,7 @@ The following is an example of the request.
   "blockType": "request",
   "name": "post_chatmessage_3"
 }-->
+
 ```http
 POST https://graph.microsoft.com/beta/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages
 Content-type: application/json
@@ -1200,6 +1201,108 @@ Content-type: application/json
             }
         }
     ],
+    "reactions": []
+}
+```
+
+### Example 10: Send message that contains cards that are attributed to a Teams app
+
+#### Request
+
+The following is an example of the request.
+
+> **Note:** When specifying a Teams app to attribute a card to, the AAD app id of the token used to make the call must match the AAD app id of the Teams app. The AAD app id of the Teams app can be found in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [app manifest schema](https://docs.microsoft.com/en-us/microsoftteams/platform/resources/schema/manifest-schema).
+
+<!-- {
+  "blockType": "request",
+  "name": "post_chatmessage_10"
+}-->
+
+```http
+POST https://graph.microsoft.com/beta/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages
+Content-type: application/json
+
+{
+    "subject": null,
+    "body": {
+        "contentType": "html",
+        "content": "<attachment id=\"74d20c7f34aa4a7fb74e2b30004247c5\"></attachment>"
+    },
+    "attachments": [
+        {
+            "id": "74d20c7f34aa4a7fb74e2b30004247c5",
+            "contentType": "application/vnd.microsoft.card.thumbnail",
+            "contentUrl": null,
+            "content": "{\r\n  \"title\": \"This is an example of posting a card\",\r\n  \"subtitle\": \"<h3>This is the subtitle</h3>\",\r\n  \"text\": \"Here is some body text. <br>\\r\\nAnd a <a href=\\\"http://microsoft.com/\\\">hyperlink</a>. <br>\\r\\nAnd below that is some buttons:\",\r\n  \"buttons\": [\r\n    {\r\n      \"type\": \"messageBack\",\r\n      \"title\": \"Login to FakeBot\",\r\n      \"text\": \"login\",\r\n      \"displayText\": \"login\",\r\n      \"value\": \"login\"\r\n    }\r\n  ]\r\n}",
+            "name": null,
+            "thumbnailUrl": null,
+            "teamsAppId": "881b8843-fd91-49e5-9ac2-47ec497ffbe5"
+        }
+    ]
+}
+```
+
+#### Response
+
+The following is an example of the response.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.chatMessage"
+} -->
+
+```http
+HTTP/1.1 201 Created
+Content-type: application/json
+
+{
+    "@odata.context": "https://graph.microsoft.com/beta/$metadata#teams('fbe2bf47-16c8-47cf-b4a5-4b9b187c508b')/channels('19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2')/messages/$entity",
+    "id": "1616991851162",
+    "replyToId": null,
+    "etag": "1616991851162",
+    "messageType": "message",
+    "createdDateTime": "2021-03-29T04:24:11.162Z",
+    "lastModifiedDateTime": "2021-03-29T04:24:11.162Z",
+    "lastEditedDateTime": null,
+    "deletedDateTime": null,
+    "subject": null,
+    "summary": null,
+    "chatId": null,
+    "importance": "normal",
+    "locale": "en-us",
+    "webUrl": "https://teams.microsoft.com/l/message/19%3A4a95f7d8db4c4e7fae857bcebe0623e6%40thread.tacv2/1616991851162?groupId=fbe2bf47-16c8-47cf-b4a5-4b9b187c508b&tenantId=2432b57b-0abd-43db-aa7b-16eadd115d34&createdTime=1616991851162&parentMessageId=1616991851162",
+    "policyViolation": null,
+    "eventDetail": null,
+    "from": {
+        "application": null,
+        "device": null,
+        "user": {
+            "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
+            "displayName": "Robin Kline",
+            "userIdentityType": "aadUser"
+        }
+    },
+    "body": {
+        "contentType": "html",
+        "content": "<attachment id=\"74d20c7f34aa4a7fb74e2b30004247c5\"></attachment>"
+    },
+    "channelIdentity": {
+        "teamId": "fbe2bf47-16c8-47cf-b4a5-4b9b187c508b",
+        "channelId": "19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2"
+    },
+    "attachments": [
+        {
+            "id": "74d20c7f34aa4a7fb74e2b30004247c5",
+            "contentType": "application/vnd.microsoft.card.thumbnail",
+            "contentUrl": null,
+            "content": "{  \"title\": \"This is an example of posting a card\",  \"subtitle\": \"<h3>This is the subtitle</h3>\",  \"text\": \"Here is some body text. <br>\\\\And a <a href=\\\"http://microsoft.com/\\\">hyperlink</a>. <br>\\\\And below that is some buttons:\",  \"buttons\": [    {      \"type\": \"messageBack\",      \"title\": \"Login to FakeBot\",      \"text\": \"login\",      \"displayText\": \"login\",      \"value\": \"login\"    }  ]}",
+            "name": null,
+            "thumbnailUrl": null,
+            "teamsAppId": "881b8843-fd91-49e5-9ac2-47ec497ffbe5"
+        }
+    ],
+    "onBehalfOf": null,
+    "mentions": [],
     "reactions": []
 }
 ```

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -1211,7 +1211,7 @@ Content-type: application/json
 
 The following is an example of the request.
 
-> **Note:** When specifying a Teams app to attribute a card to, the AAD app ID used to make the call must match the AAD app ID of the Teams app. The AAD app ID of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
+> **Note:** When specifying a Teams app to attribute a card to, the Azure AD app ID used to make the call must match the Azure AD app ID of the Teams app. The Azure AD app ID of the Teams app can be specified in the *webApplicationInfo* section of the app's manifest. Refer to the following documentation on the current [Teams app manifest schema](/microsoftteams/platform/resources/schema/manifest-schema).
 >
 > Furthermore, the app specified in the payload must be installed either for the user sending the message or in the chat or channel in which the message is being sent.
 

--- a/api-reference/beta/resources/chatmessageattachment.md
+++ b/api-reference/beta/resources/chatmessageattachment.md
@@ -49,7 +49,8 @@ An entity of type `chatMessageAttachment` is returned as part of the [Get channe
   "contentUrl": "string",
   "content": "string",
   "name": "string",
-  "thumbnailUrl": "string"
+  "thumbnailUrl": "string",
+  "teamsAppId": "string"
 }
 
 ```

--- a/api-reference/beta/resources/chatmessageattachment.md
+++ b/api-reference/beta/resources/chatmessageattachment.md
@@ -26,6 +26,7 @@ An entity of type `chatMessageAttachment` is returned as part of the [Get channe
 |content|string|The content of the attachment. If the attachment is a [rich card](/microsoftteams/platform/task-modules-and-cards/cards/cards-reference), set the property to the rich card object. This property and contentUrl are mutually exclusive.|
 |name|string|Name of the attachment.|
 |thumbnailUrl| string |URL to a thumbnail image that the channel can use if it supports using an alternative, smaller form of content or contentUrl. For example, if you set contentType to application/word and set contentUrl to the location of the Word document, you might include a thumbnail image that represents the document. The channel could display the thumbnail image instead of the document. When the user clicks the image, the channel would open the document.|
+|teamsAppId| string |The id of the Teams app that is associated with the attachment. It is specifically used to attribute a Teams message card to the specified app.|
 
 ## JSON representation
  The following is a JSON representation of the resource

--- a/api-reference/beta/resources/chatmessageattachment.md
+++ b/api-reference/beta/resources/chatmessageattachment.md
@@ -36,7 +36,8 @@ An entity of type `chatMessageAttachment` is returned as part of the [Get channe
   "optionalProperties": [
     "thumbnailUrl",
     "content",
-    "contentUrl"
+    "contentUrl",
+    "teamsAppId"
   ],
   "keyProperty": "id",
   "@odata.type": "microsoft.graph.chatMessageAttachment"

--- a/api-reference/beta/resources/chatmessageattachment.md
+++ b/api-reference/beta/resources/chatmessageattachment.md
@@ -25,8 +25,9 @@ An entity of type `chatMessageAttachment` is returned as part of the [Get channe
 |contentUrl|string|URL for the content of the attachment. Supported protocols: http, https, file and data.|
 |content|string|The content of the attachment. If the attachment is a [rich card](/microsoftteams/platform/task-modules-and-cards/cards/cards-reference), set the property to the rich card object. This property and contentUrl are mutually exclusive.|
 |name|string|Name of the attachment.|
+|teamsAppId| string |The ID of the Teams app that is associated with the attachment. The property is specifically used to attribute a Teams message card to the specified app.|
 |thumbnailUrl| string |URL to a thumbnail image that the channel can use if it supports using an alternative, smaller form of content or contentUrl. For example, if you set contentType to application/word and set contentUrl to the location of the Word document, you might include a thumbnail image that represents the document. The channel could display the thumbnail image instead of the document. When the user clicks the image, the channel would open the document.|
-|teamsAppId| string |The id of the Teams app that is associated with the attachment. It is specifically used to attribute a Teams message card to the specified app.|
+
 
 ## JSON representation
  The following is a JSON representation of the resource
@@ -50,8 +51,8 @@ An entity of type `chatMessageAttachment` is returned as part of the [Get channe
   "contentUrl": "string",
   "content": "string",
   "name": "string",
-  "thumbnailUrl": "string",
-  "teamsAppId": "string"
+  "teamsAppId": "string",
+  "thumbnailUrl": "string"
 }
 
 ```

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4938,7 +4938,7 @@
       "Id": "242cb3e4-ef8c-11eb-b6a8-8203ca0139f2",
       "Cloud": "prd",
       "Version": "beta",
-      "CreatedDateTime": "2021-04-05T10:11:41.458Z",
+      "CreatedDateTime": "2021-04-25T10:11:41.458Z",
       "WorkloadArea": "Teamwork",
       "SubArea": ""
     }

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4923,6 +4923,24 @@
           "CreatedDateTime": "2022-04-18T20:34:40.595Z",
           "WorkloadArea": "Teamwork",
           "SubArea": ""
+    },
+	{
+      "ChangeList": [
+        {
+          "Id": "242cb3e4-ef8c-11eb-b6a8-8203ca0139f2",
+          "ApiChange": "Property",
+          "ChangedApiName": "teamsAppId",
+          "ChangeType": "Addition",
+          "Description": "Added the **teamsAppId** property to the [chatMessageAttachment](https://docs.microsoft.com/en-us/graph/api/resources/chatMessageAttachment?view=graph-rest-beta) resource.",
+          "Target": "chatMessageAttachment"
+        }
+      ],
+      "Id": "242cb3e4-ef8c-11eb-b6a8-8203ca0139f2",
+      "Cloud": "prd",
+      "Version": "beta",
+      "CreatedDateTime": "2021-04-05T10:11:41.458Z",
+      "WorkloadArea": "Teamwork",
+      "SubArea": ""
     }
   ]
 }


### PR DESCRIPTION
Doc changes to expose 'teamsAppId' in chat message attachment type, with corresponding changes in Send Chat Message doc to include an example request + response.