### PR TITLE
Update displayName in Microsoft Graph TOC

### DIFF
--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -12,7 +12,7 @@ items:
       - name: Services in Microsoft Graph
         href: overview-major-services.md
       - name: What's new
-        expanded: false
+        expanded: true
         items:
           - name: What's new highlights
             href: whats-new-overview.md
@@ -28,6 +28,8 @@ items:
             href: deployments.md
           - name: Hybrid deployments (deprecated)
             href: hybrid-rest-support.md
+      - name: Quick start
+        href: https://developer.microsoft.com/graph/quick-start
       - name: Tutorials
         items:
           - name: Overview
@@ -51,8 +53,6 @@ items:
             href: /graph/tutorials/python
           - name: TypeScript
             href: /graph/tutorials/typescript
-      - name: Quick start
-        href: https://developer.microsoft.com/graph/quick-start
       - name: Versioning and support
         href: versioning-and-support.md
       - name: Terms of use
@@ -103,9 +103,9 @@ items:
             href: data-connect-filtering.md
           - name: Integrate with PAM
             href: data-connect-pam.md
-          - name: Frequently asked questions
+          - name: Data Connect FAQ
             href: data-connect-faq.md
-            displayName: Microsoft Graph Data Connect, FAQ
+            displayName: Microsoft Graph Data Connect, frequently asked questions
       - name: Calendar
         items:
           - name: Overview
@@ -377,10 +377,10 @@ items:
         items:
           - name: Overview
             href: notifications-concept-overview.md
-            displayName: deprecated
+            displayName: deprecated, notifications
           - name: Get started
             items:
-              - name: Get started overview
+              - name: Integrate with notifications
                 href: notifications-integration-e2e-overview.md
               - name: App registration
                 href: notifications-integration-app-registration.md
@@ -677,9 +677,9 @@ items:
                     href: migrate-azure-ad-graph-client-libraries.md
               - name: "4: Deploy, test, and extend"
                 href: migrate-azure-ad-graph-deploy-test-extend.md
-              - name: Migration FAQ
+              - name: Azure AD Graph migration FAQ
                 href: migrate-azure-ad-graph-faq.md
-                displayName: migrate, Azure AD Graph, frequently asked questions
+                displayName: migrate, frequently asked questions
               - name: Configure Azure AD Graph permissions
                 href: migrate-azure-ad-graph-configure-permissions.md
           - name: Exchange Web Services
@@ -824,7 +824,7 @@ items:
               - name: Right-to-left support
                 href: toolkit/customize-components/right-to-left.md
       - name: Resources
-        expanded: false
+        expanded: true
         items:
           - name: Best practices
             href: best-practices-concept.md

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -105,7 +105,7 @@ items:
             href: data-connect-pam.md
           - name: Frequently asked questions
             href: data-connect-faq.md
-            displayName: Microsoft Graph Data Connect
+            displayName: Microsoft Graph Data Connect, FAQ
       - name: Calendar
         items:
           - name: Overview
@@ -679,7 +679,7 @@ items:
                 href: migrate-azure-ad-graph-deploy-test-extend.md
               - name: Migration FAQ
                 href: migrate-azure-ad-graph-faq.md
-                displayName: migrate, Azure AD Graph
+                displayName: migrate, Azure AD Graph, frequently asked questions
               - name: Configure Azure AD Graph permissions
                 href: migrate-azure-ad-graph-configure-permissions.md
           - name: Exchange Web Services

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -532,6 +532,7 @@ items:
         items:
           - name: Overview
             href: auth/index.yml
+            displayName: authentication, authorization
           - name: Basics
             href: auth/auth-concepts.md
           - name: Register your app
@@ -552,31 +553,33 @@ items:
         items:
           - name: Overview
             href: use-the-api.md
+            displayName: use the API, Microsoft Graph API
           - name: Access data and methods
             href: traverse-the-graph.md
           - name: Paging
             href: paging.md
           - name: Query parameters
-            displayName: OData query parameters
             items:
               - name: Use query parameters
                 href: query-parameters.md
+                displayName: OData query parameters, OData
               - name: Use the search query parameter
                 href: search-query-parameter.md
               - name: Advanced query capabilities
                 href: aad-advanced-queries.md
           - name: Batching
-            displayName: Batch requests
             href: json-batching.md
+            displayName: Batch request
           - name: Throttling
             href: throttling.md
           - name: Change notifications
-            displayName: Webhooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
             items:
               - name: Overview
                 href: webhooks.md
+                displayName: WebHooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
               - name: Tutorial
                 href: /learn/modules/msgraph-changenotifications-trackchanges
+                displayName: change notification
               - name: Missing change notifications
                 href: webhooks-lifecycle.md
               - name: Notifications with resource data
@@ -589,6 +592,7 @@ items:
                 items:
                   - name: Overview
                     href: teams-change-notification-in-microsoft-teams-overview.md
+                    displayName: change notifications, Teams, Microsoft Teams
                   - name: Teams and channels
                     href: teams-changenotifications-team-and-channel.md
                   - name: Team and channel membership
