### PR TITLE
Add rbac roles to domain api docs v1

### DIFF
--- a/api-reference/v1.0/api/domain-delete.md
+++ b/api-reference/v1.0/api/domain-delete.md
@@ -28,6 +28,12 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/domain-forcedelete.md
+++ b/api-reference/v1.0/api/domain-forcedelete.md
@@ -39,6 +39,12 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/domain-get.md
+++ b/api-reference/v1.0/api/domain-get.md
@@ -24,6 +24,48 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.Read.All, Domain.ReadWrite.All, Directory.Read.All  |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* User Administrator
+* Helpdesk Administrator
+* Service Support Administrator
+* Billing Administrator
+* Mailbox Administrator
+* Partner Tier1 Support
+* Partner Tier2 Support
+* Directory Readers
+* Directory Writers
+* AdHoc License Administrator
+* Application Administrator
+* Security Reader
+* Security Administrator
+* Privileged Role Administrator
+* Cloud Application Administrator
+* Customer LockBox Access Approver
+* Dynamics 365 Administrator
+* Power BI Administrator
+* Azure Information Protection Administrator
+* Desktop Analytics Administrator
+* License Administrator
+* Microsoft Managed Desktop Administrator
+* Authentication Administrator
+* Privileged Authentication Administrator
+* Teams Communications Administrator
+* Teams Communications Support Engineer
+* Teams Communications Support Specialist
+* Teams Administrator
+* Insights Administrator
+* Compliance Data Administrator
+* Security Operator
+* Kaizala Administrator
+* Global Reader
+* Volume Licensing Business Center User
+* Volume Licensing Service Center User
+* Modern Commerce User
+* Microsoft Store for Business User
+* Directory Reviewer
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/domain-list-domainnamereferences.md
+++ b/api-reference/v1.0/api/domain-list-domainnamereferences.md
@@ -24,6 +24,13 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.Read.All, Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+* Global Reader
+
 [!INCLUDE [limited-info](../../includes/limited-info.md)]
 
 ## HTTP request

--- a/api-reference/v1.0/api/domain-list-verificationdnsrecords.md
+++ b/api-reference/v1.0/api/domain-list-verificationdnsrecords.md
@@ -28,6 +28,13 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.Read.All, Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+* Global Reader
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/domain-list.md
+++ b/api-reference/v1.0/api/domain-list.md
@@ -22,6 +22,52 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.Read.All, Domain.ReadWrite.All, Directory.Read.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* User Administrator
+* Helpdesk Administrator
+* Service Support Administrator
+* Billing Administrator
+* Mailbox Administrator
+* Partner Tier1 Support
+* Partner Tier2 Support
+* Directory Readers
+* Directory Writers
+* AdHoc License Administrator
+* Application Administrator
+* Security Reader
+* Security Administrator
+* Privileged Role Administrator
+* Cloud Application Administrator
+* Customer LockBox Access Approver
+* Dynamics 365 Administrator
+* Power BI Administrator
+* Azure Information Protection Administrator
+* Desktop Analytics Administrator
+* License Administrator
+* Microsoft Managed Desktop Administrator
+* Privileged Authentication Administrator
+* Teams Communications Administrator
+* Teams Communications Support Engineer
+* Authentication Administrator
+* Teams Communications Support Specialist
+* Teams Administrator
+* Insights Administrator
+* Compliance Data Administrator
+* Security Operator
+* Kaizala Administrator
+* Global Reader
+* Volume Licensing Business Center User
+* Volume Licensing Service Center User
+* Modern Commerce User
+* Microsoft Store for Business User
+* Directory Reviewer
+* Domain Name Administrator
+* Users
+* Guest User
+* Restricted Guest User
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/domain-post-domains.md
+++ b/api-reference/v1.0/api/domain-post-domains.md
@@ -26,6 +26,12 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->

--- a/api-reference/v1.0/api/domain-update.md
+++ b/api-reference/v1.0/api/domain-update.md
@@ -27,6 +27,14 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+* Security Administrator
+* External Identity Provider Administrator
+
 ## HTTP request
 <!-- { "blockType": "ignored" } -->
 ```http

--- a/api-reference/v1.0/api/domain-verify.md
+++ b/api-reference/v1.0/api/domain-verify.md
@@ -27,6 +27,12 @@ One of the following permissions is required to call this API. To learn more, in
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | Domain.ReadWrite.All |
 
+The work or school account needs to belong to one of the following roles:
+
+* Global Administrator
+* Domain Name Administrator
+* Partner Tier2 Support
+
 ## HTTP request
 
 <!-- { "blockType": "ignored" } -->


### PR DESCRIPTION
Update RBAC Roles for the following apis in domains

1. Delete domain
2. Force delete domain
3. Get domain
4. List domainNameReferences
5. List verificationDnsRecords
6. List domains
7. Create domain
8. Update domain
9. Verify domain