### PR TITLE
entitlement management: add missing close to HTTP block

### DIFF
--- a/api-reference/beta/api/accesspackage-post-incompatiblegroup.md
+++ b/api-reference/beta/api/accesspackage-post-incompatiblegroup.md
@@ -65,6 +65,7 @@ Content-type: application/json
 {
     "@odata.id": "https://graph.microsoft.com/beta/groups/c0a74b4d-2694-4d5d-a964-1bee4ff0aaf2"
 }
+```
 
 ### Response
 


### PR DESCRIPTION
The formatting of the examples section of https://learn.microsoft.com/en-us/graph/api/accesspackage-post-incompatiblegroup?view=graph-rest-beta wasn't right as the closing quote for a HTTP block was missing from an example.