### PR TITLE
Allow Collapse Against ExternalItem

### DIFF
--- a/api-reference/beta/resources/search-api-overview.md
+++ b/api-reference/beta/resources/search-api-overview.md
@@ -120,9 +120,9 @@ The **collapseProperties** property contains a set of criteria, fields, and limi
 
 The [query](../api/search-query.md) method lets you customize the collapse property by specifying **collapseProperties** on the `requests` parameter, which is a collection of [collapseProperty](collapseproperty.md) objects. This allows you to specify a set of one or more collapse properties.
 
-Note that collapsing results is currently only supported on the following SharePoint and OneDrive types: [driveItem](driveitem.md), [listItem](listitem.md), [drive](drive.md), [list](list.md), [site](site.md).
+Note that collapsing results is currently supported on the following entity types: [driveItem](driveitem.md), [listItem](listitem.md), [drive](drive.md), [list](lcist.md), [site](site.md), [externalItem](externalconnectors-externalitem.md).
 
-The properties on which the collapse clause are applied need to be queryable and either sortable or refinable in the SharePoint [search schema](/sharepoint/manage-search-schema). For multi-level collapse, each subsequent property limit size specified in a multi-level request should be less than or equal to the previous; otherwise, the response will return an `HTTP 400 Bad Request` error.
+The properties on which the collapse clause are applied need to be queryable and either sortable or refinable. For multi-level collapse, each subsequent property limit size specified in a multi-level request should be less than or equal to the previous; otherwise, the response will return an `HTTP 400 Bad Request` error.
 
 For examples that show how to collapse results, see [collapse search results](/graph/search-concept-collapse).
 

--- a/api-reference/beta/resources/search-api-overview.md
+++ b/api-reference/beta/resources/search-api-overview.md
@@ -120,7 +120,7 @@ The **collapseProperties** property contains a set of criteria, fields, and limi
 
 The [query](../api/search-query.md) method lets you customize the collapse property by specifying **collapseProperties** on the `requests` parameter, which is a collection of [collapseProperty](collapseproperty.md) objects. This allows you to specify a set of one or more collapse properties.
 
-Note that collapsing results is currently supported on the following entity types: [driveItem](driveitem.md), [listItem](listitem.md), [drive](drive.md), [list](lcist.md), [site](site.md), [externalItem](externalconnectors-externalitem.md).
+Note that collapsing results is currently supported on the following entity types: [driveItem](driveitem.md), [listItem](listitem.md), [drive](drive.md), [list](list.md), [site](site.md), [externalItem](externalconnectors-externalitem.md).
 
 The properties on which the collapse clause are applied need to be queryable and either sortable or refinable. For multi-level collapse, each subsequent property limit size specified in a multi-level request should be less than or equal to the previous; otherwise, the response will return an `HTTP 400 Bad Request` error.
 

--- a/concepts/search-concept-collapse.md
+++ b/concepts/search-concept-collapse.md
@@ -8,18 +8,18 @@ ms.prod: "search"
 
 # Use the Microsoft Search API to collapse search results
 
-You can use the Microsoft Search API in Microsoft Graph to collapse items in search result set, which can display these results in a concise, readable way. You can specify the criteria for collapsing by using **collapseProperties** property in a [searchRequest](/graph/api/resources/searchrequest) object, which contains one or more collapseProperty parameter that point out fields set to be collapsed and a limit size. The **collapseProperties** property is only supported on files hosted in SharePoint and OneDrive.
+You can use the Microsoft Search API in Microsoft Graph to collapse items in search result set, which can display these results in a concise, readable way. You can specify the criteria for collapsing by using **collapseProperties** property in a [searchRequest](/graph/api/resources/searchrequest) object, which contains one or more collapseProperty parameter that point out fields set to be collapsed and a limit size. The **collapseProperties** property is supported for following entity types: site, drive, driveItem, list, listItem and externalItem.
 
 | Scenarios | Description | Sample |
 | :----     | :----       | :----  |
-|**Basic Collapse**|Collapse by any single queryable and either sortable or refineable property. This limit value must be an integer between 1 and 32767.|"collapseProperties":[{"fields":["title"],"limit":3}]|
-|**Compound Collapse**|Collapse by compound fields of properties. There is no built-in maximum size for number of fields, but at least two fields need to be nominated. This limit value must be an integer between 1 and 32767.|"collapseProperties":[{"fields":["title","createdBy"],"limit":2}]|
-|**Multi-level Collapse**|Collapse by level-by-level collapseProperty. There is no built-in maximum size for number of levels, but at least two levels need to be specified. For the limit value of each level must be an integer between 1 and 32767, and must be equal or less than upper-level limit value. |"collapseProperties":[{"fields":["title"],"limit":3},{"fields":["createdBy"],"limit":1}]|
+|**Basic Collapse**|Collapse by any single queryable and either sortable or refineable property. This limit value must be an integer between 1 and 32767.|"collapseProperties":[{"fields":["filename"],"limit":3}]|
+|**Compound Collapse**|Collapse by compound fields of properties. There is no built-in maximum size for number of fields, but at least two fields need to be nominated. This limit value must be an integer between 1 and 32767.|"collapseProperties":[{"fields":["filename","author"],"limit":2}]|
+|**Multi-level Collapse**|Collapse by level-by-level collapseProperty. There is no built-in maximum size for number of levels, but at least two levels need to be specified. For the limit value of each level must be an integer between 1 and 32767, and must be equal or less than upper-level limit value. |"collapseProperties":[{"fields":["filename"],"limit":3},{"fields":["author"],"limit":1}]|
 
 ## Examples of using collapseProperties
 The following table shows a sample list in SharePoint. The next set of examples use this list to show how the collapseProperties property works.
 