@@ -602,10 +606,10 @@ items:
               - name: Change notifications for Outlook resources
                 href: outlook-change-notifications-overview.md
           - name: Change tracking
-            displayName: Delta query, track changes, Outlook calendar, Groups, Outlook mail, Users
             items:
               - name: Overview
                 href: delta-query-overview.md
+                displayName: Delta query, track changes, Outlook calendar, Groups, Outlook mail, Users, change tracking
               - name: Get changes to events (example)
                 href: delta-query-events.md
               - name: Get changes to groups (example)
@@ -615,10 +619,10 @@ items:
               - name: Get changes to users (example)
                 href: delta-query-users.md
           - name: Add custom data
-            displayName: Outlook calendar, Groups, Outlook mail, Outlook contacts, Outlook contact, People, Users
             items:
               - name: Overview
                 href: extensibility-overview.md
+                displayName: add custom data, Outlook calendar, Groups, Outlook mail, Outlook contacts, Outlook contact, People, Users
               - name: Use open extensions (example)
                 href: extensibility-open-users.md
               - name: Use schema extensions (example)
@@ -627,18 +631,18 @@ items:
             items:
             - name: Get started
               href: graph-explorer/graph-explorer-overview.md
+              displayName: Graph Explorer, try the API, try API
             - name: Work with Graph Explorer
               href: graph-explorer/graph-explorer-features.md
           - name: Use Postman
             href: use-postman.md
       - name: Migrate
-        expanded: false
         items:
           - name: Azure AD Graph
-            displayName: Migration, Azure AD Graph
             items:
               - name: Overview
                 href: migrate-azure-ad-graph-overview.md
+                displayName: Migration, Azure AD Graph, migrate
               - name: Checklist to migrate apps
                 href: migrate-azure-ad-graph-planning-checklist.md
               - name: "1: Review differences"
@@ -672,10 +676,10 @@ items:
               - name: Configure Azure AD Graph permissions
                 href: migrate-azure-ad-graph-configure-permissions.md
           - name: Exchange Web Services
-            displayName: Migration, Exchange Web Services, EWS
             items:
               - name: Overview
                 href: migrate-exchange-web-services-overview.md
+                displayName: Migration, Exchange Web Services, EWS, migrate
               - name: Authentication
                 href: migrate-exchange-web-services-authentication.md
               - name: API mapping
@@ -684,8 +688,10 @@ items:
         items:
           - name: Overview
             href: sdks/sdks-overview.md
+            displayName: SDK, SDKs, Microsoft Graph SDK
           - name: Install an SDK
             href: sdks/sdk-installation.md
+            displayName: install SDK, install SDKs
           - name: Create a client
             href: sdks/create-client.md
           - name: Customize a client
@@ -706,11 +712,11 @@ items:
             items:
               - name: Overview
                 href: /powershell/microsoftgraph/overview?toc=/graph/toc.json
-              - name: Installation
+              - name: Install PowerShell SDK
                 href: /powershell/microsoftgraph/installation?toc=/graph/toc.json
               - name: Get started
                 href: /powershell/microsoftgraph/get-started?toc=/graph/toc.json
-              - name: Navigating the SDK
+              - name: Navigate the SDK
                 href: /powershell/microsoftgraph/navigating?toc=/graph/toc.json
               - name: App-only authentication
                 href: /powershell/microsoftgraph/app-only?toc=/graph/toc.json
@@ -718,10 +724,12 @@ items:
         items:
           - name: Toolkit overview
             href: toolkit/overview.md
+            displayName: Microsoft Graph Toolkit
           - name: Get started
             items:
               - name: Overview
                 href: toolkit/get-started/overview.md
+                displayName: Microsoft Graph Toolkit, toolkit
               - name: Toolkit for React
                 href: toolkit/get-started/mgt-react.md
               - name: Toolkit for SPFx
@@ -748,6 +756,7 @@ items:
             items:
               - name: Using the providers
                 href: toolkit/providers/providers.md
+                displayName: Microsoft Graph Toolkit providers, toolkit provider
               - name: MSAL provider
                 href: toolkit/providers/msal.md
               - name: MSAL2 provider
@@ -770,6 +779,7 @@ items:
             items:
               - name: Login
                 href: toolkit/components/login.md
+                displayName: Microsoft Graph toolkit components, toolkit component
               - name: Get
                 href: toolkit/components/get.md
               - name: Person

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -12,12 +12,13 @@ items:
       - name: Services in Microsoft Graph
         href: overview-major-services.md
       - name: What's new
-        expanded: true
+        expanded: false
         items:
           - name: What's new highlights
             href: whats-new-overview.md
           - name: API changelog
             href: https://developer.microsoft.com/graph/changelog
+            displayName: API changes, API updates, Microsoft Graph API
       - name: Users you can reach
         items:
           - name: Overview
@@ -50,6 +51,8 @@ items:
             href: /graph/tutorials/python
           - name: TypeScript
             href: /graph/tutorials/typescript
+      - name: Quick start
+        href: https://developer.microsoft.com/graph/quick-start
       - name: Versioning and support
         href: versioning-and-support.md
       - name: Terms of use
