### PR TITLE
Fix examples with inconsistent versions

### DIFF
--- a/api-reference/beta/api/attachment-createuploadsession.md
+++ b/api-reference/beta/api/attachment-createuploadsession.md
@@ -185,7 +185,7 @@ For an inline attachment, set _isInline_ property to `true` and use the _content
 }-->
 
 ```http
-POST https://graph.microsoft.com/v1.0/me/messages/AAMkAGUwNjQ4ZjIxLTQ3Y2YtNDViMi1iZjc4LTMA=/attachments/createUploadSession
+POST https://graph.microsoft.com/beta/me/messages/AAMkAGUwNjQ4ZjIxLTQ3Y2YtNDViMi1iZjc4LTMA=/attachments/createUploadSession
 Content-type: application/json
 
 {

--- a/api-reference/v1.0/api/directoryobject-checkmembergroups.md
+++ b/api-reference/v1.0/api/directoryobject-checkmembergroups.md
@@ -230,7 +230,7 @@ Content-type: application/json
   "name": "directoryobject_checkmembergroups_me"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/me/checkMemberGroups
+POST https://graph.microsoft.com/v1.0/me/checkMemberGroups
 Content-type: application/json
 
 {

--- a/api-reference/v1.0/api/drive-post-bundles.md
+++ b/api-reference/v1.0/api/drive-post-bundles.md
@@ -64,7 +64,7 @@ This bundle can be used to share a collection of files with other users without 
 <!-- { "blockType": "request", "name": "create-bundle" } -->
 
 ```http
-POST https://graph.microsoft.com/beta/drive/bundles
+POST https://graph.microsoft.com/v1.0/drive/bundles
 Content-Type: application/json
 
 {
@@ -131,7 +131,7 @@ The request to create a new photo album is similar, although inside the bundle f
 <!-- { "blockType": "request", "name": "create-album" } -->
 
 ```http
-POST https://graph.microsoft.com/beta/drive/bundles
+POST https://graph.microsoft.com/v1.0/drive/bundles
 Content-Type: application/json
 
 {

--- a/api-reference/v1.0/api/identityuserflowattributeassignment-setorder.md
+++ b/api-reference/v1.0/api/identityuserflowattributeassignment-setorder.md
@@ -68,7 +68,7 @@ If successful, this action returns a `204 No Content` response code.
 -->
 
 ``` http
-POST https://graph.microsoft.com/beta/identity/b2xUserFlows/{id}/userAttributeAssignments/setOrder
+POST https://graph.microsoft.com/v1.0/identity/b2xUserFlows/{id}/userAttributeAssignments/setOrder
 Content-Type: application/json
 
 {

--- a/api-reference/v1.0/api/participant-delete.md
+++ b/api-reference/v1.0/api/participant-delete.md
@@ -118,7 +118,7 @@ HTTP/1.1 204 No Content
   "name": "participant-invite-nonactive-participant"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/communications/calls/{id}/participants/invite
+POST https://graph.microsoft.com/v1.0/communications/calls/{id}/participants/invite
 Content-Type: application/json
 Content-Length: 464
 
@@ -215,7 +215,7 @@ Content-Type: application/json
   "name": "delete-participant_before-added-to-roster"
 }-->
 ```http
-DELETE https://graph.microsoft.com/beta/communications/calls/{id}/participants/{id}
+DELETE https://graph.microsoft.com/v1.0/communications/calls/{id}/participants/{id}
 ```
 
 # [C#](#tab/csharp)

--- a/api-reference/v1.0/api/presence-clearpresence.md
+++ b/api-reference/v1.0/api/presence-clearpresence.md
@@ -67,7 +67,7 @@ The following request shows the application with ID `22553876-f5ab-4529-bffb-cfe
 }-->
 
 ```msgraph-interactive
-POST https://graph.microsoft.com/beta/users/fa8bf3dc-eca7-46b7-bad1-db199b62afc3/presence/clearPresence
+POST https://graph.microsoft.com/v1.0/users/fa8bf3dc-eca7-46b7-bad1-db199b62afc3/presence/clearPresence
 Content-Type: application/json
 
 {

--- a/api-reference/v1.0/api/presence-setpresence.md
+++ b/api-reference/v1.0/api/presence-setpresence.md
@@ -90,7 +90,7 @@ The following request shows the application with ID `22553876-f5ab-4529-bffb-cfe
 }-->
 
 ```msgraph-interactive
-POST https://graph.microsoft.com/beta/users/fa8bf3dc-eca7-46b7-bad1-db199b62afc3/presence/setPresence
+POST https://graph.microsoft.com/v1.0/users/fa8bf3dc-eca7-46b7-bad1-db199b62afc3/presence/setPresence
 Content-Type: application/json
 
 {

--- a/api-reference/v1.0/api/serviceprincipal-post-owners.md
+++ b/api-reference/v1.0/api/serviceprincipal-post-owners.md
@@ -52,7 +52,7 @@ Here is an example of the request.
   "name": "create_directoryobject_from_serviceprincipal"
 }-->
 ```http
-POST https://graph.microsoft.com/beta/servicePrincipals/{id}/owners/$ref
+POST https://graph.microsoft.com/v1.0/servicePrincipals/{id}/owners/$ref
 Content-type: application/json
 
 {


### PR DESCRIPTION
This PR fixes HTTP examples with inconsistent API versions relative to the location of the example in the docs. 
