### PR TITLE
Update channel.md

### DIFF
--- a/api-reference/beta/resources/channel.md
+++ b/api-reference/beta/resources/channel.md
@@ -59,7 +59,7 @@ where files are shared, and where tabs are added.
 | Property   | Type |Description|
 |:---------------|:--------|:----------|
 |description|String|Optional textual description for the channel.|
-|displayName|String|Channel name as it will appear to the user in Microsoft Teams.|
+|displayName|String|Channel name as it will appear to the user in Microsoft Teams. The maximum length is 50 characters.|
 |id|String|The channel's unique identifier. Read-only.|
 |isFavoriteByDefault|Boolean|Indicates whether the channel should automatically be marked 'favorite' for all members of the team. Can only be set programmatically with [Create team](../api/team-post.md). Default: `false`.|
 |email|String| The email address for sending messages to the channel. Read-only.|


### PR DESCRIPTION
The display name of the channel can't have more than 50 characters. Fixed property description to reflect this limitation.
Fixes: #19391