### PR TITLE
Fixes Planner Roster typo and toc label

### DIFF
--- a/api-reference/beta/api/plannerroster-post-members.md
+++ b/api-reference/beta/api/plannerroster-post-members.md
@@ -46,7 +46,7 @@ The following table shows the properties that are required when you create the [
 
 |Property|Type|Description|
 |:---|:---|:---|
-|userId|String|Identifier of the .|
+|userId|String|Identifier of the user.|
 |tenantId|String|Identifier of the tenant the user belongs to. Optional. Currently roster members cannot be from different tenants.|
 |roles|String collection|Additional roles assigned to the user. Optional. Currently there are no additional roles available for users.|
 

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -16199,6 +16199,8 @@ items:
           href: api/plannerroster-get.md
         - name: Delete roster
           href: api/plannerroster-delete.md
+        - name: Get roster's member
+          href: api/plannerrostermember-get.md
         - name: List roster's members
           href: api/plannerroster-list-members.md
         - name: Add a member to roster


### PR DESCRIPTION
Noticed a typo in the add Planner Roster member docs.
Also noticed that the `get` page for Planner Roster members was not included in the toc.