### PR TITLE
Update Speller And Answer

### DIFF
--- a/api-reference/beta/resources/search-api-overview.md
+++ b/api-reference/beta/resources/search-api-overview.md
@@ -190,7 +190,7 @@ The search API has the following limitations:
 
 | Entity Type |acronym     |bookmark     |message     | chatMessage| drive       | driveItem  | event      |externalItem | list       | listItem   | person     |qna     | site       |
 |-------------|------------|------------|-------------|------------|------------|-------------|------------|------------|------------|------------|------------|------------|------------|
-|  acronym    |     True   |     -      |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
+|  acronym    |     True   |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     True   |     -      |
 |  bookmark    |     -      |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
 |  message    |     -      |     -      |     True   |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
 | chatMessage |     -      |     -      |     -      |     True   |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |

--- a/api-reference/beta/resources/search-api-overview.md
+++ b/api-reference/beta/resources/search-api-overview.md
@@ -191,7 +191,7 @@ The search API has the following limitations:
 | Entity Type |acronym     |bookmark     |message     | chatMessage| drive       | driveItem  | event      |externalItem | list       | listItem   | person     |qna     | site       |
 |-------------|------------|------------|-------------|------------|------------|-------------|------------|------------|------------|------------|------------|------------|------------|
 |  acronym    |     True   |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     True   |     -      |
-|  bookmark    |     -      |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
+|  bookmark    |     True   |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     True   |     -      |
 |  message    |     -      |     -      |     True   |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
 | chatMessage |     -      |     -      |     -      |     True   |      -      |       -    |      -     |       -     |      -     |       -    |      -     |     -      |     -      |
 |    drive    |     -      |     -      |     -      |     -      |      True   |     True   |    -       |   True      |   True     |    True    |      -     |     -      |  True      |
@@ -201,7 +201,7 @@ The search API has the following limitations:
 |   list      |     -      |     -      |     -      |     -      |      True   |     True   |    -       |   True      |   True     |    True    |      -     |     -      |  True      |
 |  listItem   |     -      |     -      |     -      |     -      |      True   |     True   |    -       |   True      |   True     |    True    |      -     |     -      |  True      |
 |   person    |     -      |     -      |     -      |     -      |      -      |       -    |    -       |       -     |      -     |    -       |     True   |     -      |     -      |
-|  qna    |     -      |     -      |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |  True      |     -      |
+|  qna    |     True   |     True   |     -      |     -      |      -      |       -    |      -     |       -     |      -     |       -    |      -     |  True      |     -      |
 |    site     |     -      |     -      |     -      |     -      |      True   |     True   |    -       |   True      |   True     |    True    |      -     |     -      |  True      |
 
 - The **contentSource** property, which defines the connection to use, is only applicable when **entityType** is specified as `externalItem`.

--- a/concepts/search-concept-acronym.md
+++ b/concepts/search-concept-acronym.md
@@ -78,8 +78,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation, and pagination are not supported for acronym searches.
-- Combination search can only support in bookmark, qna and acronym. 
-
+- Combination search with non-Answer entityTypes (i.e. driveItem, list) is not supported. Only combination search with the other Answer entityTypes bookmarks, qna and acronym is supported.
 ## Next steps
 
 - [Use the Microsoft Search API to query data](/graph/api/resources/search-api-overview)

--- a/concepts/search-concept-acronym.md
+++ b/concepts/search-concept-acronym.md
@@ -78,7 +78,8 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation, and pagination are not supported for acronym searches.
-- Combination search with non-Answer entityTypes (i.e. driveItem, list) is not supported. Only combination search with the other Answer entityTypes bookmarks, qna and acronym is supported.
+- Combination searches with non-answer entity types (for example, driveItem, list) are not supported. 
+
 ## Next steps
 
 - [Use the Microsoft Search API to query data](/graph/api/resources/search-api-overview)

--- a/concepts/search-concept-acronym.md
+++ b/concepts/search-concept-acronym.md
@@ -78,7 +78,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation, and pagination are not supported for acronym searches.
-- Combination search with other entity types is not supported.
+- Combination search can only support in bookmark, qna and acronym. 
 
 ## Next steps
 

