### PR TITLE
Updating roles/permissions for CA data

### DIFF
--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -38,22 +38,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Operator
 + Security Reader
 
-### Viewing applied conditional access (CA) policies in sign-ins
-The applied CA policies listed in **appliedConditionalAccessPolicies** property are only available to users and apps with roles that allow them to read [conditional access data](../resources/appliedconditionalaccesspolicy.md). If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the **appliedConditionalAccessPolicies** property in the response will be omitted. The following Azure AD roles grant users permissions to view conditional access data:
-
-+ Global Administrator
-+ Global Reader
-+ Security Administrator
-+ Security Reader
-+ Conditional Access Administrator
-
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) objects in the sign-in logs. 
-
-+ Policy.Read.All
-+ Policy.ReadWrite.ConditionalAccess
-+ Policy.Read.ConditionalAccess
-
-**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
+[!INCLUDE [signins-roles-for-ca-data](../../includes/signins-roles-for-ca-data.md)]
 
 ## HTTP request
 

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -17,7 +17,7 @@ Get a [signIn](../resources/signin.md) object that contains a specific user sign
 
 ## Permissions
 
-One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -37,6 +37,21 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Administrator
 + Security Operator
 + Security Reader
+
+### Viewing applied CA policies in sign-ins
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+
++ Global Reader
++ Company Administrator
++ Security Administrator
++ Security Reader
++ Conditional Access Administrator
+
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+
++ Policy.Read.All
++ Policy.ReadWrite.ConditionalAccess
++ Policy.Read.ConditionalAccess
 
 ## HTTP request
 

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -41,8 +41,8 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 ### Viewing applied conditional access (CA) policies in sign-ins
 The applied CA policies listed in **appliedConditionalAccessPolicies** property are only available to users and apps with roles that allow them to read [conditional access data](../resources/appliedconditionalaccesspolicy.md). If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the **appliedConditionalAccessPolicies** property in the response will be omitted. The following Azure AD roles grant users permissions to view conditional access data:
 
++ Global Administrator
 + Global Reader
-+ Company Administrator
 + Security Administrator
 + Security Reader
 + Conditional Access Administrator
@@ -52,6 +52,8 @@ Applications must have at least one of the following permissions to see [applied
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess
 + Policy.Read.ConditionalAccess
+
+**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
 
 ## HTTP request
 

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -39,7 +39,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Reader
 
 ### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
 + Global Reader
 + Company Administrator
@@ -47,7 +47,7 @@ The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedcondit
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -17,7 +17,7 @@ Get a [signIn](../resources/signin.md) object that contains a specific user sign
 
 ## Permissions
 
-Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -38,8 +38,8 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Operator
 + Security Reader
 
-### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+### Viewing applied conditional access (CA) policies in sign-ins
+The applied CA policies listed in **appliedConditionalAccessPolicies** property are only available to users and apps with roles that allow them to read [conditional access data](../resources/appliedconditionalaccesspolicy.md). If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the **appliedConditionalAccessPolicies** property in the response will be omitted. The following Azure AD roles grant users permissions to view conditional access data:
 
 + Global Reader
 + Company Administrator
@@ -47,7 +47,7 @@ The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) objects in the sign-in logs. 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -41,7 +41,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Reader
 
 ### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
 + Global Reader
 + Company Administrator
@@ -49,7 +49,7 @@ The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedcondit
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -19,7 +19,7 @@ The maximum and default page size is 1,000 objects and by default, the most rece
 
 ## Permissions
 
-One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 | Permission type | Permissions (from least to most privileged) |
 |:--------------- |:------------------------------------------- |
@@ -39,6 +39,22 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Administrator
 + Security Operator
 + Security Reader
+
+### Viewing applied CA policies in sign-ins
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+
++ Global Reader
++ Company Administrator
++ Security Administrator
++ Security Reader
++ Conditional Access Administrator
+
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+
++ Policy.Read.All
++ Policy.ReadWrite.ConditionalAccess
++ Policy.Read.ConditionalAccess
+
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -40,22 +40,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Operator
 + Security Reader
 
-### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
-
-+ Global Administrator
-+ Global Reader
-+ Security Administrator
-+ Security Reader
-+ Conditional Access Administrator
-
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
-
-+ Policy.Read.All
-+ Policy.ReadWrite.ConditionalAccess
-+ Policy.Read.ConditionalAccess
-
-**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
+[!INCLUDE [signins-roles-for-ca-data](../../includes/signins-roles-for-ca-data.md)]
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -19,7 +19,7 @@ The maximum and default page size is 1,000 objects and by default, the most rece
 
 ## Permissions
 
-Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 | Permission type | Permissions (from least to most privileged) |
 |:--------------- |:------------------------------------------- |
@@ -43,8 +43,8 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 ### Viewing applied CA policies in sign-ins
 The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
++ Global Administrator
 + Global Reader
-+ Company Administrator
 + Security Administrator
 + Security Reader
 + Conditional Access Administrator
@@ -55,6 +55,7 @@ Applications must have at least one of the following permissions to see [applied
 + Policy.ReadWrite.ConditionalAccess
 + Policy.Read.ConditionalAccess
 
+**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
 
 ## HTTP request
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/includes/signins-roles-for-ca-data.md
+++ b/api-reference/includes/signins-roles-for-ca-data.md
@@ -16,10 +16,10 @@ The applied CA policies listed in **appliedConditionalAccessPolicies** property 
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) objects in the sign-in logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) objects in the sign-in logs: 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess
 + Policy.Read.ConditionalAccess
 
-**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above.
+>**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above.

