### PR TITLE
Docs update for enabling Private/shared channel change notifications 

### DIFF
--- a/concepts/teams-changenotifications-team-and-channel.md
+++ b/concepts/teams-changenotifications-team-and-channel.md
@@ -115,7 +115,9 @@ Content-Type: application/json
 ## Subscribe to changes in any channel of a particular team
 
 
-To get change notifications for all changes related to any channel in a particular team, subscribe to `/teams/{team-id}/channels`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification. Change notifications for private channels aren't supported in delegated context. In this case, a subscriber to this resource in delegated context will receive notifications only for standard channels under a particular team, not for private channels. Change notifications for shared channels aren't supported.
+To get change notifications for all changes related to any channel in a particular team, subscribe to `/teams/{team-id}/channels`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
+
+>**Note:** Change notifications for private & shared channels in delegated context are only supported in beta. This is not currently available for v1.0. In this case, a subscriber to this resource in delegated context will receive notifications only for standard channels under a particular team, not for private & shared channels.
 
 
 ### Permissions

--- a/concepts/teams-changenotifications-team-and-channel.md
+++ b/concepts/teams-changenotifications-team-and-channel.md
@@ -117,7 +117,7 @@ Content-Type: application/json
 
 To get change notifications for all changes related to any channel in a particular team, subscribe to `/teams/{team-id}/channels`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
 
->**Note:** Change notifications for private & shared channels in delegated context are only supported in beta. This is not currently available for v1.0. In this case, a subscriber to this resource in delegated context will receive notifications only for standard channels under a particular team, not for private & shared channels.
+>**Note:** Change notifications for private and shared channels in delegated context are only supported in beta. This is not currently available in v1.0. When you call the v1.0 endpoint, a subscriber to this resource in delegated context will receive notifications only for standard channels under a particular team, not for private and shared channels.
 
 
 ### Permissions

--- a/concepts/teams-changenotifications-teamMembership.md
+++ b/concepts/teams-changenotifications-teamMembership.md
@@ -110,7 +110,7 @@ Content-Type: application/json
 
 To get change notifications for membership changes in all the private & shared channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
 
->**Note:** Change notifications shared channels membership updates are only supported in beta. This is not currently available for v1.0. In this case, a subscriber to this resource in v1.0 context will receive notifications only for private channels under a particular team, not for private channels.
+>**Note:** This resource doesn't support delegated context in v1.0.
 
 [!INCLUDE [teams-model-A-and-B-disclaimer](../includes/teams-model-A-and-B-disclaimer.md)]
 

--- a/concepts/teams-changenotifications-teamMembership.md
+++ b/concepts/teams-changenotifications-teamMembership.md
@@ -106,9 +106,11 @@ Content-Type: application/json
 }
 ```
 
-## Subscribe to membership changes in all private channels of a particular team
+## Subscribe to membership changes in all private & shared channels of a particular team
 
-To get change notifications for membership changes in all private channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
+To get change notifications for membership changes in all the private & shared channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
+
+>**Note:** Change notifications shared channels membership updates are only supported in beta. This is not currently available for v1.0. In this case, a subscriber to this resource in v1.0 context will receive notifications only for private channels under a particular team, not for private channels.
 
 [!INCLUDE [teams-model-A-and-B-disclaimer](../includes/teams-model-A-and-B-disclaimer.md)]
 
@@ -116,7 +118,7 @@ To get change notifications for membership changes in all private channels in a 
 
 |Permission type      | Permissions (from least to most privileged)              |
 |:--------------------|:---------------------------------------------------------|
-|Delegated (work or school account) | Not supported. |
+|Delegated (work or school account) | ChannelMember.Read.All. |
 |Delegated (personal Microsoft account) | Not supported.    |
 |Application | ChannelMember.Read.All   |
 

--- a/concepts/teams-changenotifications-teamMembership.md
+++ b/concepts/teams-changenotifications-teamMembership.md
@@ -106,9 +106,9 @@ Content-Type: application/json
 }
 ```
 
-## Subscribe to membership changes in all private & shared channels of a particular team
+## Subscribe to membership changes in all private and shared channels of a particular team
 
-To get change notifications for membership changes in all the private & shared channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
+To get change notifications for membership changes in all the private and shared channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
 
 >**Note:** This resource doesn't support delegated context in v1.0.
 


### PR DESCRIPTION
Private/shared channel based notifications are not enabled. 
However, the delegated context is only supported in beta, not v1.0