### PR TITLE
fix parameters for using a refresh token

### DIFF
--- a/concepts/auth-v2-user.md
+++ b/concepts/auth-v2-user.md
@@ -208,7 +208,6 @@ Content-Type: application/x-www-form-urlencoded
 client_id=11111111-1111-1111-1111-111111111111
 &scope=user.read%20mail.read
 &refresh_token=OAAABAAAAiL9Kn2Z27UubvWFPbm0gLWQJVzCTE9UkP3pSx1aXxUjq...
-&redirect_uri=http%3A%2F%2Flocalhost%2Fmyapp%2F
 &grant_type=refresh_token
 &client_secret=jXoM3iz...      // NOTE: Only required for web apps
 ```
@@ -217,9 +216,8 @@ client_id=11111111-1111-1111-1111-111111111111
 |---------------|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | client_id     | Required              | The application ID that the [registration portal](https://go.microsoft.com/fwlink/?linkid=2083908) assigned your app.                                                                                                                                                                                             |
 | grant_type    | Required              | Must be `refresh_token`.                                                                                                                                                                                                                                                                                          |
-| scope         | Required              | A space-separated list of permissions (scopes). The permissions that your app requests must be equivalent to or a subset of the permissions that it requested in the original authorization_code request.                                                                                                                             |
+| scope         | Optional              | A space-separated list of permissions (scopes). The permissions that your app requests must be equivalent to or a subset of the permissions that it requested in the original authorization_code request.                                                                                                                             |
 | refresh_token | Required              | The refresh_token that you acquired during the token request.                                                                                                                                                                                                                                                     |
-| redirect_uri  | Required              | The same redirect_uri value that was used to acquire the authorization_code.                                                                                                                                                                                                                                      |
 | client_secret | Required for web apps | The client secret that you created in the app registration portal for your app. Don't use the secret in a native app, because client_secrets can’t be reliably stored on devices. It's required for web apps and web APIs, which have the ability to store the client_secret securely on the server side. |
 
 ### Response


### PR DESCRIPTION
Fix #17710 

I made the parameter changes with below references:
- https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
- https://datatracker.ietf.org/doc/html/rfc6749#section-6

I confirmed I could get a access token using a refresh token without `scope` and `redirect_uri`.

Raw Http Reuqest is below (I masked some information with `xxx`) :
```
POST https://login.microsoftonline.com/47f9d27d-8362-4034-a0bd-4bf7582904e1/oauth2/v2.0/token HTTP/1.1
Content-Type: application/x-www-form-urlencoded
Host: login.microsoftonline.com
Content-Length: 1219

client_id=xxx&grant_type=refresh_token&refresh_token=xxx&client_secret=xxx
```

Raw Http Response is below:

```
HTTP/1.1 200 OK
Cache-Control: no-store, no-cache
Pragma: no-cache
Content-Type: application/json; charset=utf-8
Expires: -1
Strict-Transport-Security: max-age=31536000; includeSubDomains
X-Content-Type-Options: nosniff
P3P: CP="DSP CUR OTPi IND OTRi ONL FIN"
x-ms-request-id: 400c05c7-4819-4996-afd1-e9995ba90301
x-ms-ests-server: 2.1.13156.10 - KRC ProdSlices
X-XSS-Protection: 0
Set-Cookie: fpc=AlEdNjSoXpBOhILT8BYbqisuKkgZAQAAAJHMZNoOAAAA; expires=Mon, 15-Aug-2022 15:13:22 GMT; path=/; secure; HttpOnly; SameSite=None
Set-Cookie: x-ms-gateway-slice=estsfd; path=/; secure; httponly
Set-Cookie: stsservicecookie=estsfd; path=/; secure; httponly
Date: Sat, 16 Jul 2022 15:13:21 GMT
Content-Length: 3446

{"token_type":"Bearer","scope":"Analytics.Read Application.Read.All User.Read User.Read.All profile openid email","expires_in":1199,"ext_expires_in":1199,"access_token":"xxx","refresh_token":"xxx"}
```