### PR TITLE
add optional Prefer header for customized paging for ListIssues and ListMessages

### DIFF
--- a/api-reference/beta/api/serviceannouncement-list-issues.md
+++ b/api-reference/beta/api/serviceannouncement-list-issues.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceannouncement-list-issues.md
+++ b/api-reference/beta/api/serviceannouncement-list-issues.md
@@ -42,13 +42,14 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
+|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a collection of [serviceHealthIssue](../resources/servicehealthissue.md) objects in the response body. The response is paginated and each page contains 100 objects.
+If successful, this method returns a `200 OK` response code and a collection of [serviceHealthIssue](../resources/servicehealthissue.md) objects in the response body. The response is paginated and default page size is 100.
 
 ## Example
 

--- a/api-reference/beta/api/serviceannouncement-list-issues.md
+++ b/api-reference/beta/api/serviceannouncement-list-issues.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceannouncement-list-issues.md
+++ b/api-reference/beta/api/serviceannouncement-list-issues.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x} | Set the maximum page size preference. The maximum page size cannot be greater than 1000. If not specified, default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceannouncement-list-messages.md
+++ b/api-reference/beta/api/serviceannouncement-list-messages.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceannouncement-list-messages.md
+++ b/api-reference/beta/api/serviceannouncement-list-messages.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/beta/api/serviceannouncement-list-messages.md
+++ b/api-reference/beta/api/serviceannouncement-list-messages.md
@@ -42,13 +42,14 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
+|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a collection of [serviceUpdateMessage](../resources/serviceupdatemessage.md) objects in the response body. The response is paginated and each page contains 100 objects.
+If successful, this method returns a `200 OK` response code and a collection of [serviceUpdateMessage](../resources/serviceupdatemessage.md) objects in the response body. The response is paginated and default page size is 100.
 
 ## Example
 

--- a/api-reference/beta/api/serviceannouncement-list-messages.md
+++ b/api-reference/beta/api/serviceannouncement-list-messages.md
@@ -42,7 +42,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x} | Set the maximum page size preference. The maximum page size cannot be greater than 1000. If not specified, the default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-issues.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-issues.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-issues.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-issues.md
@@ -40,13 +40,14 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
+|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a collection of [serviceHealthIssue](../resources/servicehealthissue.md) objects in the response body. The response is paginated and each page contains 100 objects.
+If successful, this method returns a `200 OK` response code and a collection of [serviceHealthIssue](../resources/servicehealthissue.md) objects in the response body. The response is paginated and default page size is 100.
 
 ## Example
 

--- a/api-reference/v1.0/api/serviceannouncement-list-issues.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-issues.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-issues.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-issues.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x} | Set the maximum page size preference. The maximum page size cannot be greater than 1000. If not specified, default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-messages.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-messages.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-messages.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-messages.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.

--- a/api-reference/v1.0/api/serviceannouncement-list-messages.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-messages.md
@@ -40,13 +40,14 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
+|Prefer:<br>odata.maxepagesize={x}|Set the max page size preference. If not specified, the response is with default page size. Default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.
 
 ## Response
 
-If successful, this method returns a `200 OK` response code and a collection of [serviceUpdateMessage](../resources/serviceupdatemessage.md) objects in the response body. The response is paginated and each page contains 100 objects.
+If successful, this method returns a `200 OK` response code and a collection of [serviceUpdateMessage](../resources/serviceupdatemessage.md) objects in the response body. The response is paginated and default page size is 100.
 
 ## Example
 

--- a/api-reference/v1.0/api/serviceannouncement-list-messages.md
+++ b/api-reference/v1.0/api/serviceannouncement-list-messages.md
@@ -40,7 +40,7 @@ This method supports the [OData query parameters](/graph/query-parameters) to he
 |Name|Description|
 |:---|:---|
 |Authorization|Bearer {token}. Required.|
-|Prefer:<br>odata.maxpagesize={x}|Set the max page size preference. The max page size cannot be greater than 1000. If not specified, the response is with default page size. Default page size is 100. Optional.|
+|Prefer:<br>odata.maxpagesize={x} | Set the maximum page size preference. The maximum page size cannot be greater than 1000. If not specified, default page size is 100. Optional.|
 
 ## Request body
 Do not supply a request body for this method.


### PR DESCRIPTION
Add optional header "Prefer:odata.maxpagesize={XXX}" to allow user to specify the server page size. It is an optional header. If not specified by user, default server page size is adopted.