### PR TITLE
Update connecting-external-content-api-limits.md

### DIFF
--- a/concepts/connecting-external-content-api-limits.md
+++ b/concepts/connecting-external-content-api-limits.md
@@ -32,6 +32,7 @@ This article describes implementation and operational limits for Microsoft Graph
 | ---------- | ----- |
 | [External groups](/graph/api/resources/externalconnectors-externalgroup) per Microsoft 365 tenant | 100,000 | 
 | Requests allowed per second (requests/sec) in the group administration [throttling](#throttling) threshold | 1,000 |
+| [External groups](/graph/api/resources/externalconnectors-externalgroup) per user for search query | 10,000 | 
 
 ## Item ingestion
 


### PR DESCRIPTION
Added external group membership limits per users for search experience. Query will fail the queries from users with higher than 10000 groups memberships