### PR TITLE
Update identitycontainer-post-identityproviders.md

### DIFF
--- a/api-reference/beta/api/identitycontainer-post-identityproviders.md
+++ b/api-reference/beta/api/identitycontainer-post-identityproviders.md
@@ -12,7 +12,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Create an identity provider resource that is of the type specified in the request body.
+Create an identity provider object that is of the type specified in the request body.
 
 Among the types of providers derived from identityProviderBase, you can currently create a [socialIdentityProvider](../resources/socialidentityprovider.md) resource in Azure AD. In Azure AD B2C, this operation can currently create a [socialIdentityProvider](../resources/socialidentityprovider.md), [openIdConnectIdentityProvider](../resources/openidconnectidentityprovider.md), or an [appleManagedIdentityProvider](../resources/applemanagedidentityprovider.md) resource.
 

--- a/api-reference/v1.0/api/identitycontainer-post-identityproviders.md
+++ b/api-reference/v1.0/api/identitycontainer-post-identityproviders.md
@@ -10,7 +10,7 @@ ms.prod: "identity-and-sign-in"
 # Create identityProvider
 Namespace: microsoft.graph
 
-Create an identity provider resource that is of the type specified in the request body.
+Create an identity provider object that is of the type specified in the request body.
 
 Among the types of providers derived from identityProviderBase, you can currently create a [socialIdentityProvider](../resources/socialidentityprovider.md) resource in Azure AD. In Azure AD B2C, this operation can currently create a [socialIdentityProvider](../resources/socialidentityprovider.md), or an [appleManagedIdentityProvider](../resources/applemanagedidentityprovider.md) resource.
 


### PR DESCRIPTION
To make the internalDomainFederation page consistent with "Create samlOrWsFedExternalDomainFederation" and "Create federationConfiguration" pages, we better use the term "object" instead of "resource".