### PR TITLE
Adds aad user manager remove page

### DIFF
--- a/api-reference/beta/api/user-delete-manager.md
+++ b/api-reference/beta/api/user-delete-manager.md
@@ -2,7 +2,7 @@
 title: "Remove manager"
 description: "Remove a user's manager."
 ms.localizationpriority: medium
-author: "milanholemans"
+author: "yyuank"
 ms.prod: "users"
 doc_type: apiPageType
 ---
@@ -52,20 +52,18 @@ If successful, this method returns `204 No Content` response code. It does not r
 
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "remove_manager"
 }-->
 ```http
-DELETE https://graph.microsoft.com/v1.0/users/{id}/manager/$ref
+DELETE https://graph.microsoft.com/beta/users/{id}/manager/$ref
 ```
-
----
 
 ##### Response
 
 The following is an example of the response.
+
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/beta/api/user-delete-manager.md
+++ b/api-reference/beta/api/user-delete-manager.md
@@ -1,0 +1,86 @@
+---
+title: "Remove manager"
+description: "Remove a user's manager."
+ms.localizationpriority: medium
+author: "milanholemans"
+ms.prod: "users"
+doc_type: apiPageType
+---
+
+# Remove manager
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Remove a user's manager.
+
+## Permissions
+
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | User.ReadWrite.All, Directory.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | User.ReadWrite.All, Directory.ReadWrite.All |
+
+## HTTP request
+
+<!-- { "blockType": "ignored" } -->
+```http
+DELETE /users/{id}/manager/$ref
+```
+
+## Request headers
+
+| Header       | Value |
+|:---------------|:----------|
+| Authorization  | Bearer {token}. Required. |
+
+## Request body
+
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns `204 No Content` response code. It does not return anything in the response body.
+
+## Example
+
+##### Request
+
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "remove_manager"
+}-->
+```http
+DELETE https://graph.microsoft.com/v1.0/users/{id}/manager/$ref
+```
+
+---
+
+##### Response
+
+The following is an example of the response.
+<!-- {
+  "blockType": "response"
+} -->
+```http
+HTTP/1.1 204 No Content
+```
+
+<!-- uuid: 9ee9eec2-7e4b-4ef1-9856-8bf2d382888a
+2023-02-23 22:41:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "Remove a user's manager",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": "",
+  "suppressions": [
+  ]
+}-->

--- a/api-reference/beta/resources/user.md
+++ b/api-reference/beta/resources/user.md
@@ -115,6 +115,7 @@ This resource supports:
 | **Org hierarchy** |||
 | [Assign manager](../api/user-post-manager.md) | None | Assign a user's manager. |
 | [Get manager](../api/user-list-manager.md) | [directoryObject](directoryobject.md) | Get the user or contact that is this user's manager from the manager navigation property. |
+| [Remove manager](../api/user-delete-manager.md) | None | Remove the manager of a user. |
 | [List directReports](../api/user-list-directreports.md) | [directoryObject](directoryobject.md) collection | Get the users and contacts that report to the user from the directReports navigation property. |
 | **Outlook settings** |||
 | [Create Outlook category](../api/outlookuser-post-mastercategories.md) | [outlookCategory](outlookcategory.md) | Create an outlookCategory object in the user's master list of categories. |

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -519,6 +519,8 @@ items:
           href: api/user-list-manager.md
         - name: List direct reports
           href: api/user-list-directreports.md
+        - name: Remove manager
+          href: api/user-delete-manager.md
       - name: Outlook settings
         items:
         - name: Mailbox settings

--- a/api-reference/v1.0/api/user-delete-manager.md
+++ b/api-reference/v1.0/api/user-delete-manager.md
@@ -1,0 +1,84 @@
+---
+title: "Remove manager"
+description: "Remove a user's manager."
+ms.localizationpriority: medium
+author: "milanholemans"
+ms.prod: "users"
+doc_type: apiPageType
+---
+
+# Remove manager
+
+Namespace: microsoft.graph
+
+Remove a user's manager.
+
+## Permissions
+
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+|Permission type      | Permissions (from least to most privileged)              |
+|:--------------------|:---------------------------------------------------------|
+|Delegated (work or school account) | User.ReadWrite.All, Directory.ReadWrite.All    |
+|Delegated (personal Microsoft account) | Not supported.    |
+|Application | User.ReadWrite.All, Directory.ReadWrite.All |
+
+## HTTP request
+
+<!-- { "blockType": "ignored" } -->
+```http
+DELETE /users/{id}/manager/$ref
+```
+
+## Request headers
+
+| Header       | Value |
+|:---------------|:----------|
+| Authorization  | Bearer {token}. Required. |
+
+## Request body
+
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns `204 No Content` response code. It does not return anything in the response body.
+
+## Example
+
+##### Request
+
+The following is an example of the request.
+
+# [HTTP](#tab/http)
+<!-- {
+  "blockType": "request",
+  "name": "remove_manager"
+}-->
+```http
+DELETE https://graph.microsoft.com/v1.0/users/{id}/manager/$ref
+```
+
+---
+
+##### Response
+
+The following is an example of the response.
+<!-- {
+  "blockType": "response"
+} -->
+```http
+HTTP/1.1 204 No Content
+```
+
+<!-- uuid: 7ac5b390-b3bf-11ed-afa1-0242ac120002
+2023-02-23 22:41:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "Remove a user's manager",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": "",
+  "suppressions": [
+  ]
+}-->

--- a/api-reference/v1.0/api/user-delete-manager.md
+++ b/api-reference/v1.0/api/user-delete-manager.md
@@ -2,7 +2,7 @@
 title: "Remove manager"
 description: "Remove a user's manager."
 ms.localizationpriority: medium
-author: "milanholemans"
+author: "yyuank"
 ms.prod: "users"
 doc_type: apiPageType
 ---
@@ -50,7 +50,6 @@ If successful, this method returns `204 No Content` response code. It does not r
 
 The following is an example of the request.
 
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "remove_manager"
@@ -59,11 +58,10 @@ The following is an example of the request.
 DELETE https://graph.microsoft.com/v1.0/users/{id}/manager/$ref
 ```
 
----
-
 ##### Response
 
 The following is an example of the response.
+
 <!-- {
   "blockType": "response"
 } -->

--- a/api-reference/v1.0/resources/user.md
+++ b/api-reference/v1.0/resources/user.md
@@ -97,6 +97,7 @@ This resource supports:
 | **Org hierarchy** |  |  |
 | [Assign manager](../api/user-post-manager.md) | [directoryObject](directoryobject.md) | Assign a user or an organizational contact as this user's manager. |
 | [Get manager](../api/user-list-manager.md) | [directoryObject](directoryobject.md) | Get the user or organizational contact that is this user's manager from the manager navigation property. |
+| [Remove manager](../api/user-delete-manager.md) | None | Remove the manager of a user. |
 | [List directReports](../api/user-list-directreports.md) | [directoryObject](directoryobject.md) collection | Get the users and contacts that report to the user from the directReports navigation property. |
 | **Outlook settings** |  |  |
 | [Create Outlook category](../api/outlookuser-post-mastercategories.md) | [outlookCategory](outlookcategory.md) | Create an outlookCategory object in the user's master list of categories. |

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -477,6 +477,8 @@ items:
           href: api/user-list-manager.md
         - name: Assign manager
           href: api/user-post-manager.md
+        - name: Remove manager
+          href: api/user-delete-manager.md
       - name: Outlook settings
         items:
         - name: Mailbox settings


### PR DESCRIPTION
Noticed there is a documentation page missing on how to remove the manager of a AAD user.