### PR TITLE
Updated profilephoto-update.md for size dimensions

### DIFF
--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -11,9 +11,9 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Update the photo for the signed-in **user**, or the specified **group** or **contact**. Due to the current limit of 4MB on the total size of each REST request, the size of the photo you can add is also limited to 4MB.
+Update the photo for the signed-in **user**, or the specified **group** or **contact**.
 
-The following are the supported dimensions for HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
+Due to the current limit of 4MB on the total size of each REST request, the size of the photo you can add is also limited to 4MB. The following are the supported dimensions for HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
 
 You can use either PATCH or PUT for this operation in version 1.0.
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 Update the photo for the signed-in **user**, or the specified **group** or **contact**. Since there is currently a limit of 4MB on the total size of each REST request, this limits the size of the photo you can add to under 4MB.
 
-The following are the supported sizes of HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
+The following are the supported dimensions for HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
 
 You can use either PATCH or PUT for this operation in version 1.0.
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -11,7 +11,7 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Update the photo for the signed-in **user**, or the specified **group** or **contact**. Since there is currently a limit of 4MB on the total size of each REST request, this limits the size of the photo you can add to under 4MB.
+Update the photo for the signed-in **user**, or the specified **group** or **contact**. Due to the current limit of 4MB on the total size of each REST request, the size of the photo you can add is also limited to 4MB.
 
 The following are the supported dimensions for HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -11,9 +11,9 @@ doc_type: apiPageType
 
 Namespace: microsoft.graph
 
-Update the photo for the signed-in **user**, or the specified **group** or **contact**. Since there
-is currently a limit of 4MB on the total size of each REST request, this limits the size of the photo
-you can add to under 4MB. When updating, be mindful that the supported sizes of HD photos on Exchange Online are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
+Update the photo for the signed-in **user**, or the specified **group** or **contact**. Since there is currently a limit of 4MB on the total size of each REST request, this limits the size of the photo you can add to under 4MB.
+
+The following are the supported sizes of HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
 
 You can use either PATCH or PUT for this operation in version 1.0.
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 Update the photo for the signed-in **user**, or the specified **group** or **contact**. Since there
 is currently a limit of 4MB on the total size of each REST request, this limits the size of the photo
-you can add to under 4MB.
+you can add to under 4MB. When updating, be mindful that the supported sizes of HD photos on Exchange Online are as follows: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
 
 You can use either PATCH or PUT for this operation in version 1.0.
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -13,11 +13,11 @@ Namespace: microsoft.graph
 
 Update the photo for the signed-in **user**, or the specified **group** or **contact**.
 
-Due to the current limit of 4MB on the total size of each REST request, the size of the photo you can add is also limited to 4MB. The following are the supported dimensions for HD photos on Exchange Online: '48x48', '64x64', '96x96', '120x120', '240x240', '360x360','432x432', '504x504', and '648x648'.
+Due to the current limit of 4 MB on the total size of each REST request, the size of the photo you can add is also limited to 4 MB. The following are the supported dimensions for HD photos on Exchange Online: `48x48`, `64x64`, `96x96`, `120x120`, `240x240`, `360x360`, `432x432`, `504x504`, and `648x648`.
 
 You can use either PATCH or PUT for this operation in version 1.0.
 
-> **Note** This operation in version 1.0 supports only a user's work or school mailboxes and not personal mailboxes.
+> **Note:** This operation supports only a user's work or school mailboxes and not personal mailboxes.
 
 ## Permissions
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
@@ -84,7 +84,7 @@ In the request body, include the binary data of the photo in the request body.
 If successful, this method returns a `200 OK` response code.
 ## Example
 ### Request
-Here is an example of the request.
+The following is an example of a request.
 
 # [HTTP](#tab/http)
 <!-- {


### PR DESCRIPTION
Users are citing errors while updating photos while adhering to the size limit however they are not honoring the dimensions that are supported and called out in the photos endpoint description. its worth calling out here, same language used in also placed here as well for completeness.