### PR TITLE
Added documentation for recentPrinterShares API

### DIFF
--- a/api-reference/v1.0/api/print-list-recentprintershares.md
+++ b/api-reference/v1.0/api/print-list-recentprintershares.md
@@ -85,6 +85,7 @@ Content-type: application/json
         }
   ]
 }
+```
 
 <!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
 2023-06-12 14:57:30 UTC -->
@@ -95,4 +96,3 @@ Content-type: application/json
   "section": "documentation",
   "tocPath": ""
 }-->
-```

--- a/api-reference/v1.0/api/print-list-recentprintershares.md
+++ b/api-reference/v1.0/api/print-list-recentprintershares.md
@@ -71,6 +71,7 @@ The following is an example of the response.
 ```http
 HTTP/1.1 200 OK
 Content-type: application/json
+
 {
   "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('74157b7f-9fa7-41b6-9ee9-97c382ba1189')/print/recentPrinterShares",
     "value": [
@@ -84,4 +85,14 @@ Content-type: application/json
         }
   ]
 }
+
+<!-- uuid: 8fcb5dbc-d5aa-4681-8e31-b001d5168d79
+2023-06-12 14:57:30 UTC -->
+<!-- {
+  "type": "#page.annotation",
+  "description": "List printer shares",
+  "keywords": "",
+  "section": "documentation",
+  "tocPath": ""
+}-->
 ```

--- a/api-reference/v1.0/api/print-list-recentprintershares.md
+++ b/api-reference/v1.0/api/print-list-recentprintershares.md
@@ -1,0 +1,87 @@
+---
+title: "List recentPrinterShares"
+description: "Get a list of printer shares recently used by the signed-in user."
+author: "venkatnagula"
+ms.localizationpriority: medium
+ms.prod: "cloud-printing"
+doc_type: apiPageType
+---
+
+# List recentPrinterShares
+
+Namespace: microsoft.graph
+
+Get a list of [printerShares](../resources/printershare.md) recently used by the signed-in user.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+To use the Universal Print service, the user or app's tenant must have an active Universal Print subscription, in addition to the permissions listed in the following table.
+
+|Permission type | Permissions (from least to most privileged) |
+|:---------------|:--------------------------------------------|
+|Delegated (work or school account)| PrinterShare.ReadBasic.All, PrinterShare.Read.All, PrinterShare.ReadWrite.All |
+|Delegated (personal Microsoft account)|Not supported.|
+|Application|Not supported.|
+
+## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /me/print/recentPrinterShares
+```
+
+## Optional query parameters
+This method supports some of the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+
+### Exceptions
+The following operators are not supported: `$count`, `$orderby`, and `$search`.
+
+## Request headers
+| Name      |Description|
+|:----------|:----------|
+| Authorization | Bearer {token}. Required. |
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+If successful, this method returns a `200 OK` response code and a collection of [printerShare](../resources/printershare.md) objects in the response body.
+
+## Example
+### Request
+The following is an example of the request.
+
+<!-- {
+  "blockType": "request",
+  "name": "get_recentprintershares"
+}-->
+```msgraph-interactive
+GET https://graph.microsoft.com/v1.0/me/print/recentPrinterShares
+```
+
+### Response
+The following is an example of the response.
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "microsoft.graph.printerShare",
+  "isCollection": true
+} -->
+```http
+HTTP/1.1 200 OK
+Content-type: application/json
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users('74157b7f-9fa7-41b6-9ee9-97c382ba1189')/print/recentPrinterShares",
+    "value": [
+        {
+            "id": "04ccb929-9e71-4aef-9f83-36e4a7fd53e3",
+            "name": "4c1cf503-efde-48fb-9db7-12c159da0ab3_FTPrinter",
+            "displayName": "4c1cf503-efde-48fb-9db7-12c159da0ab3_FTPrinter",
+            "viewPoint": {
+                "lastUsedDateTime": "2023-06-12T05:11:07Z"
+            }
+        }
+  ]
+}
+```

--- a/api-reference/v1.0/resources/printershare.md
+++ b/api-reference/v1.0/resources/printershare.md
@@ -45,6 +45,7 @@ Inherits from [printerBase](../resources/printerbase.md).
 |manufacturer|String|The manufacturer reported by the printer associated with this printer share. Inherited from [printerBase](../resources/printerbase.md). Read-only.|
 |model|String|The model name reported by the printer associated with this printer share. Inherited from [printerBase](../resources/printerbase.md). Read-only.|
 |status|[printerStatus](printerstatus.md)|The processing status, including any errors, of the printer associated with this printer share.Inherited from [printerBase](../resources/printerbase.md). Read-only.|
+|viewPoint|[printerShareViewpoint](../resources/printershareviewpoint.md)|Additional data for a printer share as viewed by the signed-in user.|
 
 
 ## Relationships
@@ -85,7 +86,8 @@ The following is a JSON representation of the resource.
     "@odata.type": "microsoft.graph.printerStatus"
   },
   "allowAllUsers": "Boolean",
-  "createdDateTime": "String (timestamp)"
+  "createdDateTime": "String (timestamp)",
+  "viewPoint": {"@odata.type": "microsoft.graph.printerShareViewpoint"}
 }
 ```
 

