### PR TITLE
Removing useForSignIn property that isn't in the schema

### DIFF
--- a/api-reference/beta/resources/authenticationmethodtarget.md
+++ b/api-reference/beta/resources/authenticationmethodtarget.md
@@ -41,7 +41,6 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.authenticationMethodTarget",
   "id": "String (identifier)",
   "targetType": "String",
-  "isRegistrationRequired": "Boolean",
-  "useForSignIn": "Boolean"
+  "isRegistrationRequired": "Boolean"
 }
 ```

--- a/api-reference/beta/resources/authenticationmethodtarget.md
+++ b/api-reference/beta/resources/authenticationmethodtarget.md
@@ -22,7 +22,6 @@ A collection of groups that are enabled to use an authentication method as part 
 |id|String|Object identifier of an Azure AD user or group.|
 |isRegistrationRequired|Boolean|Determines if the user is enforced to register the authentication method.|
 |targetType|authenticationMethodTargetType| Possible values are: `group`, and `unknownFutureValue`. From December 2022, targeting individual users using `user` is no longer recommended. Existing targets will remain but we recommend to move the individual users to a targeted group.|
-|useForSignIn|Boolean|Determines if the authentication method can be used to sign in to Azure AD.|
 
 ## Relationships
 None.

--- a/api-reference/v1.0/resources/authenticationmethodtarget.md
+++ b/api-reference/v1.0/resources/authenticationmethodtarget.md
@@ -20,7 +20,6 @@ A collection of groups that are enabled to use an authentication method as part 
 |id|String|Object Id of an Azure AD user or group.|
 |isRegistrationRequired|Boolean|Determines if the user is enforced to register the authentication method.|
 |targetType|authenticationMethodTargetType|Possible values are: `user`, `group`.|
-|useForSignIn|Boolean|Determines if the authentication method can be used to sign in to Azure AD.|
 
 ## Relationships
 None.

--- a/api-reference/v1.0/resources/authenticationmethodtarget.md
+++ b/api-reference/v1.0/resources/authenticationmethodtarget.md
@@ -39,7 +39,6 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.authenticationMethodTarget",
   "id": "String (identifier)",
   "isRegistrationRequired": "Boolean",
-  "targetType": "String",
-  "useForSignIn": "Boolean"
+  "targetType": "String"
 }
 ```


### PR DESCRIPTION
Remove property that is not in schema 'useForSignIn'

cc @Lauragra - A changelog isn't required in this case because property wasn't really deprecated. The docs just went ahead of the schema.