### PR TITLE
Update migrate-azure-ad-graph-configure-permissions.md

### DIFF
--- a/concepts/migrate-azure-ad-graph-configure-permissions.md
+++ b/concepts/migrate-azure-ad-graph-configure-permissions.md
@@ -324,17 +324,19 @@ Create a new PowerShell script named **updatePermissions.ps1** and add the follo
 # Sign in with the required Application.ReadWrite.All scope
 Connect-Graph -Scopes "Application.ReadWrite.All" 
 
+## Azure AD Graph's globally unique appId is 00000002-0000-0000-c000-000000000000 identified by the ResourceAppId
+$graphResourceId = "00000002-0000-0000-c000-000000000000"
+
 ## Replace 581088ba-83c5-4975-b8af-11d2d7a76e98 with the object ID of the app you wish to add new permissions to
 $applicationId = '581088ba-83c5-4975-b8af-11d2d7a76e98' 
 
 $app = Get-MgApplication -ApplicationId $applicationId
 
-## Azure AD Graph's globally unique appId is 00000002-0000-0000-c000-000000000000 identified by the ResourceAppId
-$aadAccess = $app.RequiredResourceAccess | Where-Object { $_.ResourceAppId -eq '00000002-0000-0000-c000-000000000000' } 
+$aadAccess = $app.RequiredResourceAccess | Where-Object { $_.ResourceAppId -eq $graphResourceId } 
 
-if($null -eq $aadAccess){ 
+if ($null -eq $aadAccess) { 
     $app.RequiredResourceAccess += @{  
-        ResourceAppId = "00000002-0000-0000-c000-000000000000"; 
+        ResourceAppId = $graphResourceId; 
         ResourceAccess = @( 
 
                 ## Replace the following with values of ID and type for all permissions - both new and existing permissions - you want to configure for the app
@@ -349,10 +351,33 @@ if($null -eq $aadAccess){
                     type = "Role"; 
                 }
             ) 
-     } 
-} 
+    } 
 
-Update-MgApplication -ApplicationId $applicationId -RequiredResourceAccess $app.RequiredResourceAccess 
+    Update-MgApplication -ApplicationId $applicationId -RequiredResourceAccess $app.RequiredResourceAccess
+}
+else {
+    $params = @{  
+        ResourceAppId = $graphResourceId; 
+        ResourceAccess = @( 
+
+            ## Replace the following with values of ID and type for all permissions - both new and existing permissions - you want to configure for the app
+            @{ 
+                # User.Read delegated permission Sign in and read user profile 
+                id = "311a71cc-e848-46a1-bdf8-97ff7156d8e6";  
+                type = "Scope"; 
+            }, 
+            @{ 
+                # Application.Read.All app role (application permission) to view application data
+                id = "3afa6a7d-9b1a-42eb-948e-1650a849e176"; 
+                type = "Role"; 
+            }
+        ) 
+    }
+
+    $params.ResourceAccess += $app.RequiredResourceAccess.ResourceAccess
+
+    Update-MgApplication -ApplicationId $applicationId -RequiredResourceAccess $params 
+}
 ```
 
 Run the script using the following command.


### PR DESCRIPTION
Issues with the code sample under **Option 4: Use the Microsoft Graph PowerShell SDK** -> **Step 2: Add Azure AD Graph permissions to your app** -> **Request**

The sample code only runs when the app registration has no existing permissions from the resource app (Azure AD Graph). There's no else statement for an example where the app registration already has permissions from the resource app.

Although the example uses the soon-to-be deprecated Azure AD Graph as the resource app, the example code is using the MS Graph PowerShell module, and there doesn't seem to be any other documentation providing an example for this scenario (using MS Graph to add additional permissions when permissions already exist)