### PR TITLE
Update query-parameters.md

### DIFF
--- a/concepts/query-parameters.md
+++ b/concepts/query-parameters.md
@@ -360,7 +360,7 @@ GET https://graph.microsoft.com/v1.0/me/drive/root?$expand=children($select=id,n
 > [!NOTE]
 > + Not all relationships and resources support the `$expand` query parameter. For example, you can expand the **directReports**, **manager**, and **memberOf** relationships on a user, but you cannot expand its **events**, **messages**, or **photo** relationships. Not all resources or relationships support using `$select` on expanded items. 
 > 
-> + With Azure AD resources that derive from [directoryObject](/graph/api/resources/directoryobject), like [user](/graph/api/resources/user) and [group](/graph/api/resources/group), `$expand` typically returns a maximum of 20 items for the expanded relationship and has no [@odata.nextLink](./paging.md). See more [known issues](known-issues.md#query-parameters).
+> + With Azure AD resources that derive from [directoryObject](/graph/api/resources/directoryobject), like [user](/graph/api/resources/user) and [group](/graph/api/resources/group), `$expand` typically returns a maximum of 100 items for the expanded relationship and has no [@odata.nextLink](./paging.md). See more [known issues](known-issues.md#query-parameters).
 >
 > + `$expand` is not currently supported with [advanced queries](/graph/aad-advanced-queries).
 


### PR DESCRIPTION
Max page size is 100, corrected in the linked doc as well.  https://learn.microsoft.com/en-us/graph/known-issues#some-limitations-apply-to-query-parameters 

$expand:
For directory objects, returns a maximum of 100 objects.