### PR TITLE
Fix doc bug #17962

### DIFF
--- a/concepts/webhooks-with-resource-data.md
+++ b/concepts/webhooks-with-resource-data.md
@@ -567,7 +567,7 @@ byte[] iv = new byte[vectorSize];
 Array.Copy(decryptedSymmetricKey, iv, vectorSize);
 aesProvider.IV = iv;
 
-byte[] encryptedPayload = Convert.FromBase64String(<value from dataKey property>);
+byte[] encryptedPayload = Convert.FromBase64String(<value from data property>);
 
 string decryptedResourceData;
 // Decrypt the resource data content.


### PR DESCRIPTION
Sample incorrectly suggests loading dataKey property, when it is the data property that should be included at this stage.

As it was written, you'd just be decrypting the encryption key again instead of decrypting the payload itself.

https://github.com/microsoftgraph/microsoft-graph-docs/issues/17962