### PR TITLE
Fix: remove permission as not supported.

### DIFF
--- a/api-reference/beta/api/profilephoto-update.md
+++ b/api-reference/beta/api/profilephoto-update.md
@@ -42,7 +42,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission type                        | Permissions (from least to most privileged)                            |
 |:---------------------------------------|:-----------------------------------------------------------------------|
-| Delegated (work or school account)     | TeamSettingsReadWriteAll, GroupReadWriteAll**, DirectoryReadWriteAll** |
+| Delegated (work or school account)     | TeamSettings.ReadWrite.All, Group.ReadWrite.All**, Directory.ReadWrite.All** |
 | Delegated (personal Microsoft account) | Not supported.                                                         |
 | Application                            | Not supported.                                                         |
 

--- a/api-reference/v1.0/api/profilephoto-get.md
+++ b/api-reference/v1.0/api/profilephoto-get.md
@@ -44,9 +44,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type | Permissions (from least to most privileged)                   |
 | --------------- | ------------------------------------------------------------- |
-| Delegated (work or school account)        | TeamReadBasicAll, TeamSettingsReadAll, TeamSettingsReadWriteAll |
+| Delegated (work or school account)        | Team.ReadBasic.All, TeamSettings.Read.All, TeamSettings.ReadWrite.All |
 | Delegated (personal Microsoft account)    | Not supported.                      |
-| Application                               | TeamReadBasicAll, TeamSettingsReadAll, TeamSettingsReadWriteAll |
+| Application                               | Team.ReadBasic.All, TeamSettings.Read.All, TeamSettings.ReadWrite.All |
 
 ### To retrieve the profile photo of a user
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -43,7 +43,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 | Permission Type | Permissions (from least to most privileged)  |
 | --------------- | -------------------------------------------- |
-| Delegated (work or school account)        | TeamSettingsReadWriteAll |
+| Delegated (work or school account)        | TeamSettings.ReadWrite.All |
 | Delegated (personal Microsoft account)    | Not supported.     |
 | Application                               | Not supported. |
 

--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -45,7 +45,7 @@ One of the following permissions is required to call this API. To learn more, in
 | --------------- | -------------------------------------------- |
 | Delegated (work or school account)        | TeamSettingsReadWriteAll |
 | Delegated (personal Microsoft account)    | Not supported.     |
-| Application                               | TeamSettingsReadWriteAll |
+| Application                               | Not supported. |
 
 ### To update the profile photo of the signed-in user
 


### PR DESCRIPTION
Application context is not supported for updating a team photo. It got added by mistake. 