### PR TITLE
Update identity set for v1.0

### DIFF
--- a/api-reference/v1.0/resources/identityset.md
+++ b/api-reference/v1.0/resources/identityset.md
@@ -34,7 +34,7 @@ Represents a keyed collection of [identity](identity.md) resources. It is used t
 The following is a JSON representation of the resource.
 
 <!-- { "blockType": "resource", "@odata.type": "microsoft.graph.identitySet",
-       "optionalProperties": ["user", "application", "device"],
+       "optionalProperties": ["application", "applicationInstance", "conversation", "conversationIdentityType", "encrypted", "onPremises", "guest", "phone", "user", "device"],
        "openType": true } -->
 ```json
 {

--- a/api-reference/v1.0/resources/identityset.md
+++ b/api-reference/v1.0/resources/identityset.md
@@ -17,9 +17,17 @@ Represents a keyed collection of [identity](identity.md) resources. It is used t
 
 | Property    | Type                    | Description                                            |
 |:------------|:------------------------|:-------------------------------------------------------|
-| application | [identity](identity.md) | Optional. The application associated with this action. |
-| device      | [identity](identity.md) | Optional. The device associated with this action.      |
-| user        | [identity](identity.md) | Optional. The user associated with this action.        |
+| application | [identity](identity.md) | Optional. The application associated with this action.  |
+| applicationInstance | [identity](identity.md) | Optional. The application instance associated with this action.  |
+| conversation| [identity](identity.md) | Optional. The team or channel associated with this action.       |
+| conversationIdentityType| [identity](identity.md) | Optional. Indicates whether the **conversation** property identifies a team or channel.|
+| device      | [identity](identity.md) | Optional. The device associated with this action.       |
+| encrypted       | [identity](identity.md) | Optional. The encrypted identity associated with this action. |
+| onPremises       | [identity](identity.md) | Optional. The on-premises identity associated with this action. |
+| guest       | [identity](identity.md) | Optional. The guest identity associated with this action. |
+| phone       | [identity](identity.md) | Optional. The phone number associated with this action. |
+| user        | [identity](identity.md) | Optional. The user associated with this action.         |
+
 
 ## JSON representation
 
@@ -31,7 +39,14 @@ The following is a JSON representation of the resource.
 ```json
 {
   "application": {"@odata.type": "microsoft.graph.identity"},
+  "applicationInstance": {"@odata.type": "microsoft.graph.identity"},
+  "conversation": {"@odata.type": "microsoft.graph.identity"},
+  "conversationIdentityType": {"@odata.type": "microsoft.graph.identity"},
   "device": {"@odata.type": "microsoft.graph.identity"},
+  "encrypted": {"@odata.type": "microsoft.graph.identity"},
+  "onPremises": {"@odata.type": "microsoft.graph.identity"},
+  "guest": {"@odata.type": "microsoft.graph.identity"},
+  "phone": {"@odata.type": "microsoft.graph.identity"},
   "user": {"@odata.type": "microsoft.graph.identity"}
 }
 ```


### PR DESCRIPTION
NICE would like to have a clear documentation with examples on different identity types, so that they can filter out the participant reporting on their side. Without filtering applications/bots in the report, it causes confusion and compliance issues. 

They pointed out this doc, which does not have clear description of different identity types and the example JSON has additional types (for example encrypted) that is not listed in the types. 