--- a/api-reference/v1.0/resources/printershareviewpoint.md
+++ b/api-reference/v1.0/resources/printershareviewpoint.md
@@ -11,9 +11,7 @@ doc_type: resourcePageType
 
 Namespace: microsoft.graph
 
-Represents additional data for a printer share as viewed by the signed-in user.
-
-**TODO: Add Description**
+Represents user-specific data for a printer share as viewed by the signed-in user.
 
 ## Properties
 |Property|Type|Description|

--- a/api-reference/v1.0/resources/printershareviewpoint.md
+++ b/api-reference/v1.0/resources/printershareviewpoint.md
@@ -16,7 +16,7 @@ Represents user-specific data for a printer share as viewed by the signed-in use
 ## Properties
 |Property|Type|Description|
 |:---|:---|:---|
-|lastUsedDateTime|DateTimeOffset|Date and time when the printer was last used by the signed-in user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`.|
+|lastUsedDateTime|DateTimeOffset|Date and time when the printer was last used by the signed-in user. The timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`.|
 
 ## Relationships
 None.

--- a/api-reference/v1.0/resources/printershareviewpoint.md
+++ b/api-reference/v1.0/resources/printershareviewpoint.md
@@ -1,0 +1,38 @@
+---
+title: "printerShareViewpoint resource type"
+description: "Represents additional data for a printer share as viewed by the signed-in user."
+author: "venkatnagula"
+ms.localizationpriority: medium
+ms.prod: "cloud-printing"
+doc_type: resourcePageType
+---
+
+# printerShareViewpoint resource type
+
+Namespace: microsoft.graph
+
+Represents additional data for a printer share as viewed by the signed-in user.
+
+**TODO: Add Description**
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|lastUsedDateTime|DateTimeOffset|Date and time when the printer was last used by the signed-in user. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is `2014-01-01T00:00:00Z`.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.printerShareViewpoint"
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.printerShareViewpoint",
+  "lastUsedDateTime": "String (timestamp)"
+}
+```

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -1698,6 +1698,8 @@ items:
             href: api/printershare-post-allowedgroups.md
           - name: Delete allowed group
             href: api/printershare-delete-allowedgroup.md
+          - name: List recent shares
+            href: api/print-list-recentprintershares.md
         - name: Print task definition
           href: resources/printtaskdefinition.md
           items:

--- a/changelog/Microsoft.PrintService.json
+++ b/changelog/Microsoft.PrintService.json
@@ -3,6 +3,40 @@
     {
       "ChangeList": [
         {
+          "Id": "9818e810-caf7-4afe-8a53-b7eaf302cabe",
+          "ApiChange": "Resource",
+          "ChangedApiName": "printerShareViewpoint",
+          "ChangeType": "Addition",
+          "Description": "Added the [printerShareViewpoint](https://learn.microsoft.com/en-us/graph/api/resources/printerShareViewpoint?view=graph-rest-1.0) resource type.",
+          "Target": "printerShareViewpoint"
+        },
+        {
+          "Id": "9818e810-caf7-4afe-8a53-b7eaf302cabe",
+          "ApiChange": "Method",
+          "ChangedApiName": "GET",
+          "ChangeType": "Addition",
+          "Description": "Added the [List recentPrinterShares](https://learn.microsoft.com/en-us/graph/api/print-list-recentprintershares?view=graph-rest-1.0) method to the [printerShare](https://learn.microsoft.com/graph/api/resources/printerShare?view=graph-rest-1.0) resource.",
+          "Target": "printerShare"
+        },
+        {
+          "Id": "9818e810-caf7-4afe-8a53-b7eaf302cabe",
+          "ApiChange": "Property",
+          "ChangedApiName": "viewPoint",
+          "ChangeType": "Addition",
+          "Description": "Added the `viewPoint` property to the [printerShare](https://learn.microsoft.com/en-us/graph/api/resources/printerShare?view=graph-rest-1.0) resource.",
+          "Target": "printerShare"
+        }
+      ],
+      "Id": "9818e810-caf7-4afe-8a53-b7eaf302cabe",
+      "Cloud": "Prod",
+      "Version": "v1.0",
+      "CreatedDateTime": "2023-06-13T01:56:49.6329133Z",
+      "WorkloadArea": "Devices and apps",
+      "SubArea": "Cloud printing"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "ed1e8b28-8fc9-4e8d-b90b-322b07ad18dd",
           "ApiChange": "Property",
           "ChangedApiName": "displayName",
@@ -72,7 +106,7 @@
     },
     {
       "ChangeList": [
-                {
+        {
           "Id": "2531d4d1-1572-4ce3-0654-61cf63abow90",
           "ApiChange": "Enum type",
           "ChangedApiName": "printerStatus",


### PR DESCRIPTION
The purpose of this PR is enable an API to allow signed user to fetch their recentprintershares in V1.0. currently it is rolled out to Beta and stable. 

  Moving it to V1.0 now. Below the links 

API.md : https://microsoftgraph.visualstudio.com/onboarding/_git/onboarding/pullrequest/9441  
PR to CSDL : https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/8264884
Beta documentation PR: https://github.com/microsoftgraph/microsoft-graph-docs/pull/16144
