### PR TITLE
fixing new issues with duplicate names

### DIFF
--- a/api-reference/beta/api/industrydata-industrydataconnector-update.md
+++ b/api-reference/beta/api/industrydata-industrydataconnector-update.md
@@ -64,7 +64,7 @@ The following is an example of a request.
 
 <!-- {
   "blockType": "request",
-  "name": "update_azuredatalakeconnector",
+  "name": "update_industrydataconnector_beta_e1",
   "sampleKeys": ["51dca0a0-85f6-4478-f526-08daddab2271"]
 }
 -->

--- a/api-reference/beta/api/webpart-get.md
+++ b/api-reference/beta/api/webpart-get.md
@@ -67,7 +67,7 @@ The following is an example of a request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
-  "name": "get_webpart"
+  "name": "get_webpart_beta_e1"
 }
 -->
 
@@ -134,7 +134,7 @@ With `select` statement, you can retrieve selected webpart metadata in a request
 
 <!-- {
   "blockType": "request",
-  "name": "get_webpart"
+  "name": "get_webpart_beta_e2"
 }
 -->
 

--- a/api-reference/v1.0/api/conditionalaccessroot-list-authenticationcontextclassreferences.md
+++ b/api-reference/v1.0/api/conditionalaccessroot-list-authenticationcontextclassreferences.md
@@ -60,7 +60,7 @@ The following is an example of the request.
 # [HTTP](#tab/http)
 <!-- {
   "blockType": "request",
-  "name": "get_authenticationcontextclassreference"
+  "name": "list_authenticationcontextclassreference_v1_e1"
 }-->
 
 ```msgraph-interactive


### PR DESCRIPTION
Some examples have duplicate names. Fixing these manually while we implement the check in API Doctor.