### PR TITLE
Remove apostrophe workaround as it is no longer needed

### DIFF
--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -86,14 +86,6 @@ When any limit is exceeded, attempts to create a subscription will result in an 
 
 ### Outlook resource limitations
 
-When subscribing to Outlook resources such as **messages**, **events** or **contacts**, if you choose to use the **userPrincipalName** (UPN) in the resource path, the subscription request might fail if the UPN contains an apostrophe. Consider using user IDs instead of UPNs to avoid running into this problem. For example, instead of using resource path:
-
-`/users/sh.o'neal@contoso.com/messages`
-
-Use:
-
-`/users/{guid-user-id}/messages`
-
 A maximum of 1000 active subscriptions per mailbox for all applications is allowed.
 
 ### Teams resource limitations


### PR DESCRIPTION
Webhooks documentation includes a workaround regarding notification subscriptions to Outlook resources when using an email with an apostrophe (originally added due to #5755). This workaround is no longer necessary as I have fixed the underlying problem; so I'm removing it. 