### PR TITLE
Moves changelog validation script

### DIFF
--- a/.github/workflows/changelog-validation.yml
+++ b/.github/workflows/changelog-validation.yml
@@ -16,7 +16,6 @@ jobs:
           INPUT_SCHEMA: /changelog/Changelog.Schema.json
           INPUT_JSONS: /changelog/Manual.NonWorkloadChanges.json,/changelog/Microsoft.AAD.Reporting.json,/changelog/Microsoft.Analytics.json,/changelog/Microsoft.BitLocker.json,/changelog/Microsoft.CloudManagedDesktop.json,/changelog/Microsoft.Compliance.Ediscovery.json,/changelog/Microsoft.DirectoryServices.json,/changelog/Microsoft.EducationAssignment.json,/changelog/Microsoft.Excel.json,/changelog/Microsoft.Exchange.json,/changelog/Microsoft.FileServices.json,/changelog/Microsoft.HybridAuthentication.json,/changelog/Microsoft.IdentityGovernance.AccessReviews.json,/changelog/Microsoft.IdentityProtectionServices.json,/changelog/Microsoft.Intune.json,/changelog/Microsoft.MicrosoftSearch.json,/changelog/Microsoft.NAV.json,/changelog/Microsoft.O365Reporting.json,/changelog/Microsoft.Office.Tasks.json,/changelog/Microsoft.OneNote.json,/changelog/Microsoft.PrintService.json,/changelog/Microsoft.Search.json,/changelog/Microsoft.SharePoint.json,/changelog/Microsoft.Skype.Calling.json,/changelog/Microsoft.SubscriptionServices.json,/changelog/Microsoft.Teams.Core.json,/changelog/Microsoft.Teams.GraphSvc.json,/changelog/Microsoft.ThreatAssessment.json,/changelog/Microsoft.Todo.json,/changelog/Microsoft.People.json
       - name: Validate Schema with Script
-        working-directory: ./changelog
         run: |
-          ./validate-json.ps1
+          ./validate-changelog-json.ps1
         shell: pwsh

--- a/validate-changelog-json.ps1
+++ b/validate-changelog-json.ps1
@@ -1,8 +1,9 @@
 $schemaFileName = "Changelog.Schema.json"
-$schema = Get-Content $schemaFileName  | Out-String
+$schemaPath = "changelog/" + $schemaFileName
+$schema = Get-Content $schemaPath  | Out-String
 
 $err = "";
-Get-ChildItem -Filter "*.json" | Where-Object { $schemaFileName -notcontains $_.Name} | ForEach-Object { 
+Get-ChildItem -Filter "changelog/*.json" | Where-Object { $schemaFileName -notcontains $_.Name} | ForEach-Object { 
     
     # first test only json parsing to not mixup error
     $json = Get-Content $_ | Out-String -ErrorAction:SilentlyContinue


### PR DESCRIPTION
Moves changelog validation script to avoid conflict with sync process. 

Can also simply be run locally from the root folder as

```shell
.\validate-changelog-json.ps1
```