### PR TITLE
Update ItemReference to add information about listItems

### DIFF
--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -41,7 +41,7 @@ Here is a JSON representation of the resource
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
 | driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if item is location in a [drive][].  See [drive][] resource for values.
+| driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][].  See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.

--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -1,13 +1,12 @@
 ---
 author: JeremyKelley
 description: "Provides information necessary to address a driveItem or listItem via the API."
-ms.date: 09/10/2017
-title: ItemReference
+title: itemReference
 ms.localizationpriority: medium
 doc_type: resourcePageType
 ms.prod: "sharepoint"
 ---
-# ItemReference resource type
+# itemReference resource type
 
 Namespace: microsoft.graph
 

--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -40,7 +40,7 @@ Here is a JSON representation of the resource
 
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
 | driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][].  See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.

--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -1,6 +1,6 @@
 ---
 author: JeremyKelley
-description: "The ItemReference resource provides information necessary to address a DriveItem or ListItem via the API."
+description: "Provides information necessary to address a driveItem or listItem via the API."
 ms.date: 09/10/2017
 title: ItemReference
 ms.localizationpriority: medium
@@ -11,11 +11,24 @@ ms.prod: "sharepoint"
 
 Namespace: microsoft.graph
 
-The **ItemReference** resource provides information necessary to address a [driveItem](driveitem.md) or a [listItem](listitem.md) via the API.
+Provides information necessary to address a [driveItem](driveitem.md) or a [listItem](listitem.md) via the API.
+
+## Properties
+
+| Property      | Type              | Description
+|:--------------|:------------------|:-----------------------------------------
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
+| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][].  See [drive][] resource for values.
+| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
+| name          | String            | The name of the item being referenced. Read-only.
+| path          | String            | Path that can be used to navigate to the item. Read-only.
+| shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
+| sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
+| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site?view=graph-rest-beta&preserve-view=true#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 ## JSON representation
 
-Here is a JSON representation of the resource
+The following is a JSON representation of the resource.
 
 <!-- {
   "blockType": "resource",
@@ -35,19 +48,6 @@ Here is a JSON representation of the resource
   "siteId": "string"
 }
 ```
-
-## Properties
-
-| Property      | Type              | Description
-|:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][].  See [drive][] resource for values.
-| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
-| name          | String            | The name of the item being referenced. Read-only.
-| path          | String            | Path that can be used to navigate to the item. Read-only.
-| shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
-| sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
-| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site?view=graph-rest-beta&preserve-view=true#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 [drive]: ../resources/drive.md
 [sharepointIds]: ../resources/sharepointids.md

--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -41,7 +41,7 @@ Here is a JSON representation of the resource
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
 | driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][].  See [drive][] resource for values.
+| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][].  See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.

--- a/api-reference/beta/resources/itemreference.md
+++ b/api-reference/beta/resources/itemreference.md
@@ -1,6 +1,6 @@
 ---
 author: JeremyKelley
-description: "The ItemReference resource provides information necessary to address a DriveItem via the API."
+description: "The ItemReference resource provides information necessary to address a DriveItem or ListItem via the API."
 ms.date: 09/10/2017
 title: ItemReference
 ms.localizationpriority: medium
@@ -11,7 +11,7 @@ ms.prod: "sharepoint"
 
 Namespace: microsoft.graph
 
-The **ItemReference** resource provides information necessary to address a [driveItem](driveitem.md) via the API.
+The **ItemReference** resource provides information necessary to address a [driveItem](driveitem.md) or a [listItem](listitem.md) via the API.
 
 ## JSON representation
 
@@ -40,14 +40,14 @@ Here is a JSON representation of the resource
 
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the item. Read-only.
-| driveType     | String            | Identifies the type of drive. See [drive][] resource for values.
-| id            | String            | Unique identifier of the item in the drive. Read-only.
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
+| driveType     | String            | Identifies the type of drive. Only returned if item is location in a [drive][].  See [drive][] resource for values.
+| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.
 | shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
 | sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
-| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site?view=graph-rest-beta&preserve-view=true#id-property) of the site. <br>For OneDrive, this property is not populated.
+| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site?view=graph-rest-beta&preserve-view=true#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 [drive]: ../resources/drive.md
 [sharepointIds]: ../resources/sharepointids.md

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -42,7 +42,7 @@ Here is a JSON representation of the resource
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
 | driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][]. See [drive][] resource for values.
+| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][]. See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -1,22 +1,34 @@
 ---
 author: JeremyKelley
-ms.date: 09/10/2017
-title: ItemReference
+title: itemReference
 ms.localizationpriority: medium
-description: "The ItemReference resource provides information necessary to address a DriveItem or ListItem via the API."
+description: "The itemReference resource provides information necessary to address a driveItem or listItem via the API."
 ms.prod: "sharepoint"
 doc_type: resourcePageType
 ---
 
-# ItemReference resource type
+# itemReference resource type
 
 Namespace: microsoft.graph
 
-The **ItemReference** resource provides information necessary to address a [DriveItem](driveitem.md) or a [listItem](listitem.md) via the API.
+The **itemReference** resource provides information necessary to address a [driveItem](driveitem.md) or a [listItem](listitem.md) via the API.
+
+## Properties
+
+| Property      | Type              | Description
+|:--------------|:------------------|:-----------------------------------------
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
+| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][]. See [drive][] resource for values.
+| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
+| name          | String            | The name of the item being referenced. Read-only.
+| path          | String            | Path that can be used to navigate to the item. Read-only.
+| shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
+| sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
+| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 ## JSON representation
 
-Here is a JSON representation of the resource
+The following is a JSON representation of the resource.
 
 <!-- {
   "blockType": "resource",
@@ -36,19 +48,6 @@ Here is a JSON representation of the resource
   "siteId": "string"
 }
 ```