-| Title | Created By | Subject | Rank |
+| Filename | Author | Subject | Rank |
 | :----: | :----: | :----: | :----: |
 |Note|Andy|Poetry|1|
 |Note|James|History|2|
@@ -45,10 +45,13 @@ Content-Type: application/json
             "query": {
                 "queryString": "note"
             },
+            "fields": [
+                "filename"
+            ],
             "collapseProperties": [
                 {
                     "fields": [
-                        "title"
+                        "filename"
                     ],
                     "limit": 3
                 }
@@ -57,9 +60,9 @@ Content-Type: application/json
     ]
 }
 ```
-Group the items based on **title** and show the top three (hence "limit": 3) for each group. As you can see in the below table, the ranking is maintained, and the top three rows and last 3 rows are kept but rows 4 and 5 are excluded because the collapseProperties limit is 3.
+Group the items based on **Filename** and show the top three (hence "limit": 3) for each group. As you can see in the below table, the ranking is maintained, and the top three rows and last 3 rows are kept but rows 4 and 5 are excluded because the collapseProperties limit is 3.
 
-| Title | Created By | Subject | Rank |
+| Filename | Author | Subject | Rank |
 | :----: | :----: | :----: | :----: |
 |Note|Andy|Poetry|1|
 |Note|James|History|2|
@@ -84,14 +87,14 @@ Content-Type: application/json
                 "queryString": "note"
             },
             "fields": [
-                "title",
-                "createdBy"
+                "filename",
+                "author"
             ],
             "collapseProperties": [
                 {
                     "fields": [
-                        "title",
-                        "createdBy"
+                        "filename",
+                        "author"
                     ],
                     "limit": 2
                 }
@@ -100,9 +103,9 @@ Content-Type: application/json
     ]
 }
 ```
-In below table, the ranking is still maintained, but we collapse by two properties simultaneously to find unique combinations of title and createdby. This results in keeping the first 4 rows and excluding row 5 because combination of Note (title) and James (createdBy) is only allowed up to 2 times. Additionally, last 3 rows are kept for the same reason.
+In below table, the ranking is still maintained, but we collapse by two properties simultaneously to find unique combinations of Filename and Author. This results in keeping the first 4 rows and excluding row 5 because combination of Note (Filename) and James (Author) is only allowed up to 2 times. Additionally, last 3 rows are kept for the same reason.
 
-| Title | Created By | Subject | Rank |
+| Filename | Author | Subject | Rank |
 | :----: | :----: | :----: | :----: |
 |Note|Andy|Poetry|1|
 |Note|James|History|2|
@@ -128,19 +131,19 @@ Content-Type: application/json
                 "queryString": "note"
             },
             "fields": [
-                "title",
-                "createdBy"
+                "filename",
+                "author"
             ],
             "collapseProperties": [
                 {
                     "fields": [
-                        "title"
+                        "filename"
                     ],
                     "limit": 3
                 },
                 {
                     "fields": [
-                        "createdBy"
+                        "author"
                     ],
                     "limit": 1
                 }
@@ -149,9 +152,9 @@ Content-Type: application/json
     ]
 }
 ```
-In below table, the ranking is still maintained, but we collapse first on title and then do a second collapse on createdBy. For the first level collapse on title with a limit of 3, this results in keeping the first 3 rows excluding rows 4 and 5 and keeping the last 3 rows as is. And then for the second level collapse with a limit of 1, we don't need to change the first 3 rows we kept because each has a unique createdBy value, but we do need to exclude row 8 because James is listed again as createdBy and we only need unique values for that property.
+In below table, the ranking is still maintained, but we collapse first on Filename and then do a second collapse on Author. For the first level collapse on Filename with a limit of 3, this results in keeping the first 3 rows excluding rows 4 and 5 and keeping the last 3 rows as is. And then for the second level collapse with a limit of 1, we don't need to change the first 3 rows we kept because each has a unique Author value, but we do need to exclude row 8 because James is listed again as Author and we only need unique values for that property.
 
-| Title | Created By | Subject | Rank |
+| Filename | Author | Subject | Rank |
 | :---- | :---- | :---- | :---- |
 |Note|Andy|Poetry|1|
 |Note|James|History|2|
@@ -160,7 +163,7 @@ In below table, the ranking is still maintained, but we collapse first on title 
 |Notebook|Andy|Culture|7|
 
 ## Known limitations
-- The **collapseProperties** property is not supported for the following resources: **message**,**chatMessage**, **event**, **person**, **externalItem**, **bookmark** or **acronym**.
+- The **collapseProperties** property is not supported for the following resources: **message**, **chatMessage**, **event**, **person**, **bookmark** or **acronym**.
 
 ## Next steps
 


### PR DESCRIPTION
Update two things:
1. Collapse is now supported for externalItem. So I append externalItem in supported entity type list.
2. Replace title to filename, createdBy to author. They are two managed properties in SPO and can function in request.