### PR TITLE
Update filter-query-parameter.md

### DIFF
--- a/concepts/filter-query-parameter.md
+++ b/concepts/filter-query-parameter.md
@@ -155,7 +155,7 @@ These examples show how to use `$filter` to match against supported properties a
 |--------------|-----------------------------------------------------------------------------------|
 | `eq`         | `/applications?$filter=createdOnBehalfOf/deletedDateTime eq 2021-01-02T12:00:00Z` |
 | `le`         | `/applications?$filter=createdOnBehalfOf/deletedDateTime le 2021-01-02T12:00:00Z` |
-| `ge`         | `/users?$filter=manager/deletedDateTime ge 2021-01-02T12:00:00Z`                  |
+| `ge`         | `/users?$filter=manager/createdDateTime ge 2021-01-02T12:00:00Z`                  |
 
 ### For a collection of GUID types
 
@@ -171,8 +171,8 @@ These examples show how to use `$filter` to match against supported properties a
 | `eq`         | `/users?$filter=authorizationInfo/certificateUserIds/any(x:x eq '9876543210@mil')`        |
 | `startsWith` | `/users?$filter=authorizationInfo/certificateUserIds/any(x:startswith(x,'987654321'))`    |
 | `endsWith`   | `/users?$filter=proxyAddresses/any(p:endsWith(p,'OnMicrosoft.com'))`*                     |
-| `le`         | `/servicePrincipals?$filter=keyCredentials/any(k:k/endDateTime le 2021-01-02T12:00:00Z)`* |
-| `ge`         | `/servicePrincipals?$filter=keyCredentials/any(k:k/endDateTime ge 2021-01-02T12:00:00Z)`* |
+| `le`         | `/applications?$filter=keyCredentials/any(k:k/endDateTime le 2021-01-02T12:00:00Z)`*      |
+| `ge`         | `/applications?$filter=keyCredentials/any(k:k/endDateTime ge 2021-01-02T12:00:00Z)`*      |
 
 
 ## See also


### PR DESCRIPTION
Changing `servicePrincipal` query to `application` query, as `servicePrincipal` will not be supported. `application` query is currently in deployment.

Changing `deletedDateTime` to `createdDateTime` as `deletedDateTime` is only accessible from the `/directory/deletedItems` path