### PR TITLE
Best practices: remove mention of x-ms-ags-diagnostic

### DIFF
--- a/concepts/best-practices-concept.md
+++ b/concepts/best-practices-concept.md
@@ -152,4 +152,4 @@ To ensure reliability and facilitate support for your application:
 - Open connections to all advertised DNS answers.
 - Generate a unique GUID and send it on each Microsoft Graph REST request. This will help Microsoft investigate any errors more easily if you need to report an issue with Microsoft Graph.
   - On every request to Microsoft Graph, generate a unique GUID, send it in the `client-request-id` HTTP request header, and also log it in your application's logs.
-  - Always log the `request-id`, `Date` and `x-ms-ags-diagnostic` from the HTTP response headers. These, together with the `client-request-id`, are required when reporting issues in [Microsoft Q&A](/answers/products/m365#microsoft-graph) or to Microsoft Support.
+  - Always log the `request-id` and `Date` from the HTTP response headers. These, together with the `client-request-id`, are required when reporting issues in [Microsoft Q&A](/answers/products/m365#microsoft-graph) or to Microsoft Support.


### PR DESCRIPTION
Remove mention of `x-ms-ags-diagnostic`:
 - It was never intended for customers to log.
 - It is not required nor helpful to diagnose customers MSGraph requests.