### PR TITLE
[Calling] add InvitationParticipantInfo options for contact center fe…

### DIFF
--- a/api-reference/beta/resources/invitationparticipantinfo.md
+++ b/api-reference/beta/resources/invitationparticipantinfo.md
@@ -23,6 +23,8 @@ Represents an entity that is being invited to a group call.
 | identity                           | [identitySet](identityset.md) | The [identitySet](identityset.md) associated with this invitation.                   |
 | participantId                      | String                        | Optional. The ID of the target participant.                                          |
 | replacesCallId                     | String                        | Optional. The call which the target identity is currently a part of. For peer-to-peer case, the call will be dropped once the participant is added successfully. |
+| removeFromDefaultAudioRoutingGroup | Boolean                       | Optional. Whether to remove them from the main mixer. |
+| hidden                             | Boolean                       | Optional. Whether to hide the participant from the roster. |
 
 ## JSON representation
 
@@ -41,7 +43,9 @@ The following is a JSON representation of the resource.
   "endpointType": "String",
   "identity": {"@odata.type": "#microsoft.graph.identitySet"},
   "participantId": "String",  
-  "replacesCallId": "String"
+  "replacesCallId": "String",
+  "removeFromDefaultAudioRoutingGroup": "Boolean",
+  "hidden": "Boolean"
 }
 ```
 

--- a/api-reference/v1.0/resources/invitationparticipantinfo.md
+++ b/api-reference/v1.0/resources/invitationparticipantinfo.md
@@ -20,6 +20,8 @@ This resource is used to represent the entity that is being invited to a group c
 | identity                           | [identitySet](identityset.md) | The [identitySet](identityset.md) associated with this invitation.                   |
 | participantId                      | String                        | Optional. The ID of the target participant.                                          |
 | replacesCallId                     | String                        | Optional. The call which the target identity is currently a part of. For peer-to-peer case, the call will be dropped once the participant is added successfully. |
+| removeFromDefaultAudioRoutingGroup | Boolean                       | Optional. Whether to remove them from the main mixer. |
+| hidden                             | Boolean                       | Optional. Whether to hide the participant from the roster. |
 
 ## JSON representation
 
@@ -36,7 +38,9 @@ The following is a JSON representation of the resource.
 {
   "identity": {"@odata.type": "#microsoft.graph.identitySet"},
   "participantId": "String",  
-  "replacesCallId": "String"
+  "replacesCallId": "String",
+  "removeFromDefaultAudioRoutingGroup": "Boolean",
+  "hidden": "Boolean"
 }
 ```
 

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -6034,25 +6034,25 @@
       "ChangeList": [
         {
           "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
-          "ApiChange": "Resource",
-          "ChangedApiName": "cloud-communications",
+          "ApiChange": "Property",
+          "ChangedApiName": "removeFromDefaultAudioRoutingGroup",
           "ChangeType": "Addition",
-          "Description": "Added the **removeFromDefaultAudioRoutingGroup** boolean type.",
+          "Description": "Added the **removeFromDefaultAudioRoutingGroup** property to the [invitationParticipantInfo](https://learn.microsoft.com/en-us/graph/api/resources/invitationparticipantinfo?view=graph-rest-beta) resource.",
           "Target": "invitationparticipantinfo"
         },
         {
           "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
-          "ApiChange": "Resource",
-          "ChangedApiName": "cloud-communications",
+          "ApiChange": "Property",
+          "ChangedApiName": "hidden",
           "ChangeType": "Addition",
-          "Description": "Added the **hidden** boolean type.",
+          "Description": "Added the **hidden** property to the [invitationParticipantInfo](https://learn.microsoft.com/en-us/graph/api/resources/invitationparticipantinfo?view=graph-rest-beta) resource.",
           "Target": "invitationparticipantinfo"
         }
       ],
       "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
       "Cloud": "Prod",
       "Version": "beta",
