### PR TITLE
[Cloud PC]Remove description about deprecate patch addomainpassword API As deprecate period is over now.

### DIFF
--- a/api-reference/beta/api/cloudpconpremisesconnection-updateaddomainpassword.md
+++ b/api-reference/beta/api/cloudpconpremisesconnection-updateaddomainpassword.md
@@ -27,8 +27,6 @@ One of the following permissions is required to call this API. To learn more, in
 
 ## HTTP request
 
-> [!CAUTION] 
-> The PATCH syntax for this action is deprecated and will stop working after June 2022. We recommend that you use POST going forward.
 
 <!-- {
   "blockType": "ignored"
@@ -36,7 +34,6 @@ One of the following permissions is required to call this API. To learn more, in
 -->
 ``` http
 POST /deviceManagement/virtualEndpoint/onPremisesConnections/{Id}/UpdateAdDomainPassword
-PATCH /deviceManagement/virtualEndpoint/onPremisesConnections/{Id}/UpdateAdDomainPassword
 ```
 
 ## Request headers


### PR DESCRIPTION
Roadmap ADO: 15290