### PR TITLE
Graph Task Triggers and task definition should have same app Id

### DIFF
--- a/api-reference/beta/api/printer-post-tasktriggers.md
+++ b/api-reference/beta/api/printer-post-tasktriggers.md
@@ -15,6 +15,8 @@ Namespace: microsoft.graph
 
 Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit may be removed in the future. 
 
+**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 

--- a/api-reference/beta/api/printer-post-tasktriggers.md
+++ b/api-reference/beta/api/printer-post-tasktriggers.md
@@ -13,9 +13,9 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit may be removed in the future. 
+Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit might be removed in the future. 
 
-**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+>**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/printer-post-tasktriggers.md
+++ b/api-reference/beta/api/printer-post-tasktriggers.md
@@ -15,7 +15,7 @@ Namespace: microsoft.graph
 
 Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit might be removed in the future. 
 
->**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+>**Note:** The appId used to generate an access token for creating a task trigger should be the same appId that was used to create the corresponding task definition.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/printer-post-tasktriggers.md
+++ b/api-reference/v1.0/api/printer-post-tasktriggers.md
@@ -12,6 +12,8 @@ Namespace: microsoft.graph
 
 Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit may be removed in the future. 
 
+**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 

--- a/api-reference/v1.0/api/printer-post-tasktriggers.md
+++ b/api-reference/v1.0/api/printer-post-tasktriggers.md
@@ -12,7 +12,7 @@ Namespace: microsoft.graph
 
 Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit might be removed in the future. 
 
->**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+>**Note:** The appId used to generate an access token for creating a task trigger should be the same appId that was used to create the corresponding task definition.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/printer-post-tasktriggers.md
+++ b/api-reference/v1.0/api/printer-post-tasktriggers.md
@@ -10,9 +10,9 @@ doc_type: apiPageType
 # Create printTaskTrigger
 Namespace: microsoft.graph
 
-Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit may be removed in the future. 
+Create a new [task trigger](../resources/printtasktrigger.md) on the specified [printer](../resources/printer.md). Currently, only **one** task trigger can be specified per printer, but this limit might be removed in the future. 
 
-**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
+>**Note:** The appId used to generate access token for creating create task trigger should be the same appId that was used to create corresponding task definition.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -95,7 +95,7 @@ Content-Type: application/json
 
 
 ### Response
-**Note:** The response object shown here might be shortened for readability.
+>**Note:** The response object shown here might be shortened for readability.
 <!-- {
   "blockType": "response",
   "truncated": true,

--- a/concepts/universal-print-concept-overview.md
+++ b/concepts/universal-print-concept-overview.md
@@ -74,7 +74,7 @@ Follow these steps to enable pull printing:
 
 3. [Update the attributes of your virtual printer](/graph/api/printer-update) by using application permissions and an `application/ipp` media type (see examples).
 
-4. [Create a task trigger for your virtual printer](/graph/api/printer-post-tasktriggers) using an administrator authentication token that will associate your task definition with virtual printer.
+4. [Create a task trigger for your virtual printer](/graph/api/printer-post-tasktriggers) using an administrator authentication token that will associate your task definition with virtual printer. The appId used to generate the access token should be the same appId that was used to create task definition.
 
 5. When a print job is submitted to the virtual printer, it will be paused due to the [printTaskTrigger](/graph/api/resources/printtasktrigger). A [printTask](/graph/api/resources/printtask) with `processing` state will be created based on the associated [printTaskDefinition](/graph/api/resources/printtaskdefinition).
 

--- a/concepts/universal-print-concept-overview.md
+++ b/concepts/universal-print-concept-overview.md
@@ -74,7 +74,7 @@ Follow these steps to enable pull printing:
 
 3. [Update the attributes of your virtual printer](/graph/api/printer-update) by using application permissions and an `application/ipp` media type (see examples).
 
-4. [Create a task trigger for your virtual printer](/graph/api/printer-post-tasktriggers) using an administrator authentication token that will associate your task definition with virtual printer. The appId used to generate the access token should be the same appId that was used to create task definition.
+4. [Create a task trigger for your virtual printer](/graph/api/printer-post-tasktriggers) using an administrator authentication token that will associate your task definition with virtual printer. The appId used to generate the access token should be the same appId that was used to create the task definition.
 
 5. When a print job is submitted to the virtual printer, it will be paused due to the [printTaskTrigger](/graph/api/resources/printtasktrigger). A [printTask](/graph/api/resources/printtask) with `processing` state will be created based on the associated [printTaskDefinition](/graph/api/resources/printtaskdefinition).
 


### PR DESCRIPTION
Document that while creating task triggers based on task definition, the appId used to generate token should be same as the one used for creating that task definition.