### PR TITLE
update descriptions in entitlementmanagement.md

### DIFF
--- a/api-reference/beta/resources/entitlementmanagement.md
+++ b/api-reference/beta/resources/entitlementmanagement.md
@@ -32,8 +32,8 @@ None.
 |accessPackageAssignmentPolicies|[accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md) collection| Represents the policy that governs which subjects can request or be assigned an access package via an access package assignment. |
 |accessPackageAssignmentRequests|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Represents access package assignment requests created by or on behalf of a user.|
 |accessPackageAssignmentResourceRoles|[accessPackageAssignmentResourceRole](../resources/accesspackageassignmentresourcerole.md) collection| Represents the resource-specific role which a subject has been assigned through an access package assignment.|
-|accessPackageAssignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection|Represents the grant of an access package to a subject (user or group).|
-|accessPackageCatalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection|Represents a group of access packages.|
+|accessPackageAssignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection|The assignment of an access package to a subject, for a period of time.|
+|accessPackageCatalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection|A container of access packages.|
 |accessPackageResourceEnvironments|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md) collection| A reference to the geolocation environment in which a resource is located.|
 |accessPackageResourceRequests|[accessPackageResourceRequest](../resources/accesspackageresourcerequest.md) collection|Represents a request to add or remove a resource to or from a catalog respectively. |
 |accessPackageResourceRoleScopes|[accessPackageResourceRoleScope](../resources/accesspackageresourcerolescope.md) collection| A reference to both a scope within a resource, and a role in that resource for that scope. |

--- a/api-reference/beta/resources/entitlementmanagement.md
+++ b/api-reference/beta/resources/entitlementmanagement.md
@@ -32,7 +32,7 @@ None.
 |accessPackageAssignmentPolicies|[accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md) collection| Represents the policy that governs which subjects can request or be assigned an access package via an access package assignment. |
 |accessPackageAssignmentRequests|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Represents access package assignment requests created by or on behalf of a user.|
 |accessPackageAssignmentResourceRoles|[accessPackageAssignmentResourceRole](../resources/accesspackageassignmentresourcerole.md) collection| Represents the resource-specific role which a subject has been assigned through an access package assignment.|
-|accessPackageAssignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection|The assignment of an access package to a subject, for a period of time.|
+|accessPackageAssignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection|The assignment of an access package to a subject for a period of time.|
 |accessPackageCatalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection|A container of access packages.|
 |accessPackageResourceEnvironments|[accessPackageResourceEnvironment](../resources/accesspackageresourceenvironment.md) collection| A reference to the geolocation environment in which a resource is located.|
 |accessPackageResourceRequests|[accessPackageResourceRequest](../resources/accesspackageresourcerequest.md) collection|Represents a request to add or remove a resource to or from a catalog respectively. |

--- a/api-reference/v1.0/resources/entitlementmanagement.md
+++ b/api-reference/v1.0/resources/entitlementmanagement.md
@@ -29,7 +29,7 @@ None.
 |accessPackages|[accessPackage](../resources/accesspackage.md) collection|Access packages define the collection of resource roles and the policies for which subjects can request or be assigned access to those resources.|
 |assignmentPolicies|[accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md) collection|Access package assignment policies govern which subjects can request or be assigned an access package via an access package assignment.|
 |assignmentRequests|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Access package assignment requests created by or on behalf of a subject.|
-|assignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection| The assignment of an access package to a subject, for a period of time.|
+|assignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection| The assignment of an access package to a subject for a period of time.|
 |catalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection|A container for access packages.|
 |connectedOrganizations|[connectedOrganization](../resources/connectedorganization.md) collection|References to a directory or domain of another organization whose users can request access.|
 |settings|[entitlementManagementSettings](../resources/entitlementmanagementsettings.md)| The settings that control the behavior of Azure AD entitlement management.|

--- a/api-reference/v1.0/resources/entitlementmanagement.md
+++ b/api-reference/v1.0/resources/entitlementmanagement.md
@@ -25,14 +25,14 @@ None.
 ## Relationships
 |Relationship|Type|Description|
 |:---|:---|:---|
-|accessPackageAssignmentApprovals|[approval](../resources/approval.md) collection | Approval stages for assignment requests.|
-|accessPackages|[accessPackage](../resources/accesspackage.md) collection|Represents access package objects.|
-|assignmentPolicies|[accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md) collection|Access package assignment policies.|
-|assignmentRequests|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Represents access package assignment requests created by or on behalf of a user.|
-|assignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection| Represents the grant of an access package to a subject (user or group).|
-|catalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection| Represents a collection of access packages.|
-|connectedOrganizations|[connectedOrganization](../resources/connectedorganization.md) collection|Represents references to a directory or domain of another organization whose users can request access.|
-|settings|[entitlementManagementSettings](../resources/entitlementmanagementsettings.md)| Represents the settings that control the behavior of Azure AD entitlement management.|
+|accessPackageAssignmentApprovals|[approval](../resources/approval.md) collection | Approval stages for decisions associated with access package assignment requests.|
+|accessPackages|[accessPackage](../resources/accesspackage.md) collection|Access packages define the collection of resource roles and the policies for which subjects can request or be assigned access to those resources.|
+|assignmentPolicies|[accessPackageAssignmentPolicy](../resources/accesspackageassignmentpolicy.md) collection|Access package assignment policies govern which subjects can request or be assigned an access package via an access package assignment.|
+|assignmentRequests|[accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) collection|Access package assignment requests created by or on behalf of a subject.|
+|assignments|[accessPackageAssignment](../resources/accesspackageassignment.md) collection| The assignment of an access package to a subject, for a period of time.|
+|catalogs|[accessPackageCatalog](../resources/accesspackagecatalog.md) collection|A container for access packages.|
+|connectedOrganizations|[connectedOrganization](../resources/connectedorganization.md) collection|References to a directory or domain of another organization whose users can request access.|
+|settings|[entitlementManagementSettings](../resources/entitlementmanagementsettings.md)| The settings that control the behavior of Azure AD entitlement management.|
 
 ## JSON representation
 The following is a JSON representation of the resource.


### PR DESCRIPTION
For MS Graph PowerShell SDK, the descriptions of some cmdlets are generated from this article. However, the context for describing a relationship in Graph doesn't necessary correspond to how a IT Pro might expect to see this described,  e.g., https://docs.microsoft.com/en-us/powershell/module/microsoft.graph.identity.governance/?view=graph-powershell-1.0 and 
```powershell
PS> get-help get-mgentitlementmanagementaccesspackage
NAME
    Get-MgEntitlementManagementAccessPackage
SYNOPSIS
    Represents access package objects.
```
doesn't tell them what an access package is, since this was written assuming it was describing a link to the access package object and the reader of the Graph article would just click the link to learn more.  But in the auto-generated SDKs the link isn't there so these descriptions aren't meaningful.

This PR updates the v1.0 descriptions in the file entitlementmanagement.md so that this will update the graph metadata/openAPI to make the descriptions clearer for use in generated SDKs.  It also fixes two issues where the beta descriptions were confusing - couldn't assign to a group and a catalog wasn't a group.  There are no API definitions changed with this PR.