### PR TITLE
use docs important box for very important message

### DIFF
--- a/concepts/auth-cloudsolutionprovider.md
+++ b/concepts/auth-cloudsolutionprovider.md
@@ -13,7 +13,9 @@ ms.custom: graphiamtop20
 
 This topic describes how to enable application access to partner-managed customer data via Microsoft Graph using either the [authorization code grant flow](/azure/active-directory/develop/active-directory-protocols-oauth-code) or the [service to service client credentials flow](/azure/active-directory/develop/active-directory-protocols-oauth-service-to-service).
 
-**Important:** Calling Microsoft Graph from a CSP application is only supported for directory resources (such as **user**, **group**,**device**, **organization**) and [Intune](/graph/api/resources/intune-graph-overview) resources.
+> [!IMPORTANT]
+> Calling Microsoft Graph from a CSP application is only supported for directory resources (such as **user**, **group**,**device**, **organization**) and [Intune](/graph/api/resources/intune-graph-overview) resources.
+> 
 
 ## What is a partner-managed application
 


### PR DESCRIPTION
A very important sentence is only marked in bold instead of using the Important Box.
This PR corrects that.