### PR TITLE
Update driveitem-createlink.md with available value, users, for scope

### DIFF
--- a/api-reference/beta/api/driveitem-createlink.md
+++ b/api-reference/beta/api/driveitem-createlink.md
@@ -54,7 +54,7 @@ The request should be a JSON object with the following properties.
 |   Property                 |  Type  |                                 Description                                                               |
 | :----------------------| :----- | :---------------------------------------------------------------------------------------------------------|
 |type|String|Optional.The type of sharing link to create.   |
-|scope|String|Optional. The scope of link to create. Either anonymous, organization or users.|
+|scope|String|Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`|
 |expirationDateTime|DateTimeOffset|Optional. A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission.|
 |password|String|Optional.The password of the sharing link that is set by the creator.|
 |recipients|[driveRecipient](../resources/driverecipient.md) collection|Optional. A collection of recipients who will receive access to the sharing link.|
@@ -82,7 +82,7 @@ The following values are allowed for the **scope** parameter.
 |:---------------|:------------------------------------------------------------
 | anonymous    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
 | organization | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
-| users        | Specific people in the recipients collection can use the link to get access. Only available in OneDrive for Business and SharePoint.
+| users        | Specific people in the recipient's collection can use the link to get access. Only available in OneDrive for Business and SharePoint.
 
 ## Response
 

--- a/api-reference/v1.0/api/driveitem-createlink.md
+++ b/api-reference/v1.0/api/driveitem-createlink.md
@@ -50,7 +50,7 @@ The request should be a JSON object with the following properties.
 | **type**     | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.       |
 | **password** | string | The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.
 | **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
-| **scope** | string | Optional. The scope of link to create. Either `anonymous`, `organization` or `users`. |
+| **scope** | string | Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`. |
 
 
 ### Link types
@@ -72,7 +72,7 @@ If the **scope** parameter is not specified, the default link type for the organ
 |:---------------|:------------------------------------------------------------
 | `anonymous`    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
 | `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
-| `users`        | Share only with people you choose inside or outside organization.
+| `users`        | Share only with people you choose inside or outside the organization.
 
 
 ## Response

--- a/api-reference/v1.0/api/driveitem-createlink.md
+++ b/api-reference/v1.0/api/driveitem-createlink.md
@@ -50,7 +50,7 @@ The request should be a JSON object with the following properties.
 | **type**     | string | The type of sharing link to create. Either `view`, `edit`, or `embed`.       |
 | **password** | string | The password of the sharing link that is set by the creator. Optional and OneDrive Personal only.
 | **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
-| **scope** | string | Optional. The scope of link to create. Either `anonymous` or `organization`. |
+| **scope** | string | Optional. The scope of link to create. Either `anonymous`, `organization` or `users`. |
 
 
 ### Link types
@@ -72,6 +72,7 @@ If the **scope** parameter is not specified, the default link type for the organ
 |:---------------|:------------------------------------------------------------
 | `anonymous`    | Anyone with the link has access, without needing to sign in. This may include people outside of your organization. Anonymous link support may be disabled by an administrator.
 | `organization` | Anyone signed into your organization (tenant) can use the link to get access. Only available in OneDrive for Business and SharePoint.
+| `users`        | Share only with people you choose inside or outside organization.
 
 
 ## Response


### PR DESCRIPTION
We noticed `users` is also an available option from the response data of [listing SharePoint permissions endpoint](https://learn.microsoft.com/en-us/graph/api/driveitem-list-permissions?view=graph-rest-1.0&tabs=http)