### PR TITLE
Correct URL path for swapping refresh token

### DIFF
--- a/concepts/auth-v2-user.md
+++ b/concepts/auth-v2-user.md
@@ -201,7 +201,7 @@ Access tokens are short lived, and you must refresh them after they expire to co
 ```
 // Line breaks for legibility only
 
-POST /common/oauth2/v2.0/token HTTP/1.1
+POST /{tenant}/oauth2/v2.0/token HTTP/1.1
 Host: https://login.microsoftonline.com
 Content-Type: application/x-www-form-urlencoded
 


### PR DESCRIPTION
The URL path in section 5 (swapping a refresh token for an access token) points to `common` but this results in a 400 response. Instead the tenant ID should be used as this returns the expected access token response.

This change will also bring it inline with the azure-docs, which currently contains the URL path with the tenant ID - [see here](https://github.com/MicrosoftDocs/azure-docs/blob/d3eb9b51c4576647156f9a5802fc9150daa9f4b0/articles/active-directory/develop/v2-oauth2-auth-code-flow.md?plain=1#L361)