### PR TITLE
Set up skeleton doc update for printjob and printdocument

### DIFF
--- a/api-reference/beta/resources/printdocument.md
+++ b/api-reference/beta/resources/printdocument.md
@@ -29,6 +29,8 @@ Represents a document being printed.
 |displayName|String|The document's name. Read-only.|
 |contentType|String|The document's content (MIME) type. Read-only.|
 |size|Int64|The document's size in bytes. Read-only.|
+|uploadedDateTime|Edm.DateTimeOffset|The DateTimeOffset when the document was uploaded by a client to Universal Print Server.|
+|downloadedDateTime|Edm.DateTimeOffset|The DateTimeOffset when the document was downloaded by a printer from Universal Print Server.|
 
 ## JSON representation
 

--- a/api-reference/beta/resources/printjob.md
+++ b/api-reference/beta/resources/printjob.md
@@ -37,6 +37,8 @@ Represents a print job that has been queued for a printer.
 |isFetchable|Edm.Boolean|If true, document can be fetched by printer.|
 |redirectedFrom|Edm.String|Contains the source job URL, if the job has been redirected from another printer.|
 |redirectedTo|Edm.String|Contains the destination job URL, if the job has been redirected to another printer.|
+|errorCode|Edm.Int|Job's errorcode if there is any sent from the printer.|
+|acknowledgedDateTime`|Edm.DateTimeOffset|The dateTimeOffset when printer acknowledged the print job.|
 
 ## Relationships
 | Relationship | Type        | Description |

--- a/changelog/Microsoft.PrintService.json
+++ b/changelog/Microsoft.PrintService.json
@@ -3,6 +3,56 @@
     {
       "ChangeList": [
         {
+          "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+          "ApiChange": "Property",
+          "ChangedApiName": "downloadedDateTime",
+          "ChangeType": "Addition",
+          "Description": "Added the `downloadedDateTime` property to the [printDocument](https://docs.microsoft.com/en-us/graph/api/resources/printDocument?view=graph-rest-beta) resource.",
+          "Target": "printDocument"
+        },
+        {
+          "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+          "ApiChange": "Property",
+          "ChangedApiName": "uploadedDateTime",
+          "ChangeType": "Addition",
+          "Description": "Added the `uploadedDateTime` property to the [printDocument](https://docs.microsoft.com/en-us/graph/api/resources/printDocument?view=graph-rest-beta) resource.",
+          "Target": "printDocument"
+        },
+        {
+          "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+          "ApiChange": "Property",
+          "ChangedApiName": "acknowledgedDateTime",
+          "ChangeType": "Addition",
+          "Description": "Added the `acknowledgedDateTime` property to the [printJob](https://docs.microsoft.com/en-us/graph/api/resources/printJob?view=graph-rest-beta) resource.",
+          "Target": "printJob"
+        },
+        {
+          "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+          "ApiChange": "Property",
+          "ChangedApiName": "completedDateTime",
+          "ChangeType": "Addition",
+          "Description": "Added the `completedDateTime` property to the [printJob](https://docs.microsoft.com/en-us/graph/api/resources/printJob?view=graph-rest-beta) resource.",
+          "Target": "printJob"
+        },
+        {
+          "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+          "ApiChange": "Property",
+          "ChangedApiName": "errorCode",
+          "ChangeType": "Addition",
+          "Description": "Added the `errorCode` property to the [printJob](https://docs.microsoft.com/en-us/graph/api/resources/printJob?view=graph-rest-beta) resource.",
+          "Target": "printJob"
+        }
+      ],
+      "Id": "75133603-c54c-4bc8-aa9a-81cb611388c0",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2022-11-08T23:57:23.5291764Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Cloud printing"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "fe732304-2d74-474b-85ae-b9daeca0a06e",
           "ApiChange": "Resource",
           "ChangedApiName": "printerShareViewpoint",
@@ -54,7 +104,7 @@
     },
     {
       "ChangeList": [
-                {
+        {
           "Id": "2531d4d1-1572-4ce3-0654-61cf63abow90",
           "ApiChange": "Enum type",
           "ChangedApiName": "printerStatus",


### PR DESCRIPTION
Added in docstubs from the AD-AggregatorService-Workloads-PullRequest pipeline.

Updated docs to add new properties for PrintJob and PrintDocument