### PR TITLE
Update assignedLabels Delegated-only support

### DIFF
--- a/api-reference/beta/api/group-update.md
+++ b/api-reference/beta/api/group-update.md
@@ -143,7 +143,7 @@ HTTP/1.1 204 No Content
 
 #### Request
 
-You can obtain the ID of the label you want to apply to a Microsoft 365 group by using [List label](informationprotectionpolicy-list-labels.md). Then you can update the [assignedLabels](../resources/assignedlabel.md) property of the group with the label ID.
+You can obtain the ID of the label you want to apply to a Microsoft 365 group by using [List label](informationprotectionpolicy-list-labels.md). Then you can update the [assignedLabels](../resources/assignedlabel.md) property of the group with the label ID. **Note:** Applying a sensitivity label to a Microsoft 365 group through this API is only supported with Delegated Permissions.
 
 # [HTTP](#tab/http)
 

--- a/api-reference/beta/api/group-update.md
+++ b/api-reference/beta/api/group-update.md
@@ -143,7 +143,9 @@ HTTP/1.1 204 No Content
 
 #### Request
 
-You can obtain the ID of the label you want to apply to a Microsoft 365 group by using [List label](informationprotectionpolicy-list-labels.md). Then you can update the [assignedLabels](../resources/assignedlabel.md) property of the group with the label ID. **Note:** Applying a sensitivity label to a Microsoft 365 group through this API is only supported with Delegated Permissions.
+You can obtain the ID of the label you want to apply to a Microsoft 365 group by using [List label](informationprotectionpolicy-list-labels.md). Then you can update the [assignedLabels](../resources/assignedlabel.md) property of the group with the label ID. 
+
+>**Note:** Only apps that use delegated permissions can use this API to apply a sensitivity label to a Microsoft 365 group.
 
 # [HTTP](#tab/http)
 

--- a/api-reference/beta/api/group-update.md
+++ b/api-reference/beta/api/group-update.md
@@ -145,7 +145,7 @@ HTTP/1.1 204 No Content
 
 You can obtain the ID of the label you want to apply to a Microsoft 365 group by using [List label](informationprotectionpolicy-list-labels.md). Then you can update the [assignedLabels](../resources/assignedlabel.md) property of the group with the label ID. 
 
->**Note:** Only apps that use delegated permissions can use this API to apply a sensitivity label to a Microsoft 365 group.
+>**Note:** Use of this API to apply sensitivity labels to Microsoft 365 groups is only supported for delegated permission scenarios.
 
 # [HTTP](#tab/http)
 


### PR DESCRIPTION
Adding a note to clearly document that the update of an M365 Group's assignedLabels property is only supported through Delegated Permission usage.