### PR TITLE
Removed reports section as we fixed the only issue

### DIFF
--- a/concepts/known-issues.md
+++ b/concepts/known-issues.md
@@ -396,30 +396,6 @@ The following limitations apply to query parameters:
   - When using the `$count=true` query string when querying against directory objects, the `@odata.count` property will be present only in the first page of the paged data.
 - Query parameters specified in a request might fail silently. This can be true for unsupported query parameters as well as for unsupported combinations of query parameters.
 
-## Reports
-
-### License check errors for Azure AD activity reports
-
-When you have a valid Azure AD Premium license and call the [directoryAudit](/graph/api/resources/directoryaudit), [signIn](/graph/api/resources/signin), or [provisioning](/graph/api/resources/provisioningobjectsummary) Azure AD activity reports APIs, you might still encounter an error message similar to the following:
-
-```json
-{
-    "error": {
-        "code": "Authentication_RequestFromNonPremiumTenantOrB2CTenant",
-        "message": "Neither tenant is B2C or tenant doesn't have premium license",
-        "innerError": {
-            "date": "2021-09-02T17:15:30",
-            "request-id": "73badd94-c0ca-4b09-a3e6-20c1f5f9a307",
-            "client-request-id": "73badd94-c0ca-4b09-a3e6-20c1f5f9a307"
-        }
-    }
-}
-```
-
-This error might also occur when retrieving the **signInActivity** property of the [user](/graph/api/resources/user?view=graph-rest-beta&preserve-view=true) resource; for example, `https://graph.microsoft.com/beta/users?$select=signInActivity`.
-
-This error is due to intermittent license check failures, which we are working to fix. As a temporary workaround, add the **Directory.Read.All** permission. This temporary workaround will not be required when the issue is resolved.
-
 ## Sites and lists (SharePoint)
 
 ### Follow/unfollow sites is not in sync with SharePoint following


### PR DESCRIPTION
The reports section included an issue describing intermittent Azure AD license check failures. This has been fixed for some time. Since it was the only known issue in that section, removed it