### PR TITLE
Fix changelog sync

### DIFF
--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -5538,7 +5538,7 @@
       "Id": "5B9E91C9-BB4A-4AF5-A78B-4B1649D02527",
       "Cloud": "prd",
       "Version": "v1.0",
-      "CreatedDateTime": "2022-08-22T15:04:69.427Z",
+      "CreatedDateTime": "2022-08-22T15:04:49.427Z",
       "WorkloadArea": "Teamwork",
       "SubArea": ""
     }


### PR DESCRIPTION
This fixes the changelog json sync due to invalid datetime in `changelog/Microsoft.Teams.Core.json` file