### PR TITLE
Update attachment-get.md

### DIFF
--- a/api-reference/beta/api/attachment-get.md
+++ b/api-reference/beta/api/attachment-get.md
@@ -40,6 +40,9 @@ For an item attachment that is a [contact](../resources/contact.md), [event](../
 
 Attempting to get the `$value` of a reference attachment returns HTTP 405.
 
+> [!NOTE]
+> When certain files are requested, MIME can encode the byte stream output in the response and provide a link to download the file as an email attachment.
+> 
 ## Permissions
 
 Depending on the resource (**event**, **message**, **outlookTask**, or **post**) that the attachment is attached to and the permission type (delegated or application) requested, the permission specified in the following table is the least privileged required to call this API. To learn more, including [taking caution](/graph/auth/auth-concepts#best-practices-for-requesting-permissions) before choosing more privileged permissions, search for the following permissions in [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/attachment-get.md
+++ b/api-reference/v1.0/api/attachment-get.md
@@ -36,7 +36,7 @@ For an item attachment that is a [contact](../resources/contact.md), [event](../
 
 Attempting to get the `$value` of a reference attachment returns HTTP 405.
 > [!NOTE]
-> Depending on the requested files MIME type the byte stream output maybe in the response via link to email attachment.
+> When certain files are requested, MIME can encode the byte stream output in the response and provide a link to download the file as an email attachment.
 > 
 ## Permissions
 

--- a/api-reference/v1.0/api/attachment-get.md
+++ b/api-reference/v1.0/api/attachment-get.md
@@ -35,7 +35,9 @@ For an item attachment that is a [contact](../resources/contact.md), [event](../
 | **message** | MIME format. See [example](#example-9-get-the-mime-raw-contents-of-a-meeting-invitation-item-attachment-on-a-message). |
 
 Attempting to get the `$value` of a reference attachment returns HTTP 405.
-
+> [!NOTE]
+> Depending on the requested files MIME type the byte stream output maybe in the response via link to email attachment.
+> 
 ## Permissions
 
 Depending on the resource (**event**, **message**, or **post**) that the attachment is attached to and the permission type (delegated or application) requested, the permission specified in the following table is the least privileged required to call this API. To learn more, including [taking caution](/graph/auth/auth-concepts#best-practices-for-requesting-permissions) before choosing more privileged permissions, search for the following permissions in [Permissions](/graph/permissions-reference).


### PR DESCRIPTION
Due to a user request via ticket system. This note was added for the scenario of when getting an email attachment with a link to email attachment (*.pdf, *.doc, *.png) in HTTPS response output.