@@ -159,8 +162,9 @@ items:
         href: compliance-concept-overview.md
       - name: Connecting external content
         items:
-          - name: Microsoft Graph connectors overview
+          - name: Connectors overview
             href: connecting-external-content-connectors-overview.md
+            displayName: Microsoft Graph connectors
           - name: Connectors API
             href: connecting-external-content-connectors-api-overview.md
             displayName: Microsoft Graph connectors
@@ -554,7 +558,7 @@ items:
         items:
           - name: Overview
             href: use-the-api.md
-            displayName: Microsoft Graph API, API, REST API
+            displayName: Microsoft Graph API, API, Microsoft Graph REST API, REST API
           - name: Access data and methods
             href: traverse-the-graph.md
           - name: Paging
@@ -818,17 +822,22 @@ items:
               - name: Right-to-left support
                 href: toolkit/customize-components/right-to-left.md
       - name: Resources
-        expanded: true
+        expanded: false
         items:
           - name: Best practices
             href: best-practices-concept.md
+            displayName: Microsoft Graph, Best practices for working with Microsoft Graph
           - name: Known issues
             href: known-issues.md
+            displayName: Microsoft Graph, Known issues with Microsoft Graph
           - name: API changelog
             href: changelog.md
           - name: Errors
             href: errors.md
-      - name: v1.0 reference
+            displayName: Microsoft Graph error responses and resource types
+      - name: API v1.0 reference
         href: /graph/api/overview?view=graph-rest-1.0&preserve-view=true
-      - name: Beta reference
+        displayName: Microsoft Graph REST API v1.0 reference
+      - name: API beta reference
         href: /graph/api/overview?view=graph-rest-beta&preserve-view=true
+        displayName: Microsoft Graph beta endpoint reference, Microsoft Graph REST API Beta

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -18,7 +18,7 @@ items:
             href: whats-new-overview.md
           - name: API changelog
             href: https://developer.microsoft.com/graph/changelog
-            displayName: API changes, API updates, Microsoft Graph API
+            displayName: API changes, API updates, Microsoft Graph API, REST API, what's new, REST API updates
       - name: Users you can reach
         items:
           - name: Overview
@@ -94,6 +94,7 @@ items:
             displayName: Microsoft Graph Data Connect, access data, bulk data           
           - name: Build your first Data Connect application
             href: data-connect-quickstart.yml
+            displayName: Microsoft Graph Data Connect
           - name: Datasets, regions, and sinks
             href: data-connect-datasets.md
           - name: Policies and billing
@@ -104,6 +105,7 @@ items:
             href: data-connect-pam.md
           - name: Frequently asked questions
             href: data-connect-faq.md
+            displayName: Microsoft Graph Data Connect
       - name: Calendar
         items:
           - name: Overview
@@ -834,7 +836,7 @@ items:
             href: changelog.md
           - name: Errors
             href: errors.md
-            displayName: Microsoft Graph error responses and resource types
+            displayName: Microsoft Graph error responses and error resource types
       - name: API v1.0 reference
         href: /graph/api/overview?view=graph-rest-1.0&preserve-view=true
         displayName: Microsoft Graph REST API v1.0 reference

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -597,7 +597,7 @@ items:
                 href: universal-print-webhook-notifications.md
               - name: Change notifications for Microsoft Teams resources
                 items:
-                  - name: Types and payloads
+                  - name: Notification types and payloads
                     href: teams-change-notification-in-microsoft-teams-overview.md
                     displayName: change notifications, Teams, Microsoft Teams
                   - name: Teams and channels

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -24,7 +24,7 @@ items:
         items:
           - name: Overview
             href: users-you-can-reach.md
-            displayName: users you can reach, users
+            displayName: users you can reach
           - name: National cloud deployments
             href: deployments.md
           - name: Hybrid deployments (deprecated)
@@ -105,6 +105,7 @@ items:
             href: data-connect-filtering.md
           - name: Integrate with PAM
             href: data-connect-pam.md
+            displayName: Privileged Access Management
           - name: Data Connect FAQ
             href: data-connect-faq.md
             displayName: Microsoft Graph Data Connect, frequently asked questions
@@ -215,7 +216,7 @@ items:
         items:
           - name: Cloud printing
             items:
-              - name: Cloud printing overview
+              - name: Overview
                 href: universal-print-concept-overview.md
                 displayName: Universal Print, Cloud printing, printing, device and app management
               - name: Upload data to upload session
@@ -231,7 +232,7 @@ items:
             href: cloudpc-concept-overview.md
           - name: Device updates (preview)           
             items:
-              - name: Device updates overview
+              - name: Overview
                 href: windowsupdates-concept-overview.md
                 displayName: Windows updates, Windows update, device update
               - name: Software updates
@@ -305,9 +306,9 @@ items:
                 displayName: governance, identity
               - name: Review access to your resources
                 items:
-                  - name: Access reviews API overview
+                  - name: Overview
                     href: accessreviews-overview.md
-                    displayName: identity
+                    displayName: identity, access reviews API, review access
                   - name: Review access to a security group
                     href: tutorial-accessreviews-securitygroup.md
                   - name: Review access for guest users