-
-## Properties
-
-| Property      | Type              | Description
-|:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if the item is located in a [drive][]. See [drive][] resource for values.
-| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
-| name          | String            | The name of the item being referenced. Read-only.
-| path          | String            | Path that can be used to navigate to the item. Read-only.
-| shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
-| sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
-| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 [drive]: ../resources/drive.md
 [sharepointIds]: ../resources/sharepointids.md

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -42,7 +42,7 @@ Here is a JSON representation of the resource
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
 | driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
-| driveType     | String            | Identifies the type of drive. Only returned if item is location in a [drive][]. See [drive][] resource for values.
+| driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][]. See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -41,7 +41,7 @@ Here is a JSON representation of the resource
 
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if the item is located in a [drive][]. Read-only.
 | driveType     | String            | Identifies the type of drive. Only returned if item is located in a [drive][]. See [drive][] resource for values.
 | id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.

--- a/api-reference/v1.0/resources/itemreference.md
+++ b/api-reference/v1.0/resources/itemreference.md
@@ -3,7 +3,7 @@ author: JeremyKelley
 ms.date: 09/10/2017
 title: ItemReference
 ms.localizationpriority: medium
-description: "The ItemReference resource provides information necessary to address a DriveItem via the API."
+description: "The ItemReference resource provides information necessary to address a DriveItem or ListItem via the API."
 ms.prod: "sharepoint"
 doc_type: resourcePageType
 ---
@@ -12,7 +12,7 @@ doc_type: resourcePageType
 
 Namespace: microsoft.graph
 
-The **ItemReference** resource provides information necessary to address a [DriveItem](driveitem.md) via the API.
+The **ItemReference** resource provides information necessary to address a [DriveItem](driveitem.md) or a [listItem](listitem.md) via the API.
 
 ## JSON representation
 
@@ -41,14 +41,14 @@ Here is a JSON representation of the resource
 
 | Property      | Type              | Description
 |:--------------|:------------------|:-----------------------------------------
-| driveId       | String            | Unique identifier of the drive instance that contains the item. Read-only.
-| driveType     | String            | Identifies the type of drive. See [drive][] resource for values.
-| id            | String            | Unique identifier of the item in the drive. Read-only.
+| driveId       | String            | Unique identifier of the drive instance that contains the driveItem. Only returned if item is located in a [drive][]. Read-only.
+| driveType     | String            | Identifies the type of drive. Only returned if item is location in a [drive][]. See [drive][] resource for values.
+| id            | String            | Unique identifier of the driveItem in the drive or a listItem in a list. Read-only.
 | name          | String            | The name of the item being referenced. Read-only.
 | path          | String            | Path that can be used to navigate to the item. Read-only.
 | shareId       | String            | A unique identifier for a shared resource that can be accessed via the [Shares][] API.
 | sharepointIds | [sharepointIds][] | Returns identifiers useful for SharePoint REST compatibility. Read-only.
-| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site#id-property) of the site. <br>For OneDrive, this property is not populated.
+| siteId        | String            | For OneDrive for Business and SharePoint, this property represents the ID of the site that contains the parent document library of the driveItem resource or the parent list of the listItem resource. The value is the same as the id property of that [site][] resource. It is an [opaque string that consists of three identifiers](/graph/api/resources/site#id-property) of the site. <br>For OneDrive, this property is not populated.
 
 [drive]: ../resources/drive.md
 [sharepointIds]: ../resources/sharepointids.md


### PR DESCRIPTION
ListItem resource has references to ItemReference, however ItemReference descriptions only mention driveItem.
Updating ItemReference Resource to also mention listItem

ListItem resource: https://learn.microsoft.com/en-us/graph/api/resources/listitem?view=graph-rest-1.0