### PR TITLE
Correcting the wording

### DIFF
--- a/api-reference/beta/api/accessreviewinstance-list-contactedreviewers.md
+++ b/api-reference/beta/api/accessreviewinstance-list-contactedreviewers.md
@@ -1,6 +1,6 @@
 ---
 title: "List contactedReviewers"
-description: "Get the reviewers who received notifications for an access review instance."
+description: "Get the reviewers for an access review instance."
 author: "isabelleatmsft"
 ms.localizationpriority: medium
 ms.prod: "governance"
@@ -12,7 +12,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Get the reviewers who received notifications for an [access review instance](../resources/accessreviewinstance.md). The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
+Get the reviewers for an [access review instance](../resources/accessreviewinstance.md), irrespective of whether or not they have received a notification. The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/accessreviewinstance-list-contactedreviewers.md
+++ b/api-reference/v1.0/api/accessreviewinstance-list-contactedreviewers.md
@@ -1,6 +1,6 @@
 ---
 title: "List contactedReviewers"
-description: "Get the reviewers who received notifications for an access review instance."
+description: "Get the reviewers for an access review instance."
 author: "isabelleatmsft"
 ms.localizationpriority: medium
 ms.prod: "governance"
@@ -10,7 +10,7 @@ doc_type: apiPageType
 # List contactedReviewers
 Namespace: microsoft.graph
 
-Get the reviewers who received notifications for an [access review instance](../resources/accessreviewinstance.md). The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
+Get the reviewers for an [access review instance](../resources/accessreviewinstance.md), irrespective of whether they have received a notification or not. The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/accessreviewinstance-list-contactedreviewers.md
+++ b/api-reference/v1.0/api/accessreviewinstance-list-contactedreviewers.md
@@ -10,7 +10,7 @@ doc_type: apiPageType
 # List contactedReviewers
 Namespace: microsoft.graph
 
-Get the reviewers for an [access review instance](../resources/accessreviewinstance.md), irrespective of whether they have received a notification or not. The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
+Get the reviewers for an [access review instance](../resources/accessreviewinstance.md), irrespective of whether or not they have received a notification. The reviewers are represented by an [accessReviewReviewer](../resources/accessreviewreviewer.md) object. A list of zero or more objects are returned, including all of their nested properties.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).


### PR DESCRIPTION
Tested and cross-checked with the Engineers.
It turns out we return contactedReviewers always, not only in case we actually contacted the reviewers (when the Access Reviews config says "Email reviewers"). Have removed the occasions where we say "the reviewers that got notified...".