### PR TITLE
Update community call link and wording

### DIFF
--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -102,7 +102,7 @@ Here are some ways we can engage:
     1. Debut in **_preview_** status. Any related REST API updates are in the beta endpoint (`https://graph.microsoft.com/beta`).  
 
     2. Promoted to **_general availability_ (GA)** status, if sufficient feedback indicates viability. Any related REST API updates are added to the v1.0 endpoint (`https://graph.microsoft.com/v1.0`). 
-- Be an active member in the Microsoft Graph community! [Join](https://aka.ms/microsoftgraphcall) the monthly Microsoft Graph community call.
+- Be an active member in the Microsoft Graph community! [Join](https://aka.ms/m365-dev-call) the weekly Microsoft 365 platform community call.
 - Sign up for the [Microsoft 365 developer program](https://developer.microsoft.com/office/dev-program), get a free Microsoft 365 subscription, and start developing!
 
 


### PR DESCRIPTION
Microsoft Graph call has merged with the M365 platform community call as of Aug 2021.  Updating link and wording to match current.