### PR TITLE
Update domain-update.md

### DIFF
--- a/api-reference/v1.0/api/domain-update.md
+++ b/api-reference/v1.0/api/domain-update.md
@@ -80,6 +80,8 @@ Content-type: application/json
   ]
 }
 ```
+> **Important:**
+> Domain authentication type must be ‘Managed’ to become default domain.
 
 # [C#](#tab/csharp)
 [!INCLUDE [sample-code](../includes/snippets/csharp/update-domain-csharp-snippets.md)]


### PR DESCRIPTION
PATCH payload shown in documentation could lead to confusion when customers try on federated domains. So adding a note that auth type should be managed to become default domains.