### PR TITLE
Fix display template docs gap

### DIFF
--- a/api-reference/beta/resources/externalconnectors-displaytemplate.md
+++ b/api-reference/beta/resources/externalconnectors-displaytemplate.md
@@ -18,9 +18,9 @@ Defines the appearance of the content and the conditions that dictate when the t
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|id|String|The text identifier for the display template; for example, `contosoTickets`.|
+|id|String|The text identifier for the display template; for example, `contosoTickets`. Maximum 16 characters. Only alphanumeric characters allowed. |
 |layout|[microsoft.graph.Json](../resources/intune-mam-json.md)|The definition of the content's appearance, represented by an [Adaptive Card](/adaptive-cards/authoring-cards/getting-started), which is a JSON-serialized card object model.|
-|priority|Int32|Defines the priority of a display template. A display template with priority 1 is evaluated before a template with priority 4. Gaps in priority values are supported.|
+|priority|Int32|Defines the priority of a display template. A display template with priority 1 is evaluated before a template with priority 4. Gaps in priority values are supported. Must be positive value.|
 |rules|[microsoft.graph.externalConnectors.propertyRule](../resources/externalconnectors-propertyrule.md) collection|Specifies additional rules for selecting this display template based on the item schema. Optional.|
 
 ## Relationships

--- a/api-reference/beta/resources/externalconnectors-searchsettings.md
+++ b/api-reference/beta/resources/externalconnectors-searchsettings.md
@@ -18,7 +18,7 @@ Collects all configurable settings related to search over connector content.
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|searchResultTemplates|[microsoft.graph.externalConnectors.displayTemplate](../resources/externalconnectors-displaytemplate.md) collection|Enables the developer to define the appearance of the content and configure conditions that dictate when the template should be displayed.|
+|searchResultTemplates|[microsoft.graph.externalConnectors.displayTemplate](../resources/externalconnectors-displaytemplate.md) collection|Enables the developer to define the appearance of the content and configure conditions that dictate when the template should be displayed. Maximum of 2 search result templates per connection.|
 
 ## Relationships
 None.


### PR DESCRIPTION
The feature was introduced in beta in Sep 2021, and the validation logic has been evaluated in the backend service since before that (May 2021). We did not properly update the docs to inform partners of these validations.

Backend service PR: https://o365exchange.visualstudio.com/O365%20Core/_git/GraphConnectors/pullrequest/1338126?path=/sources/dev/GCS/Services/Common/Utils.Standard/CommonUtil.cs&_a=files
Changelog: https://developer.microsoft.com/en-us/graph/changelog/?filterBy=beta,Search#f7d67d61-f565-11eb-b6a8-8203ca0139f1beta

This PR will close that gap.