### PR TITLE
App-only support enabled for PIM for groups policy endpoints

### DIFF
--- a/api-reference/beta/api/policyroot-list-rolemanagementpolicies.md
+++ b/api-reference/beta/api/policyroot-list-rolemanagementpolicies.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/policyroot-list-rolemanagementpolicyassignments.md
+++ b/api-reference/beta/api/policyroot-list-rolemanagementpolicyassignments.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicy-get.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicy-get.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicy-list-rules.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicy-list-rules.md
@@ -38,7 +38,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicy-update.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicy-update.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicyassignment-get.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicyassignment-get.md
@@ -31,7 +31,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicyrule-get.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicyrule-get.md
@@ -34,7 +34,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.Read.AzureADGroup, RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 

--- a/api-reference/beta/api/unifiedrolemanagementpolicyrule-update.md
+++ b/api-reference/beta/api/unifiedrolemanagementpolicyrule-update.md
@@ -38,7 +38,7 @@ One of the following permissions is required to call this API. To learn more, in
 |:---|:---|
 |Delegated (work or school account)|RoleManagementPolicy.ReadWrite.AzureADGroup|
 |Delegated (personal Microsoft account)|Not supported.|
-|Application|Not supported.|
+|Application|RoleManagementPolicy.ReadWrite.AzureADGroup|
 
 ## HTTP request
 


### PR DESCRIPTION
Update documentations on PIM for groups policy endpoints to support application permissions.

This docs PR is tracked via this work item: https://dev.azure.com/msft-skilling/Content/_workitems/edit/98819
