### PR TITLE
EM create policy: include example for review settings

### DIFF
--- a/api-reference/v1.0/api/entitlementmanagement-post-assignmentpolicies.md
+++ b/api-reference/v1.0/api/entitlementmanagement-post-assignmentpolicies.md
@@ -51,6 +51,7 @@ You can specify the following properties when creating an **accessPackageAssignm
 |expiration|[expirationPattern](../resources/expirationpattern.md)|The expiration date for assignments created in this policy.|
 |requestApprovalSettings|[accessPackageAssignmentApprovalSettings](../resources/accesspackageassignmentapprovalsettings.md)|Specifies the settings for approval of requests for an access package assignment through this policy. For example, if approval is required for new requests.|
 |requestorSettings|[accessPackageAssignmentRequestorSettings](../resources/accesspackageassignmentrequestorsettings.md)|Provides additional settings to select who can create a request for an access package assignment through this policy, and what they can include in their request.|
+|reviewSettings|[accessPackageAssignmentReviewSettings](../resources/accesspackageassignmentreviewsettings.md)|Settings for access reviews of assignments through this policy.|
 |specificAllowedTargets|[subjectSet](../resources/subjectset.md) collection|The targets for being assigned access from an access package from this policy.|
 |accessPackage|[accessPackage](../resources/accesspackage.md)| A reference to the access package that will contain the policy, which must already exist.|
 
@@ -157,7 +158,7 @@ Content-Type: application/json
 
 ### Example 2: Create a policy for users from other organizations to request
 
-The following example shows a more complex policy with two stages of approval.
+The following example shows a more complex policy with two stages of approval and recurring access reviews.
 
 #### Request
 
@@ -237,6 +238,40 @@ Content-Type: application/json
                 "fallbackEscalationApprovers": []
             }
         ]
+    },
+    "reviewSettings": {
+        "isEnabled": true,
+        "expirationBehavior": "keepAccess",
+        "isRecommendationEnabled": true,
+        "isReviewerJustificationRequired": true,
+        "isSelfReview": false,
+        "schedule": {
+            "startDateTime": "2022-07-02T06:59:59.998Z",
+            "expiration": {
+                "duration": "P14D",
+                "type": "afterDuration"
+            },
+            "recurrence": {
+                "pattern": {
+                    "type": "absoluteMonthly",
+                    "interval": 3,
+                    "month": 0,
+                    "dayOfMonth": 0,
+                    "daysOfWeek": []
+                },
+                "range": {
+                    "type": "noEnd",
+                    "numberOfOccurrences": 0
+                }
+            }
+        },
+        "primaryReviewers": [
+            {
+                "@odata.type": "#microsoft.graph.groupMembers",
+                "groupId": "1623f912-5e86-41c2-af47-39dd67582b66"
+            }
+        ],
+        "fallbackReviewers": []
     },
     "accessPackage": {
         "id": "a2e1ca1e-4e56-47d2-9daa-e2ba8d12a82b"


### PR DESCRIPTION
In entitlement management in v1.0 API, I had included `reviewSettings` as a property of the accessPackageAssignmentPolicy resource, but didn't mention it in the crreate article's list of properties as one of the properties that could be included in a new policy when its created.  This PR adds the missing row to that table to clarify that a new policy can have reviewSettings, and includes an example of its syntax in the second example.