### PR TITLE
Fix changelog sync

### DIFF
--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -5530,7 +5530,7 @@
       "Id": "81CC1882-7054-4CCF-971B-17E05E1AB312",
       "Cloud": "prd",
       "Version": "beta",
-      "CreatedDateTime": "2022-08-02T15:04:69.427Z",
+      "CreatedDateTime": "2022-08-02T15:04:59.427Z",
       "WorkloadArea": "Teamwork",
       "SubArea": ""
     }


### PR DESCRIPTION
Fixes an issue with the `Microsoft.Teams.Core.json` where the seconds value has more that 60 seconds in it. 