### PR TITLE
Fix odata type annotation namespace in documentation examples

### DIFF
--- a/api-reference/beta/api/chatmessage-delta.md
+++ b/api-reference/beta/api/chatmessage-delta.md
@@ -181,7 +181,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -225,7 +225,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -327,7 +327,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -369,7 +369,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -471,7 +471,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -513,7 +513,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -616,7 +616,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",

--- a/api-reference/beta/api/chatmessage-get.md
+++ b/api-reference/beta/api/chatmessage-get.md
@@ -154,7 +154,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -248,7 +248,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -348,7 +348,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",

--- a/api-reference/beta/api/chatmessage-list-replies.md
+++ b/api-reference/beta/api/chatmessage-list-replies.md
@@ -135,7 +135,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -177,7 +177,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -219,7 +219,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",

--- a/api-reference/beta/api/chatmessage-post-replies.md
+++ b/api-reference/beta/api/chatmessage-post-replies.md
@@ -141,7 +141,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser"
@@ -253,7 +253,7 @@ HTTP/1.1 200 OK
       "application":null,
       "device":null,
       "user":{
-         "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+         "@odata.type": "#microsoft.graph.teamworkUserIdentity",
          "id":"8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca",
          "displayName":"Joh Doe",
          "userIdentityType":"aadUser",

--- a/api-reference/beta/api/chatmessage-post.md
+++ b/api-reference/beta/api/chatmessage-post.md
@@ -165,7 +165,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -285,7 +285,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -310,7 +310,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "ef1c916a-3135-4417-ba27-8eb7bd084193",
                     "displayName": "Jane Smith",
                     "userIdentityType": "aadUser"
@@ -421,7 +421,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -547,7 +547,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -676,7 +676,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -803,7 +803,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -935,7 +935,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -1075,7 +1075,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -1210,7 +1210,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -1350,7 +1350,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",

--- a/api-reference/v1.0/api/chatmessage-delta.md
+++ b/api-reference/v1.0/api/chatmessage-delta.md
@@ -180,7 +180,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -222,7 +222,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -322,7 +322,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -363,7 +363,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -463,7 +463,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -504,7 +504,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -605,7 +605,7 @@ Content-type: application/json
                 "device": null,
                 "conversation": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",

--- a/api-reference/v1.0/api/chatmessage-get.md
+++ b/api-reference/v1.0/api/chatmessage-get.md
@@ -151,7 +151,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -244,7 +244,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -342,7 +342,7 @@ Content-type: application/json
         "device": null,
         "conversation": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",

--- a/api-reference/v1.0/api/chatmessage-list-replies.md
+++ b/api-reference/v1.0/api/chatmessage-list-replies.md
@@ -133,7 +133,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -173,7 +173,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",
@@ -213,7 +213,7 @@ Content-type: application/json
                 "application": null,
                 "device": null,
                 "user": {
-                    "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+                    "@odata.type": "#microsoft.graph.teamworkUserIdentity",
                     "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
                     "displayName": "Robin Kline",
                     "userIdentityType": "aadUser",

--- a/api-reference/v1.0/api/chatmessage-post-replies.md
+++ b/api-reference/v1.0/api/chatmessage-post-replies.md
@@ -139,7 +139,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -250,7 +250,7 @@ HTTP/1.1 200 OK
       "application":null,
       "device":null,
       "user":{
-         "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+         "@odata.type": "#microsoft.graph.teamworkUserIdentity",
          "id":"8c0a1a67-50ce-4114-bb6c-da9c5dbcf6ca",
          "displayName":"Joh Doe",
          "userIdentityType":"aadUser",

--- a/api-reference/v1.0/api/chatmessage-post.md
+++ b/api-reference/v1.0/api/chatmessage-post.md
@@ -163,7 +163,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -281,7 +281,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -414,7 +414,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -538,7 +538,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -664,7 +664,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -790,7 +790,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -920,7 +920,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",
@@ -1058,7 +1058,7 @@ Content-type: application/json
         "application": null,
         "device": null,
         "user": {
-            "@odata.type": "#Microsoft.Teams.GraphSvc.teamworkUserIdentity",
+            "@odata.type": "#microsoft.graph.teamworkUserIdentity",
             "id": "8ea0e38b-efb3-4757-924a-5f94061cf8c2",
             "displayName": "Robin Kline",
             "userIdentityType": "aadUser",


### PR DESCRIPTION
Fix odata type annotation namespace in documentation examples for teamwork user identity.
Updating from "Microsoft.Teams.GraphSvc" to "microsoft.graph" 