### PR TITLE
Minor and typo fixes in attendancerecord.md and onlinemeeting.md.

### DIFF
--- a/api-reference/beta/resources/attendancerecord.md
+++ b/api-reference/beta/resources/attendancerecord.md
@@ -26,8 +26,8 @@ Contains information associated with an attendance record in a [meetingAttendanc
 | Property            | Type    | Description|
 |:--------------------|:--------|:-----------|
 | attendanceIntervals | [attendanceInterval](attendanceinterval.md) collection | List of time periods between joining and leaving a meeting. |
-| emailAddress | String | Email address of the user associated with this atttendance record. |
-| identity | [identity](identity.md) | Identity of the user associated with this atttendance record. The specific type will be one of the following derived types of [identity](identity.md), depending on the type of the user: [communicationsUserIdentity](communicationsUserIdentity.md), [azureCommunicationServicesUserIdentity](azureCommunicationServicesUserIdentity.md). |
+| emailAddress | String | Email address of the user associated with this attendance record. |
+| identity | [identity](identity.md) | Identity of the user associated with this attendance record. The specific type will be one of the following derived types of [identity](identity.md), depending on the type of the user: [communicationsUserIdentity](communicationsUserIdentity.md), [azureCommunicationServicesUserIdentity](azureCommunicationServicesUserIdentity.md). |
 | role | String | Role of the attendee. Possible values are: `None`, `Attendee`, `Presenter`, and `Organizer`.  |
 | registrantId | String | Unique identifier of a [meetingRegistrant](meetingregistrantbase.md). Presents when the participant has registered for the meeting. |
 | totalAttendanceInSeconds | Int32 | Total duration of the attendances in seconds. |

--- a/api-reference/v1.0/resources/attendancerecord.md
+++ b/api-reference/v1.0/resources/attendancerecord.md
@@ -24,8 +24,8 @@ Contains information associated with an attendance record in a [meetingAttendanc
 | Property            | Type    | Description|
 |:--------------------|:--------|:-----------|
 | attendanceIntervals | [attendanceInterval](attendanceinterval.md) collection | List of time periods between joining and leaving a meeting. |
-| emailAddress | String | Email address of the user associated with this atttendance record. |
-| identity | [identity](identity.md) | Identity of the user associated with this atttendance record. |
+| emailAddress | String | Email address of the user associated with this attendance record. |
+| identity | [identity](identity.md) | Identity of the user associated with this attendance record. |
 | role | String | Role of the attendee. Possible values are: `None`, `Attendee`, `Presenter`, and `Organizer`.  |
 | totalAttendanceInSeconds | Int32 | Total duration of the attendances in seconds. |
 

--- a/api-reference/v1.0/resources/onlinemeeting.md
+++ b/api-reference/v1.0/resources/onlinemeeting.md
@@ -32,7 +32,6 @@ Contains information about a meeting, including the URL used to join a meeting, 
 | allowedPresenters     | [onlineMeetingPresenters](#onlinemeetingpresenters-values)                       | Specifies who can be a presenter in a meeting. Possible values are listed in the following table.                          |
 | allowMeetingChat      | [meetingChatMode](#meetingchatmode-values) | Specifies the mode of meeting chat. |
 | allowTeamworkReactions | Boolean | Indicates whether Teams reactions are enabled for the meeting. |
-| allowedPresenters     | [onlineMeetingPresenters](#onlinemeetingpresenters-values)                       | Specifies who can be a presenter in a meeting. Possible values are listed in the following table.                          |
 | attendeeReport | Stream | The content stream of the attendee report of a [Microsoft Teams live event](/microsoftteams/teams-live-events/what-are-teams-live-events). Read-only. |
 | audioConferencing     | [audioConferencing](audioconferencing.md)     | The phone access (dial-in) information for an online meeting. Read-only.                                                   |
 | broadcastSettings              | [broadcastMeetingSettings](broadcastMeetingSettings.md)                      | Settings related to a live event.                                                                  |


### PR DESCRIPTION
- removed duplicated property allowedPresenters in onlinemeeting.md
- typo fix in attendancerecord.md