@@ -736,7 +737,7 @@ items:
             displayName: Microsoft Graph Toolkit, toolkit
           - name: Get started
             items:
-              - name: Get started overview
+              - name: Get started
                 href: toolkit/get-started/overview.md
                 displayName: Microsoft Graph Toolkit, toolkit
               - name: Toolkit for React

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -30,6 +30,7 @@ items:
             href: hybrid-rest-support.md
       - name: Quick start
         href: https://developer.microsoft.com/graph/quick-start
+        displayName: quickstart
       - name: Tutorials
         items:
           - name: Overview
@@ -166,7 +167,7 @@ items:
         items:
           - name: Connectors overview
             href: connecting-external-content-connectors-overview.md
-            displayName: Microsoft Graph connectors
+            displayName: Microsoft Graph connectors, connect external content
           - name: Connectors API
             href: connecting-external-content-connectors-api-overview.md
             displayName: Microsoft Graph connectors
@@ -215,7 +216,7 @@ items:
             items:
               - name: Cloud printing overview
                 href: universal-print-concept-overview.md
-                displayName: Universal Print, Cloud printing, printing
+                displayName: Universal Print, Cloud printing, printing, device and app management
               - name: Upload data to upload session
                 href: upload-data-to-upload-session.md
                 displayName: Universal Print Job Submission
@@ -581,9 +582,9 @@ items:
             href: throttling.md
           - name: Change notifications
             items:
-              - name: Change notifications overview
+              - name: Overview
                 href: webhooks.md
-                displayName: change notifications, WebHooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
+                displayName: change notifications, WebHooks, set up notifications for changes in resource data
               - name: Change notifications tutorial
                 href: /learn/modules/msgraph-changenotifications-trackchanges
               - name: Missing change notifications
@@ -594,9 +595,9 @@ items:
                 href: change-notifications-delivery.md
               - name: Change notifications for cloud printing
                 href: universal-print-webhook-notifications.md
-              - name: Change notifications for Microsoft Teams
+              - name: Change notifications for Microsoft Teams resources
                 items:
-                  - name: Change notifications for Microsoft Teams resources
+                  - name: Types and payloads
                     href: teams-change-notification-in-microsoft-teams-overview.md
                     displayName: change notifications, Teams, Microsoft Teams
                   - name: Teams and channels
@@ -613,9 +614,9 @@ items:
                 href: outlook-change-notifications-overview.md
           - name: Change tracking
             items:
-              - name: Change tracking overview
+              - name: Overview
                 href: delta-query-overview.md
-                displayName: Delta query, track changes, Outlook calendar, Groups, Outlook mail, Users, change tracking
+                displayName: Delta query, track changes, change tracking
               - name: Get changes to events (example)
                 href: delta-query-events.md
               - name: Get changes to groups (example)
@@ -626,9 +627,9 @@ items:
                 href: delta-query-users.md
           - name: Add custom data
             items:
-              - name: Add custom data to resources using extensions
+              - name: Overview
                 href: extensibility-overview.md
-                displayName: add custom data, Outlook calendar, Groups, Outlook mail, Outlook contacts, Outlook contact, People, Users
+                displayName: add custom data, extensions, resources using extensions
               - name: Use open extensions (example)
                 href: extensibility-open-users.md
               - name: Use schema extensions (example)

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -207,7 +207,7 @@ items:
         items:
           - name: Cloud printing
             items:
-              - name: Overview
+              - name: Cloud printing overview
                 href: universal-print-concept-overview.md
                 displayName: Universal Print, Cloud printing, printing
               - name: Upload data to upload session
@@ -223,7 +223,7 @@ items:
             href: cloudpc-concept-overview.md
           - name: Device updates (preview)           
             items:
-              - name: Overview
+              - name: Device updates overview
                 href: windowsupdates-concept-overview.md
                 displayName: Windows updates, Windows update, device update
               - name: Software updates
@@ -372,7 +372,7 @@ items:
             displayName: notification, notifications
           - name: Get started
             items:
-              - name: Overview
+              - name: Get started overview
                 href: notifications-integration-e2e-overview.md
                 displayName: notification, notifications
               - name: App registration
@@ -553,7 +553,7 @@ items:
         items:
           - name: Overview
             href: use-the-api.md
-            displayName: use the API, Microsoft Graph API
+            displayName: Microsoft Graph API
           - name: Access data and methods
             href: traverse-the-graph.md
           - name: Paging
@@ -574,9 +574,9 @@ items:
             href: throttling.md
           - name: Change notifications
             items:
-              - name: Overview
+              - name: Change notifications overview
                 href: webhooks.md
-                displayName: WebHooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
+                displayName: change notifications, WebHooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
               - name: Tutorial
                 href: /learn/modules/msgraph-changenotifications-trackchanges
                 displayName: change notification
@@ -590,7 +590,7 @@ items:
                 href: universal-print-webhook-notifications.md
               - name: Change notifications for Microsoft Teams
                 items:
