### PR TITLE
Fix missing "$" character on example code

### DIFF
--- a/api-reference/v1.0/api/channel-list-messages.md
+++ b/api-reference/v1.0/api/channel-list-messages.md
@@ -279,7 +279,7 @@ The following is an example of the request.
   "name": "get_listchannelmessages_2"
 }-->
 ```msgraph-interactive
-GET https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages?top=3
+GET https://graph.microsoft.com/v1.0/teams/fbe2bf47-16c8-47cf-b4a5-4b9b187c508b/channels/19:4a95f7d8db4c4e7fae857bcebe0623e6@thread.tacv2/messages?$top=3
 
 Prefer: include-unknown-enum-members
 ```


### PR DESCRIPTION
Fix missing "$" character on the query parameter example