### PR TITLE
[Doc Improvement][channel-post-messages]

### DIFF
--- a/api-reference/beta/api/channel-post-messages.md
+++ b/api-reference/beta/api/channel-post-messages.md
@@ -25,7 +25,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | ChannelMessage.Send, Group.ReadWrite.All** |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Teamwork.Migrate.All, ChannelMessage.ReadWrite.All |
+| Application                            | Teamwork.Migrate.All |
 
 > **Note**: Permissions marked with ** are supported only for backward compatibility. We recommend that you update your solutions to use an alternative permission listed in the previous table and avoid using these permissions going forward.
 

--- a/api-reference/v1.0/api/channel-post-messages.md
+++ b/api-reference/v1.0/api/channel-post-messages.md
@@ -23,7 +23,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---------------------------------------|:--------------------------------------------|
 | Delegated (work or school account)     | ChannelMessage.Send, Group.ReadWrite.All** |
 | Delegated (personal Microsoft account) | Not supported. |
-| Application                            | Teamwork.Migrate.All, ChannelMessage.ReadWrite.All |
+| Application                            | Teamwork.Migrate.All |
 
 > **Note**: Permissions marked with ** are supported only for backward compatibility. We recommend that you update your solutions to use an alternative permission listed in the previous table and avoid using these permissions going forward.
 


### PR DESCRIPTION
ChannelMessage.ReadWrite.All permission removed from channel-post-messages.md for v1.0 and beta version.
w.r.t Issue #18996 