-                  - name: Overview
+                  - name: Microsoft Teams overview
                     href: teams-change-notification-in-microsoft-teams-overview.md
                     displayName: change notifications, Teams, Microsoft Teams
                   - name: Teams and channels
@@ -607,7 +607,7 @@ items:
                 href: outlook-change-notifications-overview.md
           - name: Change tracking
             items:
-              - name: Overview
+              - name: Change tracking overview
                 href: delta-query-overview.md
                 displayName: Delta query, track changes, Outlook calendar, Groups, Outlook mail, Users, change tracking
               - name: Get changes to events (example)
@@ -620,7 +620,7 @@ items:
                 href: delta-query-users.md
           - name: Add custom data
             items:
-              - name: Overview
+              - name: Add custom data to resources using extensions
                 href: extensibility-overview.md
                 displayName: add custom data, Outlook calendar, Groups, Outlook mail, Outlook contacts, Outlook contact, People, Users
               - name: Use open extensions (example)
@@ -640,7 +640,7 @@ items:
         items:
           - name: Azure AD Graph
             items:
-              - name: Overview
+              - name: Migrate Azure AD Graph apps
                 href: migrate-azure-ad-graph-overview.md
                 displayName: Migration, Azure AD Graph, migrate
               - name: Checklist to migrate apps
@@ -677,7 +677,7 @@ items:
                 href: migrate-azure-ad-graph-configure-permissions.md
           - name: Exchange Web Services
             items:
-              - name: Overview
+              - name: Migrate Exchange Web Services apps
                 href: migrate-exchange-web-services-overview.md
                 displayName: Migration, Exchange Web Services, EWS, migrate
               - name: Authentication
@@ -710,7 +710,7 @@ items:
             href: sdks/use-beta.md
           - name: Use PowerShell
             items:
-              - name: Overview
+              - name: PowerShell overview
                 href: /powershell/microsoftgraph/overview?toc=/graph/toc.json
               - name: Install PowerShell SDK
                 href: /powershell/microsoftgraph/installation?toc=/graph/toc.json
@@ -722,12 +722,12 @@ items:
                 href: /powershell/microsoftgraph/app-only?toc=/graph/toc.json
       - name: Use the toolkit
         items:
-          - name: Toolkit overview
+          - name: Overview
             href: toolkit/overview.md
             displayName: Microsoft Graph Toolkit
           - name: Get started
             items:
-              - name: Overview
+              - name: Get started overview
                 href: toolkit/get-started/overview.md
                 displayName: Microsoft Graph Toolkit, toolkit
               - name: Toolkit for React

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -22,6 +22,7 @@ items:
         items:
           - name: Overview
             href: users-you-can-reach.md
+            displayName: users you can reach, users
           - name: National cloud deployments
             href: deployments.md
           - name: Hybrid deployments (deprecated)
@@ -30,6 +31,7 @@ items:
         items:
           - name: Overview
             href: tutorials.md
+            displayName: tutorials
           - name: .NET
             href: /graph/tutorials/dotnet
           - name: Go
@@ -59,12 +61,14 @@ items:
         items:
           - name: Overview
             href: azuread-users-concept-overview.md
+            displayName: users
           - name: Access user data
             href: /learn/modules/msgraph-access-user-data
       - name: Groups
         items:
           - name: Overview
             href: /graph/api/resources/groups-overview?context=graph/context
+            displayName: groups
           - name: Microsoft 365 groups
             href: office365-groups-concept-overview.md
           - name: Configure group options
@@ -75,15 +79,16 @@ items:
         items:
           - name: Overview
             href: applications-concept-overview.md
+            displayName: applications, apps
           - name: Automate SAML-based SSO configuration
             href: application-saml-sso-configure-api.md
           - name: Configure application proxy
             href: application-proxy-configure-api.md
       - name: Accessing data at scale
-        displayName: Microsoft Graph Data Connect
         items:
           - name: Overview of Data Connect
             href: data-connect-concept-overview.md
+            displayName: Microsoft Graph Data Connect            
           - name: Build your first Data Connect application
             href: data-connect-quickstart.yml
           - name: Datasets, regions, and sinks
@@ -97,10 +102,10 @@ items:
           - name: Frequently asked questions
             href: data-connect-faq.md
       - name: Calendar
-        displayName: Outlook
         items:
           - name: Overview
             href: outlook-calendar-concept-overview.md
+            displayName: Outlook, calendar
           - name: Find meeting times
             href: findmeetingtimes-example.md
           - name: Get free/busy schedule
@@ -129,6 +134,7 @@ items:
         items:
           - name: Overview
             href: cloud-communications-concept-overview.md
+            displayName: cloud communications
           - name: Get started
             href: cloud-communications-get-started.md
           - name: Calls
@@ -152,16 +158,18 @@ items:
       - name: Compliance
         href: compliance-concept-overview.md
       - name: Connecting external content
-        displayName: connectors
         items:
           - name: Overview of Microsoft Graph connectors
             href: connecting-external-content-connectors-overview.md
           - name: Connectors API
             href: connecting-external-content-connectors-api-overview.md
+            displayName: Microsoft Graph connectors
           - name: Use Postman
             href: connecting-external-content-connectors-api-postman.md
