### PR TITLE
Fixed docs for channelMembershipType enum in v1.0 and beta

### DIFF
--- a/api-reference/beta/api/conversationmember-update.md
+++ b/api-reference/beta/api/conversationmember-update.md
@@ -18,7 +18,7 @@ Update the role of a [conversationMember](../resources/conversationmember.md) in
 or [channel](../resources/channel.md).
 
 > [!NOTE]
-> On channels, this operation is only supported on channels with a [channelMembershipType](../resources/enums.md#channelmembershiptype-values) of `private`. Calls with any other [channelMembershipType](../resources/enums.md#channelmembershiptype-values) will return a `400 Bad Request` response.
+> On channels, this operation is only supported on channels with a [channelMembershipType](../resources/channel.md#channelmembershiptype-values) of `private`. Calls with any other [channelMembershipType](../resources/channel.md#channelmembershiptype-values) will return a `400 Bad Request` response.
 
 ## Permissions
 

--- a/api-reference/beta/resources/channel.md
+++ b/api-reference/beta/resources/channel.md
@@ -64,10 +64,19 @@ where files are shared, and where tabs are added.
 |isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically with [Create team](../api/team-post.md). Default: `false`.|
 |email|String| The email address for sending messages to the channel. Read-only.|
 |webUrl|String|A hyperlink that will go to the channel in Microsoft Teams. This is the URL that you get when you right-click a channel in Microsoft Teams and select Get link to channel. This URL should be treated as an opaque blob, and not parsed. Read-only.|
-|membershipType|channelMembershipType|The type of the channel. Can be set during creation and can't be changed. The possible values are: `standard`, `private`, `unknownFutureValue`, `shared`. The default value is `standard`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `shared`.|
+|membershipType|[channelMembershipType](../resources/channel.md#channelmembershiptype-values)|The type of the channel. Can be set during creation and can't be changed. The possible values are: `standard`, `private`, `unknownFutureValue`, `shared`. The default value is `standard`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `shared`.|
 |createdDateTime|dateTimeOffset|Read only. Timestamp at which the channel was created.|
 |moderationSettings|[channelModerationSettings](../resources/channelmoderationsettings.md)|Settings to configure channel moderation to control who can start new posts and reply to posts in that channel.|
 |tenantId |string | The ID of the Azure Active Directory tenant. |
+
+### channelMembershipType values
+
+| Member             | Value | Description                                                                       |
+|:-------------------|:------|:----------------------------------------------------------------------------------|
+| standard           | 0     | Channel inherits the list of members of the parent team.                          |
+| private            | 1     | Channel can have members that are a subset of all the members on the parent team. |
+| unknownFutureValue | 2     | Evolvable enumeration sentinel value. Do not use.                                 |
+| shared             | 3     | Members can be directly added to the channel without adding them to the team.     |
 
 ### Instance attributes
 
@@ -113,7 +122,7 @@ The following is a JSON representation of the resource.
   "isFavoriteByDefault": true,
   "email": "string",
   "webUrl": "string",
-  "membershipType": "channelMembershipType",
+  "membershipType": "String",
   "createdDateTime": "string (timestamp)",
   "moderationSettings": { "@odata.type": "microsoft.graph.channelModerationSettings" }
 }

--- a/api-reference/beta/resources/enums.md
+++ b/api-reference/beta/resources/enums.md
@@ -2104,15 +2104,6 @@ Possible values for user account types (group membership), per Windows definitio
 |high|
 |urgent|
 
-### channelMembershipType values
-
-| Member             |
-| :----------------- |
-| standard           |
-| private            |
-| unknownFutureValue |
-| shared             |
-
 ### stagedFeatureName values
 
 | Member                    | Description                   |

--- a/api-reference/v1.0/resources/channel.md
+++ b/api-reference/v1.0/resources/channel.md
@@ -62,9 +62,18 @@ where files are shared, and where tabs are added.
 |isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically with [Create team](../api/team-post.md). Default: `false`.|
 |email|String| The email address for sending messages to the channel. Read-only.|
 |webUrl|String|A hyperlink that will go to the channel in Microsoft Teams. This is the URL that you get when you right-click a channel in Microsoft Teams and select Get link to channel. This URL should be treated as an opaque blob, and not parsed. Read-only.|
-|membershipType|[channelMembershipType](../resources/enums.md#channelmembershiptype-values)|The type of the channel. Can be set during creation and can't be changed. The possible values are: `standard`, `private`, `unknownFutureValue`, `shared`. The default value is `standard`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `shared`.|
+|membershipType|[channelMembershipType](../resources/channel.md#channelmembershiptype-values)|The type of the channel. Can be set during creation and can't be changed. The possible values are: `standard`, `private`, `unknownFutureValue`, `shared`. The default value is `standard`. Note that you must use the `Prefer: include-unknown-enum-members` request header to get the following value in this [evolvable enum](/graph/best-practices-concept#handling-future-members-in-evolvable-enumerations): `shared`.|
 |createdDateTime|dateTimeOffset|Read only. Timestamp at which the channel was created.|
 |tenantId |string | The ID of the Azure Active Directory tenant. |
+
+### channelMembershipType values
+
+| Member             | Value | Description                                                                       |
+|:-------------------|:------|:----------------------------------------------------------------------------------|
+| standard           | 0     | Channel inherits the list of members of the parent team.                          |
+| private            | 1     | Channel can have members that are a subset of all the members on the parent team. |
+| unknownFutureValue | 2     | Evolvable enumeration sentinel value. Do not use.                                 |
+| shared             | 3     | Members can be directly added to the channel without adding them to the team.     |
 
 ### Instance attributes
 
@@ -110,7 +119,7 @@ The following is a JSON representation of the resource.
   "isFavoriteByDefault": true,
   "email": "string",
   "webUrl": "string",
-  "membershipType": "channelMembershipType",
+  "membershipType": "String",
   "createdDateTime": "string (timestamp)"
 }
 ```

--- a/api-reference/v1.0/resources/enums.md
+++ b/api-reference/v1.0/resources/enums.md
@@ -1626,14 +1626,6 @@ Possible values for user account types (group membership), per Windows definitio
 | AllowOverrideWithoutJustification | 2 | User is allowed to override the block and send the message. Justification text is not required. Exclusive to `AllowOverrideWithJustification`. |
 | AllowOverrideWithJustification | 4 |  User is allowed to override the block and send the message. Justification text is required. Exclusive to `AllowOverrideWithoutJustification`.|
 
-### channelMembershipType values
-
-| Member             | Value |Description|
-| :----------------- | :---- |:-----------|
-| standard           | 0     |Channel inherits the list of members of the parent team.|
-| private            | 1     |Channel can have members that are a subset of all the members on the parent team.|
-| unknownFutureValue | 2     |      |
-| shared             | 3     |Members can be directly added to the channel without adding them to the team.|
 ### wellknownListName values
 | Member
 |:----------------------


### PR DESCRIPTION
Fixed the documentation for the channelMembershipType enum in v1.0 and beta as per our guidance. 

Updated documentation based on Angela's feedback.
