### PR TITLE
Fix broken links to API pages and overview

### DIFF
--- a/concepts/teams-licenses.md
+++ b/concepts/teams-licenses.md
@@ -12,7 +12,7 @@ This article describes the licensing and payment requirements for the Microsoft 
 
 Some APIs provide the option to choose a licensing and payment model via the `model` query parameter; others only support one model or do not support a licensing and payment model. The following APIs have consumption charges:
 
-* [Export Teams content](/microsoftteams/export-teams-content)
+* [Export Teams content](https://docs.microsoft.com/microsoftteams/export-teams-content)
 * [Create subscription](/graph/api/subscription-post-subscriptions)
 * [Update chat message](/graph/api/chatmessage-update)
 * [Get channel message](/graph/api/chatmessage-get)

--- a/concepts/teams-licenses.md
+++ b/concepts/teams-licenses.md
@@ -8,7 +8,7 @@ ms.prod: "microsoft-teams"
 
 # Licensing and payment requirements for the Microsoft Teams API
 
-This article describes the licensing and payment requirements for the Microsoft Teams API in Microsoft Graph.
+This article describes the licensing and payment requirements for the Microsoft Teams APIs in Microsoft Graph.
 
 Some APIs provide the option to choose a licensing and payment model via the `model` query parameter; others only support one model or do not support a licensing and payment model. The following APIs have consumption charges:
 

--- a/concepts/teams-licenses.md
+++ b/concepts/teams-licenses.md
@@ -12,9 +12,9 @@ This article describes the licensing and payment requirements for the Microsoft 
 
 Some APIs provide the option to choose a licensing and payment model via the `model` query parameter; others only support one model or do not support a licensing and payment model. The following APIs have consumption charges:
 
-* [Export Teams content](/graph/api/export-teams-content.md)
-* [Create subscription](/graph/api/subscription-post-subscriptions.md)
-* [Update chat message](/graph/api/chatmessage-update.md)
+* [Export Teams content](/microsoftteams/export-teams-content)
+* [Create subscription](/graph/api/subscription-post-subscriptions)
+* [Update chat message](/graph/api/chatmessage-update)
 * [Get channel message](/graph/api/chatmessage-get)
 * [Get message in chat](/graph/api/chatmessage-get)
 

--- a/concepts/teams-licenses.md
+++ b/concepts/teams-licenses.md
@@ -12,7 +12,7 @@ This article describes the licensing and payment requirements for the Microsoft 
 
 Some APIs provide the option to choose a licensing and payment model via the `model` query parameter; others only support one model or do not support a licensing and payment model. The following APIs have consumption charges:
 
-* [Export Teams content](https://docs.microsoft.com/microsoftteams/export-teams-content)
+* [Export Teams content](/microsoftteams/export-teams-content)
 * [Create subscription](/graph/api/subscription-post-subscriptions)
 * [Update chat message](/graph/api/chatmessage-update)
 * [Get channel message](/graph/api/chatmessage-get)


### PR DESCRIPTION
Links incorrectly pointing to Markdown files as well as incorrect location for Export Teams content page.