### PR TITLE
Update tutorial-lifecycle-workflows-set-employeeleavedatetime.md

### DIFF
--- a/concepts/tutorial-lifecycle-workflows-set-employeeleavedatetime.md
+++ b/concepts/tutorial-lifecycle-workflows-set-employeeleavedatetime.md
@@ -17,7 +17,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|User-LifeCycleInfo.ReadWrite.All, Directory.AccessAsUser.All |
+|Delegated (work or school account)|User.Read.All and User-LifeCycleInfo.ReadWrite.All |
 |Delegated (personal Microsoft account)|Not supported.|
 |Application|User-LifeCycleInfo.ReadWrite.All|
 


### PR DESCRIPTION
API requires User.Read.All and User-LifeCycleInfo.ReadWrite.All. Remove Directory.AccessAsUser.All which is too privileged.

-------
cc: @AlexFilipin