### PR TITLE
Edit Sample response to add a Content-Length header

### DIFF
--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -43,6 +43,7 @@ Whenever the throttling threshold is exceeded, Microsoft Graph responds with a r
 
 ```http
 HTTP/1.1 429 Too Many Requests
+Content-Length: 312
 Content-Type: application/json
 Retry-After: 10
 


### PR DESCRIPTION
When using Fidder's AutoResponder feature to validate the Microsoft Graph Powershell built-in retry handler, the built-in retry handler would not work without the Content-Length header