### PR TITLE
Adding GDPR boxes to GET sign in and LIST sign in 

### DIFF
--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -15,9 +15,7 @@ Namespace: microsoft.graph
 
 Get a [signIn](../resources/signin.md) object that contains a specific user sign-in event for your tenant. This includes sign-ins where a user is asked to enter a username or password, and session tokens.
 
-> [!NOTE]
-> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
-
+[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 ## Permissions
 
@@ -208,7 +206,7 @@ Content-type: application/json
       }
     },
   "appliedConditionalAccessPolicies":[],
-  "authenticationProcessingDetails":[
+  "authenticationProcessingD[!INCLUDE [gdpr-msgraph-export-note](../../includes/gdpr-msgraph-export-note.md)]etails":[
       {
         "key":"Login Hint Present",
         "value":"True"

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -15,7 +15,7 @@ Namespace: microsoft.graph
 
 Get a [signIn](../resources/signin.md) object that contains a specific user sign-in event for your tenant. This includes sign-ins where a user is asked to enter a username or password, and session tokens.
 
-[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
+[!INCLUDE [GDPR-related-guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 ## Permissions
 

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -15,6 +15,10 @@ Namespace: microsoft.graph
 
 Get a [signIn](../resources/signin.md) object that contains a specific user sign-in event for your tenant. This includes sign-ins where a user is asked to enter a username or password, and session tokens.
 
+> [!NOTE]
+> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/beta/api/signin-get.md
+++ b/api-reference/beta/api/signin-get.md
@@ -206,7 +206,7 @@ Content-type: application/json
       }
     },
   "appliedConditionalAccessPolicies":[],
-  "authenticationProcessingD[!INCLUDE [gdpr-msgraph-export-note](../../includes/gdpr-msgraph-export-note.md)]etails":[
+  "authenticationProcessingDetails":[
       {
         "key":"Login Hint Present",
         "value":"True"

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -17,8 +17,7 @@ Get a list of [signIn](../resources/signin.md) objects. The list contains the us
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
-> [!NOTE]
-> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -17,7 +17,7 @@ Get a list of [signIn](../resources/signin.md) objects. The list contains the us
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
-[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
+[!INCLUDE [GDPR-related-guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions

--- a/api-reference/beta/api/signin-list.md
+++ b/api-reference/beta/api/signin-list.md
@@ -17,6 +17,10 @@ Get a list of [signIn](../resources/signin.md) objects. The list contains the us
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
+> [!NOTE]
+> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/includes/gdpr-msgraph-export-note.md
+++ b/api-reference/includes/gdpr-msgraph-export-note.md
@@ -1,0 +1,11 @@
+---
+author: besiler
+ms.topic: include
+ms.date: 03/15/2021
+ms.localizationpriority: medium
+---
+
+<!-- markdownlint-disable MD041-->
+
+>[!NOTE]
+>This article describes how to export personal data from a device or service. These steps can be used to support your obligations under the General Data Protection Regulation (GDPR). Authorized tenant admins can use Microsoft Graph to correct, update, or delete identifiable information about end users, including customer and employee user profiles or personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/en-us/services/active-directory/) environment.

--- a/api-reference/includes/gdpr-msgraph-export-note.md
+++ b/api-reference/includes/gdpr-msgraph-export-note.md
@@ -8,4 +8,4 @@ ms.localizationpriority: medium
 <!-- markdownlint-disable MD041-->
 
 >[!NOTE]
->This article describes how to export personal data from a device or service. These steps can be used to support your obligations under the General Data Protection Regulation (GDPR). Authorized tenant admins can use Microsoft Graph to correct, update, or delete identifiable information about end users, including customer and employee user profiles or personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/en-us/services/active-directory/) environment.
+>This article describes how to export personal data from a device or service. These steps can be used to support your obligations under the General Data Protection Regulation (GDPR). Authorized tenant admins can use Microsoft Graph to correct, update, or delete identifiable information about end users, including customer and employee user profiles or personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment.

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 Retrieve a specific Azure AD user sign-in event for your tenant. Sign-ins that are interactive in nature (where a username/password is passed as part of auth token) and successful federated sign-ins are currently included in the sign-in logs.
 
-[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
+[!INCLUDE [GDPR-related-guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -13,8 +13,7 @@ Namespace: microsoft.graph
 
 Retrieve a specific Azure AD user sign-in event for your tenant. Sign-ins that are interactive in nature (where a username/password is passed as part of auth token) and successful federated sign-ins are currently included in the sign-in logs.
 
-> [!NOTE]
-> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions

--- a/api-reference/v1.0/api/signin-get.md
+++ b/api-reference/v1.0/api/signin-get.md
@@ -13,6 +13,10 @@ Namespace: microsoft.graph
 
 Retrieve a specific Azure AD user sign-in event for your tenant. Sign-ins that are interactive in nature (where a username/password is passed as part of auth token) and successful federated sign-ins are currently included in the sign-in logs.
 
+> [!NOTE]
+> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -15,8 +15,7 @@ Retrieve the Azure AD user sign-ins for your tenant. Sign-ins that are interacti
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
-> [!NOTE]
-> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -15,6 +15,10 @@ Retrieve the Azure AD user sign-ins for your tenant. Sign-ins that are interacti
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
+> [!NOTE]
+> This article provides steps about how to export personal data from the device or service and can be uses to support your obligations under the GDPR. You can correct, update, or delete identifiable information about end users, such as customer and employee user profiles and user work information that contain personal data, such as a user's name, work title, address, or phone number, in your [Azure Active Directory (Azure AD)](https://azure.microsoft.com/services/active-directory/) environment by using the [Azure portal](https://portal.azure.com/). You must sign in with an account that's a global admin for the directory.
+
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/signin-list.md
+++ b/api-reference/v1.0/api/signin-list.md
@@ -15,7 +15,7 @@ Retrieve the Azure AD user sign-ins for your tenant. Sign-ins that are interacti
 
 The maximum and default page size is 1,000 objects and by default, the most recent sign-ins are returned first. Only sign-in events that occurred within the Azure Active Directory (Azure AD) [default retention period](/azure/active-directory/reports-monitoring/reference-reports-data-retention#how-long-does-azure-ad-store-the-data) are available.
 
-[!INCLUDE [GDPR-related guidance](../../includes/gdpr-msgraph-export-note.md)]
+[!INCLUDE [GDPR-related-guidance](../../includes/gdpr-msgraph-export-note.md)]
 
 
 ## Permissions


### PR DESCRIPTION
Privacy let us know that we need a GDPR statement since the API can be used to export personal data. Added that statement as approved by Eddie Young (CELA) and Peter Gurevich (Privacy)