### PR TITLE
EM: suppress generation of example payloads in v1.0 which have derived types 

### DIFF
--- a/api-reference/v1.0/api/entitlementmanagement-post-assignmentpolicies.md
+++ b/api-reference/v1.0/api/entitlementmanagement-post-assignmentpolicies.md
@@ -164,9 +164,8 @@ The following example shows a more complex policy with two stages of approval an
 #### Request
 
 
-# [HTTP](#tab/http)
 <!-- {
-  "blockType": "request",
+  "blockType": "ignored",
   "name": "create_accesspackageassignmentpolicy_2"
 }
 -->
@@ -279,33 +278,6 @@ Content-Type: application/json
     }
 }
 ```
-
-# [C#](#tab/csharp)
-[!INCLUDE [sample-code](../includes/snippets/csharp/create-accesspackageassignmentpolicy-2-csharp-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/create-accesspackageassignmentpolicy-2-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Java](#tab/java)
-[!INCLUDE [sample-code](../includes/snippets/java/create-accesspackageassignmentpolicy-2-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/create-accesspackageassignmentpolicy-2-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [PowerShell](#tab/powershell)
-[!INCLUDE [sample-code](../includes/snippets/powershell/create-accesspackageassignmentpolicy-2-powershell-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [PHP](#tab/php)
-[!INCLUDE [sample-code](../includes/snippets/php/create-accesspackageassignmentpolicy-2-php-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
----
-
 
 #### Response
 

--- a/api-reference/v1.0/api/entitlementmanagement-post-connectedorganizations.md
+++ b/api-reference/v1.0/api/entitlementmanagement-post-connectedorganizations.md
@@ -62,10 +62,8 @@ If successful, this method returns a `201 Created` response code and a new [conn
 
 ### Request
 
-
-# [HTTP](#tab/http)
 <!-- {
-  "blockType": "request",
+  "blockType": "ignored",
   "name": "create_connectedorganization_from_connectedorganizations"
 }
 -->
@@ -86,33 +84,6 @@ Content-Type: application/json
   "state":"proposed"
 }
 ```
-
-# [C#](#tab/csharp)
-[!INCLUDE [sample-code](../includes/snippets/csharp/create-connectedorganization-from-connectedorganizations-csharp-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/create-connectedorganization-from-connectedorganizations-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Java](#tab/java)
-[!INCLUDE [sample-code](../includes/snippets/java/create-connectedorganization-from-connectedorganizations-java-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [Go](#tab/go)
-[!INCLUDE [sample-code](../includes/snippets/go/create-connectedorganization-from-connectedorganizations-go-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [PowerShell](#tab/powershell)
-[!INCLUDE [sample-code](../includes/snippets/powershell/create-connectedorganization-from-connectedorganizations-powershell-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
-# [PHP](#tab/php)
-[!INCLUDE [sample-code](../includes/snippets/php/create-connectedorganization-from-connectedorganizations-php-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
----
-
 
 ### Response
 >**Note:** The response object shown here might be shortened for readability.


### PR DESCRIPTION
There is currently an issue with the Graph SDK client, seen with PSh but probably affecting others, in generating payloads in which there is a derived type. These are easy to spot as there is usually a mention of @odata.type within the payload.  See email thread of Feb 15 2022 with Darrel Miller "RE: named location, Graph case sensitive and generated PSh fragments".  EM uses derived types in policy and connected organization, and the second example in the v1.0 create of an assignment policy illustrates this in the fallback approver selection. Unfortunately this example does not work as shown,  New-MgEntitlementManagementAssignmentPolicy in 1.10.0 with
```
 FallbackPrimaryApprovers = @(
                     @{
                         "@odata.type" = "#microsoft.graph.singleUser"
                         UserId = "3b5d4c83-0517-4f44-9d6d-ff9624f28aa3"
```
does not convert from PSh case to OData case and sends .  

```
"fallbackPrimaryApprovers": [
          {
            "UserId": "3b5d4c83-0517-4f44-9d6d-ff9624f28aa3",
```
which results in invalid model error.

It would be possible to make a change to the generated example PSh snippet itself to make it legal, but then that PSh might get overwritten the next time the article is edited.  So for now suppressing the generation of examples where the v1.0 payload has @odata.type for now until this can be resolved. 