### PR TITLE
Fix changelog sync

### DIFF
--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -4920,7 +4920,7 @@
         "Id": "0b96fb40-df13-4bb3-8868-7d6198b0e22e",
           "Cloud": "prd",
           "Version": "v1.0",
-          "CreatedDateTime": "2022-04-18T20:3418:40.595Z",
+          "CreatedDateTime": "2022-04-18T20:34:40.595Z",
           "WorkloadArea": "Teamwork",
           "SubArea": ""
     }


### PR DESCRIPTION
This PR fixes an issue with the changelog sync due to invalid date present in the `changelog/Microsoft.Teams.Core.json` file