### PR TITLE
Fix permissions in intune-devices-applepushnotificationcertificate-get.md

### DIFF
--- a/api-reference/v1.0/api/intune-devices-applepushnotificationcertificate-get.md
+++ b/api-reference/v1.0/api/intune-devices-applepushnotificationcertificate-get.md
@@ -20,9 +20,9 @@ One of the following permissions is required to call this API. To learn more, in
 
 |Permission type|Permissions (from least to most privileged)|
 |:---|:---|
-|Delegated (work or school account)|DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
+|Delegated (work or school account)|DeviceManagementServiceConfig.Read.All, DeviceManagementServiceConfig.ReadWrite.All|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|DeviceManagementServiceConfig.ReadWrite.All, DeviceManagementManagedDevices.Read.All|
+|Application|DeviceManagementServiceConfig.Read.All, DeviceManagementServiceConfig.ReadWrite.All|
 
 ## HTTP Request
 <!-- {


### PR DESCRIPTION
The permissions listed for "Get applePushNotificationCertificate" appear to be wrong and I believe these are the correct permissions from least to most privileged