+            displayName: connector, connectors
           - name: Build your first custom connector
             href: connecting-external-content-build-quickstart.yml
+            displayName: connectors, Microsoft Graph connectors
           - name: Manage connections
             href: connecting-external-content-manage-connections.md
           - name: Manage schema
@@ -173,22 +181,27 @@ items:
           - name: API limits
             href: connecting-external-content-api-limits.md
       - name: Cross-device experiences
-        displayName: Project Rome
         items:
           - name: Overview
             href: cross-device-concept-overview.md
+            displayName: Project Rome, cross-device, cross device, cross-device experience
           - name: Activity feed
             href: activity-feed-concept-overview.md
+            displayName: cross-device, cross device
           - name: Device relay (preview)
             href: device-relay-concept-overview.md
+            displayName: cross-device, cross device
           - name: Build cross-device apps
             href: cross-device-app-configuration.md
+            displayName: cross device
       - name: Customer booking (preview)
-        href: booking-concept-overview.md
-        displayName: Bookings, Microsoft Bookings
         items:
+          - name: Overview 
+            href: booking-concept-overview.md
+            displayName: Bookings, Microsoft Bookings, booking, customer booking
           - name: Business rules
             href: bookingsbusiness-business-rules.md
+            displayName: Bookings, Microsoft Bookings, booking
       - name: Device and app management
         expanded: true
         items:
@@ -196,7 +209,7 @@ items:
             items:
               - name: Overview
                 href: universal-print-concept-overview.md
-                displayName: Universal Print
+                displayName: Universal Print, Cloud printing, printing
               - name: Upload data to upload session
                 href: upload-data-to-upload-session.md
                 displayName: Universal Print Job Submission
@@ -208,11 +221,11 @@ items:
             displayName: Intune
           - name: Cloud PC (preview)
             href: cloudpc-concept-overview.md
-          - name: Device updates (preview)
-            displayName: Windows updates
+          - name: Device updates (preview)           
             items:
               - name: Overview
                 href: windowsupdates-concept-overview.md
+                displayName: Windows updates, Windows update, device update
               - name: Software updates
                 href: windowsupdates-software-updates.md
               - name: Deployments
@@ -230,15 +243,16 @@ items:
               - name: Manage monitoring rules
                 href: windowsupdates-manage-monitoring-rules.md
           - name: Multi-tenant management (preview)
-            displayName: Microsoft 365 Lighthouse
             href: managedtenants-concept-overview.md
+            displayName: Microsoft 365 Lighthouse
           - name: Service health and communications
-            display name: service communications API
             href: service-communications-concept-overview.md
+            displayName: service communications
       - name: Education
         items:
           - name: Overview
             href: education-concept-overview.md
+            displayName: education
           - name: Rubrics
             href: education-rubric-overview.md
           - name: Upload files
@@ -248,24 +262,25 @@ items:
           - name: Specify the default channel for assignment notifications
             href: education-build-notificationchannelurl.md
       - name: Files
-        displayName: OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint
         items:
           - name: Overview
             href: onedrive-concept-overview.md
+            displayName: files, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint
           - name: Addressing drive items
             href: onedrive-addressing-driveitems.md
       - name: Financials (preview)
         href: dynamics-business-central-concept-overview.md
         displayName: Dynamics, Dynamics 365 Business Central
       - name: Identity and access
-        displayName: Azure AD, Microsoft identity platform
         items:
           - name: Overview
             href: azuread-identity-access-management-concept-overview.md
+            displayName: Azure AD, Microsoft identity platform, identity, access
           - name: Directory management
             items:
               - name: Manage custom security attributes (preview)
                 href: custom-security-attributes-examples.md
+                displayName: directory
               - name: Use PIM to assign Azure AD roles
                 href: tutorial-assign-azureadroles.md
           - name: Identity and sign-in
@@ -278,6 +293,7 @@ items:
             items:
               - name: Manage access to resources
                 href: tutorial-access-package-api.md
+                displayName: governance
               - name: Review access to your resources
                 items:
                   - name: Overview of the access reviews API
@@ -295,10 +311,10 @@ items:
               - name: Use PIM to assign Azure AD roles
                 href: tutorial-assign-azureadroles.md
       - name: Mail
-        displayName: Outlook, Outlook mail
         items:
           - name: Overview
             href: outlook-mail-concept-overview.md
+            displayName: Outlook, Outlook mail, mail, message           
           - name: Automate messaging
             href: outlook-create-send-messages.md
           - name: Organize messages
@@ -318,10 +334,10 @@ items:
           - name: Subscribe to change notifications
             href: outlook-change-notifications-overview.md
       - name: Notes
-        displayName: OneNote
         items:
           - name: Overview
             href: integrate-with-onenote.md
+            displayName: OneNote, notes
           - name: Get OneNote content
             href: onenote-get-content.md
           - name: Open the OneNote client
@@ -350,15 +366,15 @@ items:
               - name: Error codes
                 href: onenote-error-codes.md
       - name: Notifications (deprecated)
-        displayName: Notifications
         items:
           - name: Overview
             href: notifications-concept-overview.md
