### PR TITLE
Adding recipients parameter to createLink

### DIFF
--- a/api-reference/v1.0/api/driveitem-createlink.md
+++ b/api-reference/v1.0/api/driveitem-createlink.md
@@ -52,7 +52,7 @@ The request should be a JSON object with the following properties.
 | **expirationDateTime** | string | A String with format of yyyy-MM-ddTHH:mm:ssZ of DateTime indicates the expiration time of the permission. |
 | **retainInheritedPermissions** |  Boolean          | Optional. If `true` (default), any existing inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all existing permissions are removed when sharing for the first time.  |
 | **scope** | string | Optional. The scope of link to create. Either `anonymous`, `organization`, or `users`. |
-| **retainInheritedPermissions** |  Boolean                       | If `true`, any current inherited permissions are retained on the shared item when sharing this item for the first time. If `false`, all current permissions are removed when sharing for the first time. The default value is `true`. Optional. |
+|**recipients**| [driveRecipient](../resources/driverecipient.md) collection | Optional. A collection of recipients who will receive access to the sharing link. |
 
 ### Link types
 


### PR DESCRIPTION
Adding the recipients parameter to createLink on v1.0, which has already been present on createLink's beta endpoint for long enough for 1.0 graduation.