### PR TITLE
Create snippet-unavailable.md

### DIFF
--- a/includes/snippet-unavailable.md
+++ b/includes/snippet-unavailable.md
@@ -1,0 +1,7 @@
+---
+ms.topic: include
+ms.date: 04/29/2022
+ms.localizationpriority: medium
+---
+
+Sample code for this tab is not available at this time.


### PR DESCRIPTION
Create new include file for when code snippets are unavailable. If tab groups are used, they must use all of the tabs in that group, and in some instances, a snippet might not be ready for one or more tabs (yet). Creating an include to insert in those cases to prevent validation warnings and help readers.