### PR TITLE
Update event-delta.md

### DIFF
--- a/api-reference/v1.0/api/event-delta.md
+++ b/api-reference/v1.0/api/event-delta.md
@@ -83,23 +83,15 @@ in the response body to 2.
 To track changes in a calendar view, you would make one or more **delta** function calls, with 
 appropriate [state tokens](/graph/delta-query-overview), to get the set of incremental changes since the last delta query. 
 
-
-# [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
   "name": "event_delta"
 }-->
 ```msgraph-interactive
 GET https://graph.microsoft.com/v1.0/me/calendarView/delta?startdatetime={start_datetime}&enddatetime={end_datetime}
-
 Prefer: odata.maxpagesize=2
+
 ```
-
-# [JavaScript](#tab/javascript)
-[!INCLUDE [sample-code](../includes/snippets/javascript/event-delta-javascript-snippets.md)]
-[!INCLUDE [sdk-documentation](../includes/snippets/snippets-sdk-documentation-link.md)]
-
----
 
 ##### Response
 If the request is successful, the response would include a state token, which is either a _skipToken_ 


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/microsoft-graph-devx-api/issues/1499

Snippet generation is failing due to invalid syntact in http block. The request url and header should not have an empty space/line between them,

Resetting this for now for generation next week. 