--- a/concepts/search-concept-bookmark.md
+++ b/concepts/search-concept-bookmark.md
@@ -77,7 +77,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation and pagination are not supported for bookmark searches.
-- Combination search can only support in bookmark, qna and acronym. 
+- Combination search with non-Answer entityTypes (i.e. driveItem, list) is not supported. Only combination search with the other Answer entityTypes bookmarks, qna and acronym is supported.
 
 ## Next steps
 

--- a/concepts/search-concept-bookmark.md
+++ b/concepts/search-concept-bookmark.md
@@ -77,7 +77,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation and pagination are not supported for bookmark searches.
-- Combination search with other entity types is not supported. 
+- Combination search can only support in bookmark, qna and acronym. 
 
 ## Next steps
 

--- a/concepts/search-concept-qna.md
+++ b/concepts/search-concept-qna.md
@@ -75,8 +75,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation, and pagination are not supported for [qna]((/graph/api/resources/search-qna) searches.
-- Combination search with other entity types is not supported. 
-- Markdown is currently not supported for the **qna** description. Instead, use plain text.
+- Combination search can only support in bookmark, qna and acronym. 
 
 ## Next steps
 

--- a/concepts/search-concept-qna.md
+++ b/concepts/search-concept-qna.md
@@ -75,7 +75,7 @@ Content-type: application/json
 ## Known issues
 
 - Sorting, aggregation, and pagination are not supported for [qna]((/graph/api/resources/search-qna) searches.
-- Combination search can only support in bookmark, qna and acronym. 
+- Combination search with non-Answer entityTypes (i.e. driveItem, list) is not supported. Only combination search with the other Answer entityTypes bookmarks, qna and acronym is supported.
 
 ## Next steps
 

--- a/concepts/search-concept-speller.md
+++ b/concepts/search-concept-speller.md
@@ -18,6 +18,8 @@ The priority of spelling modification is higher than spelling suggestion if they
 
 If speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, speller suggestion can be returned in the response.
 
+If speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, then results in the response can still contain the speller suggestion for the original query with the typo. This is by design since it is part of the feature to provide the spelling suggestion if spelling modification is enabled.
+
 All the user query strings should be the same to enable spelling corrections for searches of multiple entities.
 
 ## Example 1: Request spelling suggestions

--- a/concepts/search-concept-speller.md
+++ b/concepts/search-concept-speller.md
@@ -16,6 +16,8 @@ You can use the Microsoft Search API in Microsoft Graph to request spelling corr
 
 The priority of spelling modification is higher than spelling suggestion if they are both enabled.
 
+If speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, speller suggestion can be returned in the response.
+
 All the user query strings should be the same to enable spelling corrections for searches of multiple entities.
 
 ## Example 1: Request spelling suggestions

--- a/concepts/search-concept-speller.md
+++ b/concepts/search-concept-speller.md
@@ -16,9 +16,7 @@ You can use the Microsoft Search API in Microsoft Graph to request spelling corr
 
 The priority of spelling modification is higher than spelling suggestion if they are both enabled.
 
-If speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, speller suggestion can be returned in the response.
-
-If speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, then results in the response can still contain the speller suggestion for the original query with the typo. This is by design since it is part of the feature to provide the spelling suggestion if spelling modification is enabled.
+If speller suggestion is disabled while speller modification is enabled, then results can still contain the speller suggestion for the original query with the typo. This is by design since feature provides the spelling suggestion by default if spelling modification is enabled
 
 All the user query strings should be the same to enable spelling corrections for searches of multiple entities.
 

--- a/concepts/search-concept-speller.md
+++ b/concepts/search-concept-speller.md
@@ -16,7 +16,7 @@ You can use the Microsoft Search API in Microsoft Graph to request spelling corr
 
 The priority of spelling modification is higher than spelling suggestion if they are both enabled.
 
-If speller suggestion is disabled while speller modification is enabled, then results can still contain the speller suggestion for the original query with the typo. This is by design since feature provides the spelling suggestion by default if spelling modification is enabled
+If speller suggestion is disabled while speller modification is enabled, results can still contain the speller suggestion for the original query with the typo. This is by design, because the feature provides the spelling suggestion by default if spelling modification is enabled.
 
 All the user query strings should be the same to enable spelling corrections for searches of multiple entities.
 


### PR DESCRIPTION
1. update speller doc that if speller suggestion is disabled while speller modification is enabled, and there're results back in the search response for the original query with typo, speller suggestion can be returned in the response.
2. remove raw markdown description is not support
3. update answer doc that multiple answer search is supported