### PR TITLE
Corrected reference to Facets example

### DIFF
--- a/api-reference/beta/resources/onedrive.md
+++ b/api-reference/beta/resources/onedrive.md
@@ -50,7 +50,7 @@ Most of the interaction with files occurs through interaction with **DriveItem**
 **Drive** and **DriveItem** resources expose data in three different ways:
 
 * _Properties_ (like **id** and **name**) expose simple values (strings, numbers, Booleans).
-* _Facets_ (like **file** and **photo**) expose complex values. The presence of **file** or **folder** facets indicates behaviors and properties of a **DriveItem**.
+* _Facets_ (like **file** and **image**) expose complex values. The presence of **file** or **folder** facets indicates behaviors and properties of a **DriveItem**.
 * _References_ (like **children** and **thumbnails**) point to collections of other resources.
 
 ## Commonly accessed resources

--- a/api-reference/v1.0/resources/onedrive.md
+++ b/api-reference/v1.0/resources/onedrive.md
@@ -50,7 +50,7 @@ The following is an example of a DriveItem resource:
 **Drive** and **DriveItem** resources expose data in three different ways:
 
 * _Properties_ (like **id** and **name**) expose simple values (strings, numbers, Booleans).
-* _Facets_ (like **file** and **photo**) expose complex values. The presence of **file** or **folder** facets indicates behaviors and properties of a **DriveItem**.
+* _Facets_ (like **file** and **image**) expose complex values. The presence of **file** or **folder** facets indicates behaviors and properties of a **DriveItem**.
 * _References_ (like **children** and **thumbnails**) point to collections of other resources.
 
 ## Commonly accessed resources


### PR DESCRIPTION
The Facets description under the example of a Graph query response for a DriveItem resource currently references "file and photo". Photo does not appear in the example Graph query response, it should say "image", which is one of the facets listed in the example.