-      "CreatedDateTime": "2022-10-26",
+      "CreatedDateTime": "2022-10-26T20:34:40.595Z",
       "WorkloadArea": "Teamwork and communications",
       "SubArea": ""
     },
@@ -6060,25 +6060,25 @@
       "ChangeList": [
         {
           "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
-          "ApiChange": "Resource",
-          "ChangedApiName": "cloud-communications",
+          "ApiChange": "Property",
+          "ChangedApiName": "removeFromDefaultAudioRoutingGroup",
           "ChangeType": "Addition",
-          "Description": "Added the **removeFromDefaultAudioRoutingGroup** boolean type.",
+          "Description": "Added the **removeFromDefaultAudioRoutingGroup** property to the [invitationParticipantInfo](https://learn.microsoft.com/en-us/graph/api/resources/invitationparticipantinfo?view=graph-rest-v1.0) resource.",
           "Target": "invitationparticipantinfo"
         },
         {
           "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
-          "ApiChange": "Resource",
-          "ChangedApiName": "cloud-communications",
+          "ApiChange": "Property",
+          "ChangedApiName": "hidden",
           "ChangeType": "Addition",
-          "Description": "Added the **hidden** boolean type.",
+          "Description": "Added the **hidden** property to the [invitationParticipantInfo](https://learn.microsoft.com/en-us/graph/api/resources/invitationparticipantinfo?view=graph-rest-v1.0) resource.",
           "Target": "invitationparticipantinfo"
         }
       ],
       "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
       "Cloud": "Prod",
       "Version": "v1.0",
-      "CreatedDateTime": "2022-10-26",
+      "CreatedDateTime": "2022-10-26T20:34:40.595Z",
       "WorkloadArea": "Teamwork and communications",
       "SubArea": ""
     }

--- a/changelog/Microsoft.Teams.Core.json
+++ b/changelog/Microsoft.Teams.Core.json
@@ -6029,6 +6029,58 @@
       "CreatedDateTime": "2022-10-20T20:34:40.595Z",
       "WorkloadArea": "Teamwork and communications",
       "SubArea": "" 
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+          "ApiChange": "Resource",
+          "ChangedApiName": "cloud-communications",
+          "ChangeType": "Addition",
+          "Description": "Added the **removeFromDefaultAudioRoutingGroup** boolean type.",
+          "Target": "invitationparticipantinfo"
+        },
+        {
+          "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+          "ApiChange": "Resource",
+          "ChangedApiName": "cloud-communications",
+          "ChangeType": "Addition",
+          "Description": "Added the **hidden** boolean type.",
+          "Target": "invitationparticipantinfo"
+        }
+      ],
+      "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2022-10-26",
+      "WorkloadArea": "Teamwork and communications",
+      "SubArea": ""
+    },
+    {
+      "ChangeList": [
+        {
+          "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+          "ApiChange": "Resource",
+          "ChangedApiName": "cloud-communications",
+          "ChangeType": "Addition",
+          "Description": "Added the **removeFromDefaultAudioRoutingGroup** boolean type.",
+          "Target": "invitationparticipantinfo"
+        },
+        {
+          "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+          "ApiChange": "Resource",
+          "ChangedApiName": "cloud-communications",
+          "ChangeType": "Addition",
+          "Description": "Added the **hidden** boolean type.",
+          "Target": "invitationparticipantinfo"
+        }
+      ],
+      "Id": "331f93e1-f1a4-4868-bf74-ee03d0e44599",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2022-10-26",
+      "WorkloadArea": "Teamwork and communications",
+      "SubArea": ""
     }
   ]
 }


### PR DESCRIPTION
* If InvitationParticipantInfo.RemoveFromDefaultAudioRoutingGroup is specified as true in the target of participant invitation request, the target user will be put out of default audio mixer once it joins the group call, which means it cannot talk to anyone in the group call.

* If InvitationParticipantInfo.Hidden is specified as true in the target of participant invitation request, the target user will be hidden to all other participants once it joins the group call.