+            displayName: notification, notifications
           - name: Get started
-            displayName: Notifications
             items:
               - name: Overview
                 href: notifications-integration-e2e-overview.md
+                displayName: notification, notifications
               - name: App registration
                 href: notifications-integration-app-registration.md
               - name: Cross-device onboarding
@@ -375,6 +391,7 @@ items:
         items:
           - name: Overview
             href: social-intel-concept-overview.md
+            displayName: people, workplace, intelligence, people and workplace intelligence
           - name: Get information about relevant people
             href: people-example.md
           - name: Customize people insights privacy (preview)
@@ -386,10 +403,10 @@ items:
           - name: Customize item insights privacy (preview)
             href: insights-customize-item-insights-privacy.md
       - name: Personal contacts
-        displayName: Outlook, Outlook contacts, Outlook contact, People
         items:
           - name: Overview
             href: outlook-contacts-concept-overview.md
+            displayName: Outlook, Outlook contacts, Outlook contact, People, personal contacts
           - name: Get shared contacts
             href: outlook-get-shared-contacts-folders.md
           - name: Immutable ID
@@ -400,12 +417,14 @@ items:
         items:
           - name: Overview
             href: reportroot-concept-overview.md
+            displayName: report, reports
           - name: Authorization for Microsoft 365 usage reports
             href: reportroot-authorization.md
       - name: Search
         items:
           - name: Overview
             href: search-concept-overview.md
+            displayName: search
           - name: Search messages
             href: search-concept-messages.md
           - name: Search events
@@ -434,6 +453,7 @@ items:
         items:
           - name: Overview
             href: security-concept-overview.md
+            displayName: security
           - name: Data flow
             href: security-dataflow.md
           - name: Authorization
@@ -446,22 +466,22 @@ items:
             href: security-partner-overview.md
       - name: Sites and lists
         href: sharepoint-concept-overview.md
-        displayName: SharePoint, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal
+        displayName: SharePoint, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, sites, lists
       - name: Tasks and plans
         href: planner-concept-overview.md
         displayName: Planner
       - name: Teamwork
-        displayName: Microsoft Teams
         items:
           - name: Overview
             href: teams-concept-overview.md
+            displayName: teams, team, teamwork, Microsoft Teams
           - name: Create a group and team
             href: teams-create-group-and-team.md
           - name: List all teams
             href: teams-list-all-teams.md
           - name: Choose an online meeting API
             href: choose-online-meeting-api.md
-          - name: Configuring built-in tabs
+          - name: Configure built-in tabs
             href: teams-configuring-builtin-tabs.md
           - name: Protected APIs
             href: teams-protected-apis.md
@@ -485,10 +505,10 @@ items:
         href: todo-concept-overview.md
         displayName: Microsoft To Do
       - name: Workbooks and charts
-        displayName: Excel
         items:
           - name: Overview
             href: excel-concept-overview.md
+            displayName: Excel, workbooks, charts
           - name: Manage sessions
             href: excel-manage-sessions.md
           - name: Display a chart image

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -14,7 +14,7 @@ items:
       - name: What's new
         expanded: true
         items:
-          - name: Highlights
+          - name: What's new highlights
             href: whats-new-overview.md
             displayName: what's new, updates
           - name: API changelog

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -14,11 +14,12 @@ items:
       - name: What's new
         expanded: true
         items:
-          - name: What's new highlights
+          - name: Highlights
             href: whats-new-overview.md
+            displayName: what's new, updates
           - name: API changelog
             href: https://developer.microsoft.com/graph/changelog
-            displayName: API changes, API updates, Microsoft Graph API, REST API, what's new, REST API updates
+            displayName: API changes, API updates, Microsoft Graph API, REST API, REST API updates
       - name: Users you can reach
         items:
           - name: Overview

--- a/concepts/toc.yml
+++ b/concepts/toc.yml
@@ -86,9 +86,9 @@ items:
             href: application-proxy-configure-api.md
       - name: Accessing data at scale
         items:
-          - name: Overview of Data Connect
+          - name: Data Connect overview
             href: data-connect-concept-overview.md
-            displayName: Microsoft Graph Data Connect            
+            displayName: Microsoft Graph Data Connect, access data, bulk data           
           - name: Build your first Data Connect application
             href: data-connect-quickstart.yml
           - name: Datasets, regions, and sinks
@@ -159,7 +159,7 @@ items:
         href: compliance-concept-overview.md
       - name: Connecting external content
         items:
-          - name: Overview of Microsoft Graph connectors
+          - name: Microsoft Graph connectors overview
             href: connecting-external-content-connectors-overview.md
           - name: Connectors API
             href: connecting-external-content-connectors-api-overview.md
@@ -280,24 +280,26 @@ items:
             items:
               - name: Manage custom security attributes (preview)
                 href: custom-security-attributes-examples.md
-                displayName: directory
+                displayName: directory, identity
               - name: Use PIM to assign Azure AD roles
                 href: tutorial-assign-azureadroles.md
           - name: Identity and sign-in
             items:
               - name: Authentication methods
                 href: authenticationmethods-get-started.md
