### PR TITLE
call out invalid characters are not validated

### DIFF
--- a/api-reference/v1.0/api/directoryobject-validateproperties.md
+++ b/api-reference/v1.0/api/directoryobject-validateproperties.md
@@ -18,6 +18,9 @@ The following policy validations are performed for the display name and mail nic
 2. Validate the custom banned words policy
 3. Validate that the mail nickname is unique
 
+> [!NOTE]
+> Invalid characters are not part of the policy validations. The following characters are considered to be invalid @ () \ [] " ; : <> , SPACE.
+
 This API only returns the first validation failure that is encountered. If the properties fail multiple validations, only the first validation failure is returned. However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy. To learn more about configuring naming policies, see [Configure naming policy](/azure/active-directory/users-groups-roles/groups-naming-policy#configure-naming-policy-in-powershell).
 
 ## Permissions

--- a/api-reference/v1.0/api/directoryobject-validateproperties.md
+++ b/api-reference/v1.0/api/directoryobject-validateproperties.md
@@ -19,7 +19,7 @@ The following policy validations are performed for the display name and mail nic
 3. Validate that the mail nickname is unique
 
 > [!NOTE]
-> Invalid characters are not part of the policy validations. The following characters are considered to be invalid @ () \ [] " ; : <> , SPACE.
+> Invalid characters are not part of the policy validations. The following characters are invalid: @ () \ [] " ; : <> , SPACE.
 
 This API only returns the first validation failure that is encountered. If the properties fail multiple validations, only the first validation failure is returned. However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy. To learn more about configuring naming policies, see [Configure naming policy](/azure/active-directory/users-groups-roles/groups-naming-policy#configure-naming-policy-in-powershell).
 

--- a/api-reference/v1.0/api/directoryobject-validateproperties.md
+++ b/api-reference/v1.0/api/directoryobject-validateproperties.md
@@ -19,7 +19,7 @@ The following policy validations are performed for the display name and mail nic
 3. Validate that the mail nickname is unique
 
 > [!NOTE]
-> Invalid characters are not part of the policy validations. The following characters are invalid: @ () \ [] " ; : <> , SPACE.
+> Invalid characters are not part of the policy validations. The following characters are invalid: @ () \ \[] " ; : <> , SPACE.
 
 This API only returns the first validation failure that is encountered. If the properties fail multiple validations, only the first validation failure is returned. However, you can validate both the mail nickname and the display name and receive a collection of validation errors if you are only validating the prefix and suffix naming policy. To learn more about configuring naming policies, see [Configure naming policy](/azure/active-directory/users-groups-roles/groups-naming-policy#configure-naming-policy-in-powershell).
 


### PR DESCRIPTION
Wanted to add a note that calls out the validate properties API does only validates the naming policy and does not take into consideration invalid characters. Invalid characters will fail during group creation but will not throw an error for validate properties