### PR TITLE
Update user-exportpersonaldata.md

### DIFF
--- a/api-reference/beta/api/user-exportpersonaldata.md
+++ b/api-reference/beta/api/user-exportpersonaldata.md
@@ -18,9 +18,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  User.Export.All and User.Read.All  |
+|Delegated (work or school account) |  User.Export.All  |
 |Delegated (personal Microsoft account) |  Not applicable  |
-|Application | User.Export.All and User.Read.All |
+|Application | User.Export.All |
 
 >**Note:** Export can only be performed by a company administrator when the delegated permission is used.
 

--- a/api-reference/v1.0/api/user-exportpersonaldata.md
+++ b/api-reference/v1.0/api/user-exportpersonaldata.md
@@ -18,9 +18,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) |  User.Export.All, User.Read.All  |
+|Delegated (work or school account) |  User.Export.All  |
 |Delegated (personal Microsoft account) |  Not applicable  |
-|Application | User.Export.All, User.Read.All |
+|Application | User.Export.All |
 
 >**Note:** The export can only be performed by a company administrator when delegated permissions are used.
 


### PR DESCRIPTION
In a recent Teams channel post a caller to /user/{id}/exportPersonalData pointed out an inconsistency in the documentation. Essentially, the text states the User.Read.All is required when it is not.  Only User.Export.All is required. My team owns the Export workflow via Privacy Experience service and the text change has been validated with our Identity team partner.

I have removed the incorrect text 'User.Read.All' from the User Personal data Export. Kindly update the changes at your earliest