### PR TITLE
Change placement of cross-link to training module

### DIFF
--- a/concepts/delta-query-overview.md
+++ b/concepts/delta-query-overview.md
@@ -13,9 +13,6 @@ ms.date: 08/12/2022
 
 Delta query enables applications to discover newly created, updated, or deleted entities without performing a full read of the target resource with every request. Microsoft Graph applications can use delta query to efficiently synchronize changes with a local data store.
 
-> [!div class="nextstepaction"]
-> [Training module: Use change notifications and track changes with Microsoft Graph](/training/modules/msgraph-changenotifications-trackchanges)
-
 ## Use delta query to track changes in a resource collection
 
 The typical call pattern is as follows:
@@ -245,6 +242,7 @@ The same [permissions](./permissions-reference.md) that are required to read a s
 
 ## Delta query request examples
 
+- [Training module: Use change notifications and track changes with Microsoft Graph](/training/modules/msgraph-changenotifications-trackchanges)
 - [Get incremental changes to events in a calendar view](delta-query-events.md)
 - [Get incremental changes to messages in a folder](./delta-query-messages.md)
 - [Get incremental changes to groups](./delta-query-groups.md)

--- a/concepts/extensibility-overview.md
+++ b/concepts/extensibility-overview.md
@@ -21,10 +21,6 @@ In this article, we'll discuss how Microsoft Graph supports extending its resour
 >
 > The extensions mentioned in this article are not similar to Azure AD [custom security attributes](/graph/api/resources/custom-security-attributes-overview). To understand their differences, see [How do custom security attributes compare with directory extensions?](/azure/active-directory/fundamentals/custom-security-attributes-overview#how-do-custom-security-attributes-compare-with-directory-extensions).
 
-
-> [!div class="nextstepaction"]
-> [Training module: Add custom data to your app using extensions in Microsoft Graph](/training/modules/msgraph-extensions/)
-
 ## Why add custom data to Microsoft Graph?
 
 - As an ISV developer, you might decide to keep your app lightweight and store app-specific user profile data in Microsoft Graph by extending the **user** resource.
@@ -975,6 +971,7 @@ For known limitations using extensions, see the [extensions section](known-issue
 
 ## Next steps
 
+- [Training module: Add custom data to your app using extensions in Microsoft Graph](/training/modules/msgraph-extensions/)
 - [Add custom data to users using open extensions](extensibility-open-users.md)
 - [Add custom data to groups using schema extensions](extensibility-schema-groups.md)
 

--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -21,9 +21,6 @@ Query parameters can be [OData system query options](http://docs.oasis-open.org/
 
 > [!VIDEO https://www.youtube-nocookie.com/embed/7BuFv3yETi4]
 
-> [!div class="nextstepaction"]
-> [Training module: Optimize data usage when using Microsoft Graph with query parameters](/training/modules/optimize-data-usage)
-
 ## OData system query options
 A Microsoft Graph API operation might support one or more of the following OData system query options. These query options are compatible with the [OData V4 query language][odata-query] and are supported in only GET operations.
 
@@ -794,3 +791,4 @@ However, it is important to note that query parameters specified in a request mi
 - [Advanced query capabilities on Azure AD directory objects](/graph/aad-advanced-queries)
 - [Use the $search query parameter to match a search criterion](/graph/search-query-parameter)
 - [Query parameter limitations](known-issues.md#query-parameters)
+- [Training module: Optimize data usage when using Microsoft Graph with query parameters](/training/modules/optimize-data-usage)

--- a/concepts/throttling.md
+++ b/concepts/throttling.md
@@ -24,8 +24,6 @@ Throttling limits vary based on the scenario. For example, if you are performing
 <!-- markdownlint-disable MD034 -->
 > [!VIDEO https://www.youtube-nocookie.com/embed/J4CFxVuzNMA]
 <!-- markdownlint-enable MD034 -->
-> [!div class="nextstepaction"]
-> [Training module: Optimize network traffic with Microsoft Graph](/training/modules/optimize-network-traffic)
 
 <!-- markdownlint-disable MD026 -->
 ## What happens when throttling occurs?
@@ -103,4 +101,5 @@ If SDKs retry throttled requests automatically when they are not batched, thrott
 
 ## Next steps
 
-Identify the [throttling limits](throttling-limits.md) that apply for each Microsoft Graph resource.
+- Identify the [throttling limits](throttling-limits.md) that apply for each Microsoft Graph resource.
+- [Training module: Optimize network traffic with Microsoft Graph](/training/modules/optimize-network-traffic)

--- a/concepts/webhooks.md
+++ b/concepts/webhooks.md
@@ -16,11 +16,7 @@ The Microsoft Graph API uses a webhook mechanism to deliver change notifications
 
 After Microsoft Graph accepts the subscription request, it pushes change notifications to the URL specified in the subscription. The app then takes action according to its business logic. For example, it fetches more data, updates its cache and views, and so on.
 
-
 > [!VIDEO https://www.youtube-nocookie.com/embed/rC1bunenaq4]
- 
-> [!div class="nextstepaction"]
-> [Training module: Use change notifications and track changes with Microsoft Graph](/training/modules/msgraph-changenotifications-trackchanges)
 
 By default, change notifications do not contain resource data, other than the `id`. If the app requires resource data, it can make calls to Microsoft Graph APIs to get the full resource. This article uses the **user** resource as an example for working with change notifications.
 


### PR DESCRIPTION
While docs accounts for almost 50% of referrer traffic, it accounts for near 0% of training module completion rate.
This change will allow me maintain only the training module links in the "See also" and TOC - and help us investigate correlation between docs and training modules, especially on the completion rates of training modules.