### PR TITLE
Remove requireChangeOnNextLogin

### DIFF
--- a/api-reference/v1.0/api/authenticationmethod-resetpassword.md
+++ b/api-reference/v1.0/api/authenticationmethod-resetpassword.md
@@ -59,7 +59,6 @@ In the request body, provide a JSON object with the following parameters.
 | Parameter    | Type        | Description |
 |:-------------|:------------|:------------|
 |newPassword|String|The new password. Required for tenants with hybrid password scenarios. If omitted for a cloud-only password, the system returns a system-generated password. This is a unicode string with no other encoding. It is validated against the tenant's banned password system before acceptance, and must adhere to the tenant's cloud and/or on-premises password requirements.|
-|requireChangeOnNextSignIn|Boolean | Specifies whether the user must change their password at their next sign in.|
 
 ## Response
 


### PR DESCRIPTION
The requireChangeOnNextLogin property was accidentally pushed to v1.0 without being hidden. It only works when called by a handful of first-party applications, so should not have been exposed. The team is working on re-hiding it; this is to ensure the doc stays in step with the actual behavior.