### PR TITLE
Removed redundancy

### DIFF
--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -15,22 +15,22 @@ This article describes implementation and operational limits for Microsoft Graph
 
 | **Limit** | **Description** |
 | --------- | --------------- |
-| **10 connections** | The maximum number of [connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant. |
-| **700,000 items** | The maximum number of [items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection. |
+| **10** | The maximum number of [connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant. |
+| **700,000** | The maximum number of [items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection. |
 | **70 GB** | The maximum byte size of a connection. |
 
 ## Schema limits
 
 | **Limit** | **Description** |
 | --------- | --------------- |
-| **128 properties** | The maximum number of properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection. |
+| **128** | The maximum number of properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection. |
 
 ## Group limits
 
 | **Limit** | **Description** |
 | --------- | --------------- |
 | **100,000** | The maximum number of [external groups](/graph/api/resources/externalconnectors-externalgroup?view=graph-rest-1.0&preserve-view=true) per Microsoft 365 tenant. |
-| **1000 requests/sec** | The maximum number of requests allowed per second in the group administration [throttling](#throttling) threshold. |
+| **1000** | The maximum number of requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold. |
 
 ## Item ingestion
 

--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -13,32 +13,32 @@ This article describes implementation and operational limits for Microsoft Graph
 
 ## Connection limits
 
-| Limit type | Maximum number |
-| -------------- | ------------------ |
+| Limit type | Maximum |
+| ---------- | ------- |
 | [Connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant | 10 |
 | [Items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection | 700,000 |
 | Connection byte size | 70 GB |
 
 ## Schema limits
 
-| **Limit type** | **Maximum number** |
-| -------------- | ------------------ |
+| Limit type | Maximum |
+| ---------- | ------- |
 | Properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection | 128 |
 
 ## Group limits
 
-| **Limit type** | **Maximum number** |
-| -------------- | ------------------ |
+| Limit type | Maximum |
+| ---------- | ------- |
 | [External groups](/graph/api/resources/externalconnectors-externalgroup?view=graph-rest-1.0&preserve-view=true) per Microsoft 365 tenant | 100,000 | 
-| Requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold | 1000 |
+| Requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold | 1,000 |
 
 ## Item ingestion
 
-| **Limit type** | **Maximum number or size** |
-| -------------- | ------------------ |
-| The throughput limit to ingest items through a connection | 4 items/sec (250 MB/hour) |
-| The size of an item; this limit applies to the request body when [ingesting and indexing an item](/graph/api/externalconnectors-externalconnection-put-items?view=graph-rest-beta&preserve-view=true&tabs=http&viewFallbackFrom=graph-rest-1.0) | 4 MB |
-| The size of a property | N/A | 
+| Limit type | Maximum |
+| ---------- | ------- |
+| Throughput limit to ingest items through a connection | 4 items/sec <br> (250 MB/hour) |
+| Item size; this limit applies to the request body when [ingesting and indexing an item](/graph/api/externalconnectors-externalconnection-put-items?view=graph-rest-beta&preserve-view=true&tabs=http&viewFallbackFrom=graph-rest-1.0) | 4 MB |
+| Property size | N/A |
 
 ## Throttling
 

--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -13,29 +13,29 @@ This article describes implementation and operational limits for Microsoft Graph
 
 ## Connection limits
 
-| Limit type | Maximum |
-| ---------- | ------- |
+| Limit type | Limit |
+| ---------- | ----- |
 | [Connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant | 10 |
 | [Items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection | 700,000 |
 | Connection byte size | 70 GB |
 
 ## Schema limits
 
-| Limit type | Maximum |
-| ---------- | ------- |
+| Limit type | Limit |
+| ---------- | ----- |
 | Properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection | 128 |
 
 ## Group limits
 
-| Limit type | Maximum |
-| ---------- | ------- |
+| Limit type | Limit |
+| ---------- | ----- |
 | [External groups](/graph/api/resources/externalconnectors-externalgroup?view=graph-rest-1.0&preserve-view=true) per Microsoft 365 tenant | 100,000 | 
 | Requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold | 1,000 |
 
 ## Item ingestion
 
-| Limit type | Maximum |
-| ---------- | ------- |
+| Limit type | Limit |
+| ---------- | ----- |
 | Throughput limit to ingest items through a connection | 4 items/sec <br> (250 MB/hour) |
 | Item size; this limit applies to the request body when [ingesting and indexing an item](/graph/api/externalconnectors-externalconnection-put-items?view=graph-rest-beta&preserve-view=true&tabs=http&viewFallbackFrom=graph-rest-1.0) | 4 MB |
 | Property size | N/A |

--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -13,32 +13,32 @@ This article describes implementation and operational limits for Microsoft Graph
 
 ## Connection limits
 
-| **Limit** | **Description** |
-| --------- | --------------- |
-| **10** | The maximum number of [connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant. |
-| **700,000** | The maximum number of [items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection. |
-| **70 GB** | The maximum byte size of a connection. |
+| Limit type | Maximum number |
+| -------------- | ------------------ |
+| [Connection](/graph/api/resources/externalconnectors-externalconnection?view=graph-rest-1.0&preserve-view=true) resources per Microsoft 365 tenant | 10 |
+| [Items](/graph/api/resources/externalconnectors-externalitem?view=graph-rest-1.0&preserve-view=true) per connection | 700,000 |
+| Connection byte size | 70 GB |
 
 ## Schema limits
 
-| **Limit** | **Description** |
-| --------- | --------------- |
-| **128** | The maximum number of properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection. |
+| **Limit type** | **Maximum number** |
+| -------------- | ------------------ |
+| Properties that can be defined in a [schema](/graph/api/resources/externalconnectors-schema?view=graph-rest-1.0&preserve-view=true), characterizing the data ingested through a connection | 128 |
 
 ## Group limits
 
-| **Limit** | **Description** |
-| --------- | --------------- |
-| **100,000** | The maximum number of [external groups](/graph/api/resources/externalconnectors-externalgroup?view=graph-rest-1.0&preserve-view=true) per Microsoft 365 tenant. |
-| **1000** | The maximum number of requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold. |
+| **Limit type** | **Maximum number** |
+| -------------- | ------------------ |
+| [External groups](/graph/api/resources/externalconnectors-externalgroup?view=graph-rest-1.0&preserve-view=true) per Microsoft 365 tenant | 100,000 | 
+| Requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold | 1000 |
 
 ## Item ingestion
 
-| **Limit** | **Description** |
-| --------- | --------------- |
-| **4 items/sec (250 MB/hour)** | The throughput limit to ingest items through a connection. |
-| **4 MB** | The maximum size of an item; this limit applies to the request body when [ingesting and indexing an item](/graph/api/externalconnectors-externalconnection-put-items?view=graph-rest-beta&preserve-view=true&tabs=http&viewFallbackFrom=graph-rest-1.0). |
-| **N/A** | The maximum size of a property. |
+| **Limit type** | **Maximum number or size** |
+| -------------- | ------------------ |
+| The throughput limit to ingest items through a connection | 4 items/sec (250 MB/hour) |
+| The size of an item; this limit applies to the request body when [ingesting and indexing an item](/graph/api/externalconnectors-externalconnection-put-items?view=graph-rest-beta&preserve-view=true&tabs=http&viewFallbackFrom=graph-rest-1.0) | 4 MB |
+| The size of a property | N/A | 
 
 ## Throttling
 


### PR DESCRIPTION
To make the page more consistent, I removed the labels in the limit column because they are defined in the description.