### PR TITLE
Adding description about `$filter` support

### DIFF
--- a/api-reference/v1.0/api/alert-list.md
+++ b/api-reference/v1.0/api/alert-list.md
@@ -58,9 +58,9 @@ The following table lists the `$filter` keywords by each vendor name. Even thoug
 | Microsoft Defender for Endpoint | Microsoft Defender ATP |
 | Office 365 | Not currently supported. |
 
-To return an alternative property set, use the OData `$select` query parameter to specify the set of **alert** properties that you want.  For example, to return the **assignedTo**, **category**, and **severity** properties, add the following to your query: `$select=assignedTo,category,severity`.
+> **Note:** Some providers might not support `$filter` keywords.
 
-> **Note:** Some providers may not support `$filter` keywords.
+To return an alternative property set, use the OData `$select` query parameter to specify the set of **alert** properties that you want  For example, to return the **assignedTo**, **category**, and **severity** properties, add the following to your query: `$select=assignedTo,category,severity`.
 
 > **Note:** The `$top` OData query parameter has a limit of 1000 alerts. We recommend that you include only `$top` and not `$skip` in your first GET query. You can use `@odata.nextLink` for pagination. If you need to use `$skip`, it has a limit of 500 alerts. For example, `/security/alerts?$top=10&$skip=500` will return a `200 OK` response code, but `/security/alerts?$top=10&$skip=501` will return a `400 Bad Request` response code. For more information, see [Microsoft Graph Security API error responses](../resources/security-error-codes.md).
 

--- a/api-reference/v1.0/api/alert-list.md
+++ b/api-reference/v1.0/api/alert-list.md
@@ -60,6 +60,8 @@ The following table lists the `$filter` keywords by each vendor name. Even thoug
 
 To return an alternative property set, use the OData `$select` query parameter to specify the set of **alert** properties that you want.  For example, to return the **assignedTo**, **category**, and **severity** properties, add the following to your query: `$select=assignedTo,category,severity`.
 
+> **Note:** Some providers may not support `$filter` keywords.
+
 > **Note:** The `$top` OData query parameter has a limit of 1000 alerts. We recommend that you include only `$top` and not `$skip` in your first GET query. You can use `@odata.nextLink` for pagination. If you need to use `$skip`, it has a limit of 500 alerts. For example, `/security/alerts?$top=10&$skip=500` will return a `200 OK` response code, but `/security/alerts?$top=10&$skip=501` will return a `400 Bad Request` response code. For more information, see [Microsoft Graph Security API error responses](../resources/security-error-codes.md).
 
 ## Request headers


### PR DESCRIPTION
We confirmed that O365 SCC alert does not support $filter by alert status from past issue [here](https://github.com/microsoftgraph/security-api-solutions/issues/56). It looks like they don't support $filter as of now but there are no descriptions about this restriction. Thus I propose a description of `$filter` support for this API.

Any comments and suggestions are welcomed.