### PR TITLE
Fixed required permissions for mobility APIs

### DIFF
--- a/api-reference/beta/api/mobileappmanagementpolicies-post-includedgroups.md
+++ b/api-reference/beta/api/mobileappmanagementpolicies-post-includedgroups.md
@@ -20,7 +20,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|Policy.Read.All, Policy.ReadWrite.MobilityManagement|
+|Delegated (work or school account)|Policy.ReadWrite.MobilityManagement|
 |Delegated (personal Microsoft account) | Not supported.|
 |Application | Not supported.|
 

--- a/api-reference/beta/api/mobileappmanagementpolicies-update.md
+++ b/api-reference/beta/api/mobileappmanagementpolicies-update.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|Policy.Read.All, Policy.ReadWrite.MobilityManagement|
+|Delegated (work or school account)|Policy.ReadWrite.MobilityManagement|
 |Delegated (personal Microsoft account) | Not supported.|
 |Application | Not supported.|
 

--- a/api-reference/beta/api/mobiledevicemanagementpolicies-post-includedgroups.md
+++ b/api-reference/beta/api/mobiledevicemanagementpolicies-post-includedgroups.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|Policy.Read.All, Policy.ReadWrite.MobilityManagement|
+|Delegated (work or school account)|Policy.ReadWrite.MobilityManagement|
 |Delegated (personal Microsoft account) | Not supported.|
 |Application | Not supported.|
 

--- a/api-reference/beta/api/mobiledevicemanagementpolicies-update.md
+++ b/api-reference/beta/api/mobiledevicemanagementpolicies-update.md
@@ -21,7 +21,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|Policy.Read.All, Policy.ReadWrite.MobilityManagement|
+|Delegated (work or school account)|Policy.ReadWrite.MobilityManagement|
 |Delegated (personal Microsoft account) | Not supported.|
 |Application | Not supported.|
 


### PR DESCRIPTION
Some write APIs indicated that read permissions are sufficient but this is not the case