### PR TITLE
Correction on update the profile photo of a group permission

### DIFF
--- a/api-reference/v1.0/api/profilephoto-update.md
+++ b/api-reference/v1.0/api/profilephoto-update.md
@@ -37,7 +37,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:--------------------|:---------------------------------------------------------|
 |Delegated (work or school account)      |   Group.ReadWrite.All           |
 |Delegated (personal Microsoft account)      |   Not supported.            |
-|Application      |    Group.ReadWrite.All           |
+|Application      |    Not supported.           |
 
 ### To update the profile photo of a team
 


### PR DESCRIPTION
Application permissions are not supported for updating the profile photo of a group. It's mentioned in the known issue-https://learn.microsoft.com/en-us/graph/known-issues#some-group-apis-dont-support-delegated-or-app-only-permissions

<img width="406" alt="image" src="https://user-images.githubusercontent.com/110056762/195584877-a50d83f9-da4c-478e-9e53-48f9701270e1.png">
