### PR TITLE
Take presence out of beta.

### DIFF
--- a/api-reference/beta/resources/subscription.md
+++ b/api-reference/beta/resources/subscription.md
@@ -33,7 +33,7 @@ A subscription allows a client app to receive change notifications about changes
 - A [list][] under a SharePoint [site][].
 - A [message][], [event][], or [contact][] in Outlook.
 - An [online meeting][] in Microsoft Teams.*
-- The [presence][] of a user in Microsoft Teams.*
+- The [presence][] of a user in Microsoft Teams.
 - A [team](./team.md) in Microsoft Teams.
 - A [printer][] (when a print job for the printer gets to JobFetchable state - ready to be fetched for printing) and a [printTaskDefinition][] in Universal Print. For more information, see [Subscribe to change notifications from cloud printing APIs](/graph/universal-print-webhook-notifications).
 - A [todoTask][] of a user in Microsoft To Do.


### PR DESCRIPTION
The presence endpoint is available in v1.0 but this document was never updated.