### PR TITLE
entitlement management: backport example description fix to beta

### DIFF
--- a/api-reference/beta/api/entitlementmanagement-post-accesspackageassignmentrequests.md
+++ b/api-reference/beta/api/entitlementmanagement-post-accesspackageassignmentrequests.md
@@ -376,7 +376,7 @@ Content-type: application/json
 To remove assignments, create a new accessPackageAssignmentRequest object with the following settings:
 
 + The value of the **requestType** property set to `AdminRemove`.
-+ In the accessPackageAssignment property, include a list with the identifier of the accessPackageAssignment objects to delete.
++ In the accessPackageAssignment property, include an object with the identifier of the accessPackageAssignment objects to delete.
 
 #### Request
 


### PR DESCRIPTION
In the example for creating a request to remove an assignment, the beta article inadvertently said "a list" whereas the structure is not a JSON list, it is a JSON object.  This was corrected in the v1.0 docs, backporting to the description in the beta article.