### PR TITLE
Clarity on $top

### DIFF
--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -239,7 +239,7 @@ The `$skiptoken` parameter contains an opaque token that references the next pag
 
 ## top parameter
 
-Use the `$top` query parameter to specify the page size of the result set. 
+Use the `$top` query parameter to specify the number of items to be included in the result.
 
 If more items remain in the result set, the response body will contain an `@odata.nextLink` parameter. This parameter contains a URL that you can use to get the next page of results. To learn more, see [Paging](./paging.md). 
 


### PR DESCRIPTION
$top is supposed to behave like TOP in SQL = return X number of records.
However, while this is true, many Graph APIs also return nextLink and make $top behave like paging/maxPageSize. 

This PR only edits the description for $top but doesn't change other info about nextLink because this other info is actual implementation, though doesn't align to OData.