### PR TITLE
Add confirmsafe confirmcompromised methods to signin.md

### DIFF
--- a/api-reference/beta/resources/signin.md
+++ b/api-reference/beta/resources/signin.md
@@ -24,6 +24,8 @@ The availability of sign-in logs is governed by the [Azure AD data retention pol
 |:---------------|:--------|:----------|
 |[List signIn](../api/signin-list.md) | [signIn](signin.md) |Read properties and relationships of signIn objects.|
 |[Get signIn](../api/signin-get.md) | [signIn](signin.md) |Read properties and relationships of a signIn object.|
+|[confirmCompromised](../api/signin-confirmcompromised.md)|None|Mark an event in the Azure AD sign in logs as risky.|
+|[confirmSafe](../api/signin-confirmsafe.md)|None|mark an event in Azure AD sign in logs as safe.|
 
 ## Properties
 | Property	   | Type	|Description|

--- a/api-reference/beta/resources/signin.md
+++ b/api-reference/beta/resources/signin.md
@@ -24,8 +24,8 @@ The availability of sign-in logs is governed by the [Azure AD data retention pol
 |:---------------|:--------|:----------|
 |[List signIn](../api/signin-list.md) | [signIn](signin.md) |Read properties and relationships of signIn objects.|
 |[Get signIn](../api/signin-get.md) | [signIn](signin.md) |Read properties and relationships of a signIn object.|
-|[confirmCompromised](../api/signin-confirmcompromised.md)|None|Mark an event in the Azure AD sign in logs as risky.|
-|[confirmSafe](../api/signin-confirmsafe.md)|None|mark an event in Azure AD sign in logs as safe.|
+|[Confirm compromised](../api/signin-confirmcompromised.md)|None|Mark an event in the Azure AD sign in logs as risky.|
+|[Confirm safe](../api/signin-confirmsafe.md)|None|mark an event in Azure AD sign in logs as safe.|
 
 ## Properties
 | Property	   | Type	|Description|


### PR DESCRIPTION
Sarah Handler pointed out that we're missing methods for the confirmsafe and confirmcompromised APIs on the signin object. Added them to signin.md