### PR TITLE
maximum duration is 62 days, not 42

### DIFF
--- a/concepts/outlook-get-free-busy-schedule.md
+++ b/concepts/outlook-get-free-busy-schedule.md
@@ -185,7 +185,7 @@ Prefer: outlook.timezone="Pacific Standard Time"
 Be aware of the following limits and error condition:
 
 - **getSchedule** can support looking up free/busy information for up to 20 entities at once. This limit applies to the number of users identified individually or as members of a distribution list, and to the number of resources as well.
-- The time period to look up must be less than 42 days.
+- The time period to look up must be less than 62 days.
 - If **getSchedule** cannot identify a specified user or resource, it returns a single schedule item and indicates the error. 
 
 


### PR DESCRIPTION
Here the exception in case I ask for a duration of 63 - so one more days as the maximum:

Exception in thread "main" com.microsoft.graph.http.GraphServiceException: Error code: ErrorTimeIntervalTooBig
Error message: The requested time duration specified for FreeBusyViewOptions.TimeWindow is too long. The allowed limit = 62 days; the actual limit = 63 days.