### PR TITLE
docs: Batch limits on Batching page

### DIFF
--- a/concepts/json-batching.md
+++ b/concepts/json-batching.md
@@ -196,15 +196,15 @@ If an individual request fails, any request that depends on that request fails w
 
 An additional use case for JSON batching is to bypass URL length limitations. In cases where the filter clause is complex, the URL length might surpass limitations built into browsers or other HTTP clients. You can use JSON batching as a workaround for running these requests because the lengthy URL simply becomes part of the request payload.
 
-## Batch size is limited
+## Batch size limitations
 
-JSON batch requests are currently limited to **20** individual requests.
+JSON batch requests are currently limited to 20 individual requests, in addition to the following limitations:
 
-* Depending on the APIs part of the batch request, the underlying services impose their own throttling limits that affect applications that use Microsoft Graph to access them.
-* Requests in a batch are evaluated individually against throttling limits and if any request exceeds the limits, it fails with a status of 429.
-* Batches targeting Outlook resources (eg. mail & calendar) may only contain **4** request targeting the same mailbox, more details see [Outlook service limits][throttling-outlook].
+* Depending on the APIs that are part of the batch request, the underlying services impose their own throttling limits that affect applications that use Microsoft Graph to access them.
+* Requests in a batch are evaluated individually against throttling limits and if any request exceeds the limits, it fails with a status of `429`.
+* Batches targeting Outlook resources (such as mail abd calendar) can only contain four requests targeting the same mailbox. For details, see [Outlook service limits][throttling-outlook].
 
-For more details, visit [Throttling and batching][throttling-and-batching].
+For more information, see [Throttling and batching][throttling-and-batching].
 
 ## Known issues
 

--- a/concepts/json-batching.md
+++ b/concepts/json-batching.md
@@ -212,8 +212,8 @@ For a list of current limitations related to batching, see [known issues][batchi
 
 [batching-known-issues]: known-issues.md#json-batching
 [odata-4.01-json]: https://www.oasis-open.org/committees/download.php/60365/odata-json-format-v4.01-wd02-2017-03-24.docx
-[throttling-and-batching]: throttling#throttling-and-batching
-[throttling-outlook]: throttling#outlook-service-limits
+[throttling-and-batching]: throttling.md#throttling-and-batching
+[throttling-outlook]: throttling.md#outlook-service-limits
 
 ## See also
 

--- a/concepts/json-batching.md
+++ b/concepts/json-batching.md
@@ -196,13 +196,24 @@ If an individual request fails, any request that depends on that request fails w
 
 An additional use case for JSON batching is to bypass URL length limitations. In cases where the filter clause is complex, the URL length might surpass limitations built into browsers or other HTTP clients. You can use JSON batching as a workaround for running these requests because the lengthy URL simply becomes part of the request payload.
 
+## Batch size is limited
+
+JSON batch requests are currently limited to **20** individual requests.
+
+* Depending on the APIs part of the batch request, the underlying services impose their own throttling limits that affect applications that use Microsoft Graph to access them.
+* Requests in a batch are evaluated individually against throttling limits and if any request exceeds the limits, it fails with a status of 429.
+* Batches targeting Outlook resources (eg. mail & calendar) may only contain **4** request targeting the same mailbox, more details see [Outlook service limits][throttling-outlook].
+
+For more details, visit [Throttling and batching][throttling-and-batching].
+
 ## Known issues
 
 For a list of current limitations related to batching, see [known issues][batching-known-issues].
 
 [batching-known-issues]: known-issues.md#json-batching
 [odata-4.01-json]: https://www.oasis-open.org/committees/download.php/60365/odata-json-format-v4.01-wd02-2017-03-24.docx
-
+[throttling-and-batching]: throttling#throttling-and-batching
+[throttling-outlook]: throttling#outlook-service-limits
 
 ## See also
 


### PR DESCRIPTION
In my opinion the limits of batching should be on the page describing batching.

There have been lengthy discussions on this topic several times [here](https://stackoverflow.com/questions/56873802/microsoft-graph-api-batch-limit) and in the issue below

Fixes #4366

This PR doesn't fix the [actual discussion](https://github.com/microsoftgraph/microsoft-graph-docs/issues/8760#issuecomment-648878458) on the batching limits, it just clarifies them to all users.