### PR TITLE
correct completedDateTime in filterbycurrentuser

### DIFF
--- a/api-reference/v1.0/api/accesspackageassignmentrequest-filterbycurrentuser.md
+++ b/api-reference/v1.0/api/accesspackageassignmentrequest-filterbycurrentuser.md
@@ -118,7 +118,7 @@ Content-Type: application/json
       "state": "delivered",
       "status": "Delivered",
       "createdDateTime": "2021-01-19T20:02:23.907Z",
-      "completedDate": "2021-01-19T20:02:40.97Z",
+      "completedDateTime": "2021-01-19T20:02:40.97Z",
       "schedule": {
         "@odata.type": "microsoft.graph.entitlementManagementSchedule"
       }

--- a/api-reference/v1.0/api/entitlementmanagement-list-assignmentrequests.md
+++ b/api-reference/v1.0/api/entitlementmanagement-list-assignmentrequests.md
@@ -34,12 +34,13 @@ GET /identityGovernance/entitlementManagement/assignmentRequests
 
 ## Query parameters
 
-This method supports the `$select`, `$expand` and `$filter` OData query parameters to help customize the response.
+This method supports the `$select`, `$expand` and `$filter` OData query parameters to help customize the response.  Not all attributes of an [accessPackageAssignmentRequest](../resources/accesspackageassignmentrequest.md) are supported for filtering.
 
 If the user or application only has permissions within a specific catalog or catalogs, you must include in the query a filter which specifies an access package, such as `$expand=accessPackage&$filter=accessPackage/id eq '9bbe5f7d-f1e7-4eb1-a586-38cdf6f8b1ea'`.
 
 ### Example scenarios for using query parameters
 
+- To retrieve requests created after a specific date, include `$filter=createdDateTime gt 2022-04-01T00:00:01Z` in the query.
 - To retrieve the access package of each request, include `$expand=accessPackage` in the query.
 - To retrieve the resulting assignment, include `$expand=assignment` in the query.
 - To obtain more details on the requestor, include `$expand=requestor` in the query.

--- a/api-reference/v1.0/resources/accesspackageassignmentrequest.md
+++ b/api-reference/v1.0/resources/accesspackageassignmentrequest.md
@@ -28,11 +28,11 @@ In [Azure AD Entitlement Management](entitlementmanagement-overview.md), an acce
 |Property|Type|Description|
 |:---|:---|:---|
 |completedDateTime|DateTimeOffset|The date of the end of processing, either successful or failure, of a request. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
-|createdDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only.|
+|createdDateTime|DateTimeOffset|The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`. Read-only. Supports `$filter`.|
 |id|String|Read-only.|
 |requestType|accessPackageRequestType|The type of the request. The possible values are: `notSpecified`, `userAdd`, `userUpdate`, `userRemove`, `adminAdd`, `adminUpdate`, `adminRemove`, `systemAdd`, `systemUpdate`, `systemRemove`, `onBehalfAdd`, `unknownFutureValue`. A request from the user themselves would have requestType of `UserAdd` or `UserRemove`. This property cannot be changed once set.|
 |schedule|[entitlementManagementSchedule](../resources/entitlementmanagementschedule.md)|The range of dates that access is to be assigned to the requestor. This property cannot be changed once set.|
-|state|accessPackageRequestState|The state of the request. The possible values are: `submitted`, `pendingApproval`, `delivering`, `delivered`, `deliveryFailed`, `denied`, `scheduled`, `canceled`, `partiallyDelivered`, `unknownFutureValue`. Read-only.|
+|state|accessPackageRequestState|The state of the request. The possible values are: `submitted`, `pendingApproval`, `delivering`, `delivered`, `deliveryFailed`, `denied`, `scheduled`, `canceled`, `partiallyDelivered`, `unknownFutureValue`. Read-only. Supports `$filter` (`eq`). |
 |status|String|More information on the request processing status. Read-only.|
 
 ## Relationships


### PR DESCRIPTION
In Graph v1.0, filterByCurrentUser() returns completedDateTime rather than completedDate, updating the example response.
Add an example of using a date filter in the list article. Related to 18012.


https://github.com/microsoftgraph/microsoft-graph-docs/issues/18012