### PR TITLE
Update connecting-external-content-api-limits.md

### DIFF
--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -15,7 +15,7 @@ This article describes implementation and operational limits for Microsoft Graph
 
 | Limit type | Limit |
 | ---------- | ----- |
-| [Connection](/graph/api/resources/externalconnectors-externalconnection) resources per Microsoft 365 tenant | 30 for search, 15 for compliance |
+| [Connection](/graph/api/resources/externalconnectors-externalconnection) resources per Microsoft 365 tenant | 30 |
 | [Items](/graph/api/resources/externalconnectors-externalitem) per connection | 5,000,000 |
 | Connection byte size | 500 GB |
 | Items per tenant | 50,000,000 |


### PR DESCRIPTION
The connection limit is agnostic of experience. 30 is valid for both search and compliance scenarios. Hence removing the distinction.