### PR TITLE
fix for odataType in educationClass-Post-Assignments

### DIFF
--- a/api-reference/beta/api/educationclass-post-assignments.md
+++ b/api-reference/beta/api/educationclass-post-assignments.md
@@ -65,11 +65,11 @@ Content-type: application/json
         "content": "Read chapter 4"
     },
     "grading": {
-        "@odata.type": "#microsoft.graph.educationAssignmentPointsGradeType",
+        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType",
         "maxPoints": 50
     },
     "assignTo": {
-        "@odata.type": "#microsoft.graph.educationAssignmentClassRecipient"
+        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentClassRecipient"
     },
     "status": "draft",
     "allowStudentsToAddResourcesToSubmission": true

--- a/api-reference/beta/api/educationclass-post-assignments.md
+++ b/api-reference/beta/api/educationclass-post-assignments.md
@@ -65,11 +65,11 @@ Content-type: application/json
         "content": "Read chapter 4"
     },
     "grading": {
-        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType",
+        "@odata.type": "#microsoft.graph.educationAssignmentGradeType",
         "maxPoints": 50
     },
     "assignTo": {
-        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentClassRecipient"
+        "@odata.type": "#microsoft.graph.educationAssignmentGradeType"
     },
     "status": "draft",
     "allowStudentsToAddResourcesToSubmission": true

--- a/api-reference/v1.0/api/educationclass-post-assignment.md
+++ b/api-reference/v1.0/api/educationclass-post-assignment.md
@@ -62,11 +62,11 @@ Content-type: application/json
         "content": "Read chapter 4"
     },
     "grading": {
-        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType",
+        "@odata.type": "#microsoft.graph.educationAssignmentGradeType",
         "maxPoints": 50
     },
     "assignTo": {
-        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType"
+        "@odata.type": "#microsoft.graph.educationAssignmentGradeType"
     },
     "status": "draft",
     "allowStudentsToAddResourcesToSubmission": true

--- a/api-reference/v1.0/api/educationclass-post-assignment.md
+++ b/api-reference/v1.0/api/educationclass-post-assignment.md
@@ -62,11 +62,11 @@ Content-type: application/json
         "content": "Read chapter 4"
     },
     "grading": {
-        "@odata.type": "#microsoft.graph.educationAssignmentPointsGradeType",
+        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType",
         "maxPoints": 50
     },
     "assignTo": {
-        "@odata.type": "#microsoft.graph.educationAssignmentClassRecipient"
+        "@odata.type": "#microsoft.education.assignments.api.educationAssignmentPointsGradeType"
     },
     "status": "draft",
     "allowStudentsToAddResourcesToSubmission": true


### PR DESCRIPTION
The odata type value is wrong in  educationClass-Post-Assignments for both graph beta and v1.0. this change is to fix that value.
This is the work item(146426) https://1edu.visualstudio.com/Homeroom/_workitems/edit/146426 

the current version of this doc is : https://docs.microsoft.com/en-us/graph/api/educationclass-post-assignments?view=graph-rest-beta&tabs=http 