### PR TITLE
Updated guidance on 40001 error resolution

### DIFF
--- a/concepts/onenote-error-codes.md
+++ b/concepts/onenote-error-codes.md
@@ -387,7 +387,7 @@ There is a required parameter missing.
 The user or application does not have the correct permissions.
 
 ### 40001
-The request doesn't contain a valid OAuth token. See [Notes permissions](permissions-reference.md#notes-permissions).
+Your request could not be authenticated. Common causes for this are an invalid OAuth token (see [Notes permissions](permissions-reference.md#notes-permissions)) and/or your account is missing a valid email.
 
 ### 40002
 The user doesn't have permission to write to the requested location.


### PR DESCRIPTION
Updated guidance on 40001 error to cover failures due to missing support for lightweight accounts