### PR TITLE
Update intune-deviceconfig-deviceconfiguration-getomasettingplaintext…

### DIFF
--- a/api-reference/v1.0/api/intune-deviceconfig-deviceconfiguration-getomasettingplaintextvalue.md
+++ b/api-reference/v1.0/api/intune-deviceconfig-deviceconfiguration-getomasettingplaintextvalue.md
@@ -20,9 +20,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|DeviceManagementConfiguration.Read.All, DeviceManagementConfiguration.ReadWrite.All|
+|Delegated (work or school account)|DeviceManagementConfiguration.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|DeviceManagementConfiguration.Read.All, DeviceManagementConfiguration.ReadWrite.All|
+|Application|DeviceManagementConfiguration.ReadWrite.All|
 
 ## HTTP Request
 <!-- {


### PR DESCRIPTION
…value.md

Due to a security change, "read only" is no longer supported on this operation.