### PR TITLE
PHP SDK 2.0.0-RC5 release

### DIFF
--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -103,16 +103,16 @@ Hide self-service password reset (SSPR) links in the [login page text visibility
 - Get the details of [pinning](/graph/api/resources/messagePinnedEventMessageDetail?view=graph-rest-beta&preserve-view=true) or [unpinning](/graph/api/resources/messageUnpinnedEventMessageDetail?view=graph-rest-beta&preserve-view=true) a [chatMessage](/graph/api/resources/chatmessage?view=graph-rest-beta&preserve-view=true) in a [chat](/graph/api/resources/chat?view=graph-rest-beta&preserve-view=true) or [channel](/graph/api/resources/channel?view=graph-rest-beta&preserve-view=true). 
 - As scenarios supported to export Teams content, you can [list](/graph/api/teamwork-list-deletedteams?view=graph-rest-beta&preserve-view=true) teams that have been deleted, and [get](/graph/api/deletedteam-getallmessages?view=graph-rest-beta&preserve-view=true) 1:1 chats, group chats, meeting chats, and channel messages of a [deleted team](/graph/api/resources/deletedTeam?view=graph-rest-beta&preserve-view=true). For more information, see [Export content with the Microsoft Teams export APIs](/microsoftteams/export-teams-content).
 
-### Use SDKs
+### SDKs
 Try the new [Microsoft Graph PHP SDK 2.0.0-RC5](https://devblogs.microsoft.com/microsoft365dev/microsoft-graph-php-sdk-2-0-0-rc5-is-now-available/) and take advantage of the following improvements:
 - A new authentication provider that automatically refreshes access tokens.
 - A built-in retry handler that understands response status codes.
 - A fluent request building pattern to improve efficiency and discoverability.
 
-To get started, please visit:
+To get started, see:
 - [README](https://aka.ms/graph/sdk/php/preview/readme)
-- [Upgrade Guide](https://aka.ms/graph/sdk/php/preview/upgrade)
-- [Code Examples](https://aka.ms/graph/sdk/php/preview/examples)
+- [Upgrade guide](https://aka.ms/graph/sdk/php/preview/upgrade)
+- [Code examples](https://aka.ms/graph/sdk/php/preview/examples)
 
 ## Want to stay in the loop?
 

--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -104,7 +104,7 @@ Hide self-service password reset (SSPR) links in the [login page text visibility
 - As scenarios supported to export Teams content, you can [list](/graph/api/teamwork-list-deletedteams?view=graph-rest-beta&preserve-view=true) teams that have been deleted, and [get](/graph/api/deletedteam-getallmessages?view=graph-rest-beta&preserve-view=true) 1:1 chats, group chats, meeting chats, and channel messages of a [deleted team](/graph/api/resources/deletedTeam?view=graph-rest-beta&preserve-view=true). For more information, see [Export content with the Microsoft Teams export APIs](/microsoftteams/export-teams-content).
 
 ### Use SDKs
-Try the new Microsoft Graph PHP SDK 2.0.0-RC5 and take advantage of the following improvements:
+Try the new [Microsoft Graph PHP SDK 2.0.0-RC5](https://devblogs.microsoft.com/microsoft365dev/microsoft-graph-php-sdk-2-0-0-rc5-is-now-available/) and take advantage of the following improvements:
 - A new authentication provider that automatically refreshes access tokens.
 - A built-in retry handler that understands response status codes.
 - A fluent request building pattern to improve efficiency and discoverability.

--- a/concepts/whats-new-overview.md
+++ b/concepts/whats-new-overview.md
@@ -103,6 +103,16 @@ Hide self-service password reset (SSPR) links in the [login page text visibility
 - Get the details of [pinning](/graph/api/resources/messagePinnedEventMessageDetail?view=graph-rest-beta&preserve-view=true) or [unpinning](/graph/api/resources/messageUnpinnedEventMessageDetail?view=graph-rest-beta&preserve-view=true) a [chatMessage](/graph/api/resources/chatmessage?view=graph-rest-beta&preserve-view=true) in a [chat](/graph/api/resources/chat?view=graph-rest-beta&preserve-view=true) or [channel](/graph/api/resources/channel?view=graph-rest-beta&preserve-view=true). 
 - As scenarios supported to export Teams content, you can [list](/graph/api/teamwork-list-deletedteams?view=graph-rest-beta&preserve-view=true) teams that have been deleted, and [get](/graph/api/deletedteam-getallmessages?view=graph-rest-beta&preserve-view=true) 1:1 chats, group chats, meeting chats, and channel messages of a [deleted team](/graph/api/resources/deletedTeam?view=graph-rest-beta&preserve-view=true). For more information, see [Export content with the Microsoft Teams export APIs](/microsoftteams/export-teams-content).
 
+### Use SDKs
+Try the new Microsoft Graph PHP SDK 2.0.0-RC5 and take advantage of the following improvements:
+- A new authentication provider that automatically refreshes access tokens.
+- A built-in retry handler that understands response status codes.
+- A fluent request building pattern to improve efficiency and discoverability.
+
+To get started, please visit:
+- [README](https://aka.ms/graph/sdk/php/preview/readme)
+- [Upgrade Guide](https://aka.ms/graph/sdk/php/preview/upgrade)
+- [Code Examples](https://aka.ms/graph/sdk/php/preview/examples)
 
 ## Want to stay in the loop?
 


### PR DESCRIPTION
Adding information to the What's new topic related to the recent PHP SDK release. 

Blog post here: https://devblogs.microsoft.com/microsoft365dev/microsoft-graph-php-sdk-2-0-0-rc5-is-now-available/