+                displayName: identity, authenticate, sign-in, sign in, signin
               - name: Identify and remediate risk
                 href: tutorial-riskdetection-api.md
           - name: Governance
             items:
               - name: Manage access to resources
                 href: tutorial-access-package-api.md
-                displayName: governance
+                displayName: governance, identity
               - name: Review access to your resources
                 items:
-                  - name: Overview of the access reviews API
+                  - name: Access reviews API overview
                     href: accessreviews-overview.md
+                    displayName: identity
                   - name: Review access to a security group
                     href: tutorial-accessreviews-securitygroup.md
                   - name: Review access for guest users
@@ -369,12 +371,11 @@ items:
         items:
           - name: Overview
             href: notifications-concept-overview.md
-            displayName: notification, notifications
+            displayName: deprecated
           - name: Get started
             items:
               - name: Get started overview
                 href: notifications-integration-e2e-overview.md
-                displayName: notification, notifications
               - name: App registration
                 href: notifications-integration-app-registration.md
               - name: Cross-device onboarding
@@ -532,7 +533,7 @@ items:
         items:
           - name: Overview
             href: auth/index.yml
-            displayName: authentication, authorization
+            displayName: authentication, authorization, authenticate, authorize
           - name: Basics
             href: auth/auth-concepts.md
           - name: Register your app
@@ -553,7 +554,7 @@ items:
         items:
           - name: Overview
             href: use-the-api.md
-            displayName: Microsoft Graph API
+            displayName: Microsoft Graph API, API, REST API
           - name: Access data and methods
             href: traverse-the-graph.md
           - name: Paging
@@ -577,9 +578,8 @@ items:
               - name: Change notifications overview
                 href: webhooks.md
                 displayName: change notifications, WebHooks, cloud printing, Universal Print, Outlook mail, Outlook calendar, Outlook contacts, Outlook contact, OneDrive, OneDrive for Business, OneDrive business, OneDrive personal, SharePoint, Security, Users, Groups
-              - name: Tutorial
+              - name: Change notifications tutorial
                 href: /learn/modules/msgraph-changenotifications-trackchanges
-                displayName: change notification
               - name: Missing change notifications
                 href: webhooks-lifecycle.md
               - name: Notifications with resource data
@@ -590,7 +590,7 @@ items:
                 href: universal-print-webhook-notifications.md
               - name: Change notifications for Microsoft Teams
                 items:
-                  - name: Microsoft Teams overview
+                  - name: Change notifications for Microsoft Teams resources
                     href: teams-change-notification-in-microsoft-teams-overview.md
                     displayName: change notifications, Teams, Microsoft Teams
                   - name: Teams and channels
@@ -673,11 +673,12 @@ items:
                 href: migrate-azure-ad-graph-deploy-test-extend.md
               - name: Migration FAQ
                 href: migrate-azure-ad-graph-faq.md
+                displayName: migrate, Azure AD Graph
               - name: Configure Azure AD Graph permissions
                 href: migrate-azure-ad-graph-configure-permissions.md
           - name: Exchange Web Services
             items:
-              - name: Migrate Exchange Web Services apps
+              - name: Migrate EWS apps
                 href: migrate-exchange-web-services-overview.md
                 displayName: Migration, Exchange Web Services, EWS, migrate
               - name: Authentication
@@ -691,7 +692,7 @@ items:
             displayName: SDK, SDKs, Microsoft Graph SDK
           - name: Install an SDK
             href: sdks/sdk-installation.md
-            displayName: install SDK, install SDKs
+            displayName: install SDK, install SDKs, installation
           - name: Create a client
             href: sdks/create-client.md
           - name: Customize a client
@@ -716,7 +717,7 @@ items:
                 href: /powershell/microsoftgraph/installation?toc=/graph/toc.json
               - name: Get started
                 href: /powershell/microsoftgraph/get-started?toc=/graph/toc.json
-              - name: Navigate the SDK
+              - name: Navigate the PowerShell SDK
                 href: /powershell/microsoftgraph/navigating?toc=/graph/toc.json
               - name: App-only authentication
                 href: /powershell/microsoftgraph/app-only?toc=/graph/toc.json
@@ -724,7 +725,7 @@ items:
         items:
           - name: Overview
             href: toolkit/overview.md
-            displayName: Microsoft Graph Toolkit
+            displayName: Microsoft Graph Toolkit, toolkit
           - name: Get started
             items:
               - name: Get started overview


### PR DESCRIPTION
PROBLEM: The displayName tag was attached to folders, but it doesn't work on empty folders. Therefore, users could not get to the Overview topics for many sections when using the search filter. 

FIXES:
- Moved displayName to first href reference in a category; usually, this was the Overview topic
- Added missing displayName elements where needed
- Updated some of the Overview topic TOC titles to be more descriptive so as to provide a better search experience. For example, in the Use the APIs section, there were several Overview topics that would come up in the same search, and they all had the same search result: Overview - Develop > Use the API. So it was impossible to tell what they were the overview for. Adding a more descriptive title fixed that issue.
- Made other tweaks where needed