### PR TITLE
Missing `planner roster get` in left navigation

### DIFF
--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -24302,6 +24302,8 @@ items:
           href: resources/plannerroster.md
         - name: Create roster
           href: api/planner-post-rosters.md
+        - name: Get roster
+          href: api/plannerroster-get.md
         - name: Delete roster
           href: api/plannerroster-delete.md
         - name: List roster's members


### PR DESCRIPTION
When looking at the Planner Roster API, I noticed that `Get plannerRoster` wasn't available in the left navigation. 

![afbeelding](https://user-images.githubusercontent.com/38426621/213865321-8fcb9b77-6453-4127-835f-3e7eca959fd0.png)

This PR resolves this by adding a link to the page `Get plannerRoster` in the file `beta/toc.yml`