--- a/api-reference/includes/signins-roles-for-ca-data.md
+++ b/api-reference/includes/signins-roles-for-ca-data.md
@@ -1,0 +1,25 @@
+---
+author: besiler
+ms.topic: include
+ms.date: 05/11/2022
+ms.localizationpriority: medium
+---
+
+<!-- markdownlint-disable MD041-->
+
+### Viewing applied conditional access (CA) policies in sign-ins
+The applied CA policies listed in **appliedConditionalAccessPolicies** property are only available to users and apps with roles that allow them to read [conditional access data](../resources/appliedconditionalaccesspolicy.md). If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the **appliedConditionalAccessPolicies** property in the response will be omitted. The following Azure AD roles grant users permissions to view conditional access data:
+
++ Global Administrator
++ Global Reader
++ Security Administrator
++ Security Reader
++ Conditional Access Administrator
+
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) objects in the sign-in logs. 
+
++ Policy.Read.All
++ Policy.ReadWrite.ConditionalAccess
++ Policy.Read.ConditionalAccess
+
+**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above.

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -15,7 +15,7 @@ Retrieve a specific Azure AD user sign-in event for your tenant. Sign-ins that a
 
 ## Permissions
 
-One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -35,6 +35,21 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Administrator
 + Security Operator
 + Security Reader
+
+### Viewing applied CA policies in sign-ins
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+
++ Global Reader
++ Company Administrator
++ Security Administrator
++ Security Reader
++ Conditional Access Administrator
+
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+
++ Policy.Read.All
++ Policy.ReadWrite.ConditionalAccess
++ Policy.Read.ConditionalAccess
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -15,7 +15,7 @@ Retrieve a specific Azure AD user sign-in event for your tenant. Sign-ins that a
 
 ## Permissions
 
-Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -39,8 +39,8 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 ### Viewing applied CA policies in sign-ins
 The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
++ Global Administrator
 + Global Reader
-+ Company Administrator
 + Security Administrator
 + Security Reader
 + Conditional Access Administrator
@@ -50,6 +50,8 @@ Applications must have at least one of the following permissions to see [applied
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess
 + Policy.Read.ConditionalAccess
+
+**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -37,7 +37,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Reader
 
 ### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
 + Global Reader
 + Company Administrator
@@ -45,7 +45,7 @@ The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedcondit
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -36,22 +36,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Operator
 + Security Reader
 
-### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
-
-+ Global Administrator
-+ Global Reader
-+ Security Administrator
-+ Security Reader
-+ Conditional Access Administrator
-
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
-
-+ Policy.Read.All
-+ Policy.ReadWrite.ConditionalAccess
-+ Policy.Read.ConditionalAccess
-
-**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
+[!INCLUDE [signins-roles-for-ca-data](../../includes/signins-roles-for-ca-data.md)]
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -17,7 +17,7 @@ The maximum and default page size is 1,000 objects and by default, the most rece
 
 ## Permissions
 
-Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -41,8 +41,8 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 ### Viewing applied CA policies in sign-ins
 The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
++ Global Administrator
 + Global Reader
-+ Company Administrator
 + Security Administrator
 + Security Reader
 + Conditional Access Administrator
@@ -52,6 +52,8 @@ Applications must have at least one of the following permissions to see [applied
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess
 + Policy.Read.ConditionalAccess
+
+**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -38,22 +38,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Operator
 + Security Reader
 
-### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
-
-+ Global Administrator
-+ Global Reader
-+ Security Administrator
-+ Security Reader
-+ Conditional Access Administrator
-
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
-
-+ Policy.Read.All
-+ Policy.ReadWrite.ConditionalAccess
-+ Policy.Read.ConditionalAccess
-
-**Note:** Azure AD users with any permissions can read sign-in logs in which their user is the actor signing in. This feature helps users spot unexpected activity in their accounts. Users cannot read CA data from their own logs unless they have one of the CA permissions identified above. 
+[!INCLUDE [signins-roles-for-ca-data](../../includes/signins-roles-for-ca-data.md)]
 
 ## HTTP request
 

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -39,7 +39,7 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Reader
 
 ### Viewing applied CA policies in sign-ins
-The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
 
 + Global Reader
 + Company Administrator
@@ -47,7 +47,7 @@ The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedcondit
 + Security Reader
 + Conditional Access Administrator
 
-Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](../resources/appliedconditionalaccesspolicy.md) in the logs. 
 
 + Policy.Read.All
 + Policy.ReadWrite.ConditionalAccess

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -17,7 +17,7 @@ The maximum and default page size is 1,000 objects and by default, the most rece
 
 ## Permissions
 
-One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+Any Azure AD user can read their own sign-ins. In order to read sign-ins beyond those where the signed in user is the actor, one of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
@@ -37,6 +37,21 @@ In addition to the delegated permissions, the signed-in user needs to belong to 
 + Security Administrator
 + Security Operator
 + Security Reader
+
+### Viewing applied CA policies in sign-ins
+The Applied CA Policies listed in [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) are only available to users and apps with roles that allow them to read conditional access data. If a user or app has permissions to read sign-in logs but not permission to read conditional access data, the [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) portion of the response will be omitted. The following roles grant users permissions to view conditional access data:
+
++ Global Reader
++ Company Administrator
++ Security Administrator
++ Security Reader
++ Conditional Access Administrator
+
+Applications must have at least one of the following permissions to see [appliedConditionalAccessPolicy](appliedconditionalaccesspolicy.md) in the logs. 
+
++ Policy.Read.All
++ Policy.ReadWrite.ConditionalAccess
++ Policy.Read.ConditionalAccess
 
 ## HTTP request
 


### PR DESCRIPTION
Due to an MSRC security incident, we had to update the RBAC required to see CA data in sign ins. This change will roll out next week (week of May 9)