### PR TITLE
Update plannerPlan - Removed owner property from body

### DIFF
--- a/api-reference/beta/api/plannerplan-update.md
+++ b/api-reference/beta/api/plannerplan-update.md
@@ -40,6 +40,10 @@ PATCH /planner/plans/{plan-id}
 ## Request body
 In the request body, supply the values for relevant fields to update. Existing properties that are not included in the request body will maintain their previous values or be recalculated based on changes to other property values. For best performance, don't include existing values that haven't changed.
 
+| Property	   | Type	|Description|
+|:---------------|:--------|:----------|
+|title|String|Title of the plan.|
+
 ## Response
 
 If successful, this method returns `204 No Content` response and empty content. If the request specifies `Prefer` header with `return=representation` preference, then this method returns a `200 OK` response code and an updated [plannerPlan](../resources/plannerplan.md) object in the response body.

--- a/api-reference/v1.0/api/plannerplan-update.md
+++ b/api-reference/v1.0/api/plannerplan-update.md
@@ -40,7 +40,6 @@ In the request body, supply the values for relevant fields to updated. Existing 
 
 | Property	   | Type	|Description|
 |:---------------|:--------|:----------|
-|owner|String|[Group](../resources/group.md) `id` by which the plan is owned. A valid group must exist before this field can be set. Once set, this can only be updated by the owner.|
 |title|String|Title of the plan.|
 
 ## Response


### PR DESCRIPTION
Closes #17084 

## Info
* Removed owner property of `update plannerPlan` page.
* Added body table to beta endpoint page since it was missing here.