### PR TITLE
Update max page size in graph search

### DIFF
--- a/api-reference/v1.0/resources/search-api-overview.md
+++ b/api-reference/v1.0/resources/search-api-overview.md
@@ -67,6 +67,7 @@ Best practices:
 
 - Specify a smaller first page in the initial request. For example, specify **from** as 0, **size** as 25.
 - Paginate subsequent pages by updating the **from** and **size** properties. You can increase the page size in each subsequent request. The following table shows an example.
+- The maximum page size is 1000.
 
     | Page | from | size |
     |:-----|:-----|:-----|

--- a/api-reference/v1.0/resources/searchrequest.md
+++ b/api-reference/v1.0/resources/searchrequest.md
@@ -33,7 +33,7 @@ The JSON blob contains the types of resources expected in the response, the unde
 |query|[searchQuery](searchquery.md)|Contains the query terms. Required.|
 |queryAlterationOptions|[searchAlterationOptions](searchalterationoptions.md)|Query alteration options formatted in a JSON blob that contains two optional flags related to spelling correction. Optional. |
 |resultTemplateOptions|[resultTemplateOption](resulttemplateoption.md) collection|Provides the search result template options to render search results from connectors.|
-|size|Int32|The size of the page to be retrieved. Optional.|
+|size|Int32|The size of the page to be retrieved.The maximum value is 1000. Optional.|
 |sortProperties|[sortProperty](sortProperty.md) collection|Contains the ordered collection of fields and direction to sort results. There can be at most 5 sort properties in the collection. Optional.|
 
 ## JSON representation

--- a/changelog/Microsoft.MicrosoftSearch.json
+++ b/changelog/Microsoft.MicrosoftSearch.json
@@ -509,14 +509,14 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchresponse?view=graph-rest-beta).",
+          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchrequest?view=graph-rest-beta).",
           "Target": "searchRequest"
         }
       ],
       "Id": "09b50a1f-9206-4fef-a7d8-efd6ec0dca1f",
       "Cloud": "Prod",
       "Version": "beta",
-      "CreatedDateTime": "2022-05-23T04:11:04.628237Z",
+      "CreatedDateTime": "2022-05-25T04:11:04.628237Z",
       "WorkloadArea": "Search",
       "SubArea": ""
     },
@@ -527,14 +527,14 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchresponse?view=graph-rest-1.0).",
+          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchrequest?view=graph-rest-1.0).",
           "Target": "searchRequest"
         }
       ],
       "Id": "fd371113-6fc5-4790-bd13-788fc7231400",
       "Cloud": "Prod",
       "Version": "v1.0",
-      "CreatedDateTime": "2022-05-23T04:11:04.628237Z",
+      "CreatedDateTime": "2022-05-25T04:11:04.628237Z",
       "WorkloadArea": "Search",
       "SubArea": ""
     }

--- a/changelog/Microsoft.MicrosoftSearch.json
+++ b/changelog/Microsoft.MicrosoftSearch.json
@@ -510,7 +510,7 @@
           "ChangedApiName": "Size",
           "ChangeType": "Change",
           "Description": "Add maximum page size for query.",
-          "Target": "Query"
+          "Target": "searchRequest"
         }
       ],
       "Id": "09b50a1f-9206-4fef-a7d8-efd6ec0dca1f",
@@ -528,7 +528,7 @@
           "ChangedApiName": "Size",
           "ChangeType": "Change",
           "Description": "Add maximum page size for query.",
-          "Target": "Query"
+          "Target": "searchRequest"
         }
       ],
       "Id": "fd371113-6fc5-4790-bd13-788fc7231400",

--- a/changelog/Microsoft.MicrosoftSearch.json
+++ b/changelog/Microsoft.MicrosoftSearch.json
@@ -509,7 +509,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size for query size",
+          "Description": "Add maximum page size for query.",
           "Target": "Query"
         }
       ],
@@ -527,7 +527,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size for query size",
+          "Description": "Add maximum page size for query.",
           "Target": "Query"
         }
       ],

--- a/changelog/Microsoft.MicrosoftSearch.json
+++ b/changelog/Microsoft.MicrosoftSearch.json
@@ -501,6 +501,42 @@
       "CreatedDateTime": "2022-02-16T06:29:33.9252671Z",
       "WorkloadArea": "Search",
       "SubArea": "Analytics"
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "09b50a1f-9206-4fef-a7d8-efd6ec0dca1f",
+          "ApiChange": "Property",
+          "ChangedApiName": "Size",
+          "ChangeType": "Change",
+          "Description": "Add maximum page size for query size",
+          "Target": "Query"
+        }
+      ],
+      "Id": "09b50a1f-9206-4fef-a7d8-efd6ec0dca1f",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2022-05-23T04:11:04.628237Z",
+      "WorkloadArea": "Search",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "fd371113-6fc5-4790-bd13-788fc7231400",
+          "ApiChange": "Property",
+          "ChangedApiName": "Size",
+          "ChangeType": "Change",
+          "Description": "Add maximum page size for query size",
+          "Target": "Query"
+        }
+      ],
+      "Id": "fd371113-6fc5-4790-bd13-788fc7231400",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2022-05-23T04:11:04.628237Z",
+      "WorkloadArea": "Search",
+      "SubArea": ""
     }
   ]
 }

--- a/changelog/Microsoft.MicrosoftSearch.json
+++ b/changelog/Microsoft.MicrosoftSearch.json
@@ -509,7 +509,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size for query.",
+          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchresponse?view=graph-rest-beta).",
           "Target": "searchRequest"
         }
       ],
@@ -527,7 +527,7 @@
           "ApiChange": "Property",
           "ChangedApiName": "Size",
           "ChangeType": "Change",
-          "Description": "Add maximum page size for query.",
+          "Description": "Add maximum page size of 1000 results for a [search query](https://docs.microsoft.com/en-us/graph/api/resources/searchresponse?view=graph-rest-1.0).",
           "Target": "searchRequest"
         }
       ],


### PR DESCRIPTION
Add max page size 1000 description in graph search document.