### PR TITLE
Add printUsage & dailyprintusage to api-reference

### DIFF
--- a/api-reference/beta/api/reportroot-list-dailyprintusage.md
+++ b/api-reference/beta/api/reportroot-list-dailyprintusage.md
@@ -1,0 +1,94 @@
+---
+title: "List printUsage"
+description: "Retrieve a list of daily print usage summaries."
+author: "JuliusShanMS"
+ms.localizationpriority: medium
+ms.prod: cloud-printing
+doc_type: apiPageType
+---
+
+# List printUsage
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Retrieve a list of daily print usage summaries.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+In addition to the following permissions, the user's tenant must have an active Universal Print subscription.
+
+|Permission type | Permissions (from least to most privileged) |
+|:---------------|:--------------------------------------------|
+|Delegated (work or school account)| Reports.Read.All |
+|Delegated (personal Microsoft account)|Not Supported.|
+|Application|Not Supported.|
+
+## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /reports/dailyPrintUsage
+```
+
+## Optional query parameters
+This method supports some of the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+
+## Request headers
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required.|
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a collection of [printUsage](../resources/printusage.md) objects in the response body.
+
+## Examples
+
+### Request
+The following is an example of a request.
+<!-- {
+  "blockType": "request",
+  "name": "list_printusage"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/reports/dailyPrintUsage
+```
+
+
+### Response
+The following is an example of the response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "Collection(microsoft.graph.printUsage)"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "value": [
+    {
+      "id": "Oct-09-2022-dailyPrintUsageSummary",
+      "usageDate": "2022-10-10",
+      "completedBlackAndWhiteJobCount": 45,
+      "completedColorJobCount": 15,
+      "incompleteJobCount": 2,
+      "completedJobCount": 60,
+      "pageCount": 105,
+      "colorPageCount": 15,
+      "blackAndWhitePageCount": 90,
+      "mediaSheetCount": 105,
+      "doubleSidedSheetCount": 45,
+      "singleSidedSheetCount": 15
+    }
+  ]
+}
+```

--- a/api-reference/beta/resources/printusage.md
+++ b/api-reference/beta/resources/printusage.md
@@ -1,0 +1,65 @@
+---
+title: printUsage resource type
+description: Describes print activity during a specified time period (usageDate).
+author: JuliusShanMS
+ms.localizationpriority: medium
+ms.prod: cloud-printing
+doc_type: resourcePageType
+---
+
+# printUsage resource type
+
+Namespace: microsoft.graph
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Describes print activity during a specified time period (usageDate).
+
+## Methods
+
+| Method       | Return Type | Description |
+|:-------------|:------------|:------------|
+| [List (daily)](../api/reportroot-list-dailyprintusage.md) | [printUsage](printusage.md) | Get a list of daily print usage summaries. |
+
+## Properties
+| Property     | Type        | Description |
+|:-------------|:------------|:------------|
+|id|String|The ID of this usage summary.|
+|usageDate|Date|The date associated with these statistics.|
+|completedBlackAndWhiteJobCount|Int64|The number of black and white print jobs completed on the associated date.|
+|completedColorJobCount|Int64|The number of color print jobs completed on the associated date.|
+|completedJobCount|Int64|The number of print jobs that were completed on the associated date.|
+|incompleteJobCount|Int64|The number of print jobs that were queued, but not completed, on the associated date.|
+|pageCount|Int64|The number of pages printed on the associated date.|
+|blackAndWhitePageCount|Int64|The number of black and white pages printed on the associated date.|
+|colorPageCount|Int64|The number of color pages printed on the associated date.|
+|mediaSheetCount|Int64|The number of media sheets printed on the associated date.|
+|doubleSidedSheetCount|Int64|The number of double-sided media sheets printed on the associated date.|
+|singleSidedSheetCount|Int64|The number of single-sided media sheets printed on the associated date.|
+
+
+## JSON representation
+
+The following is a JSON representation of the resource.
+
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.printUsage"
+}-->
+
+```json
+{
+    "id": "String (identifier)",
+    "usageDate": "String (timestamp)",
+    "completedBlackAndWhiteJobCount": 123456,
+    "completedColorJobCount": 123456,
+    "completedJobCount": 123456,
+    "incompleteJobCount": 123456,
+    "pageCount": 123456,
+    "blackAndWhitePageCount": 123456,
+    "colorPageCount": 123456
+    "mediaSheetCount": 123456,
+    "doubleSidedSheetCount": 123456,
+    "singleSidedSheetCount": 123456
+}
+```

--- a/api-reference/beta/toc.yml
+++ b/api-reference/beta/toc.yml
@@ -2102,6 +2102,8 @@ items:
               href: api/unifiedstoragequota-list-services.md
         - name: Reports
           items:
+          - name: List daily reports
+            href: api/reportroot-list-dailyprintusage.md
           - name: Organized by printer
             items:
             - name: Get

--- a/api-reference/v1.0/api/reportroot-list-dailyprintusage.md
+++ b/api-reference/v1.0/api/reportroot-list-dailyprintusage.md
@@ -1,0 +1,92 @@
+---
+title: "List printUsage"
+description: "Retrieve a list of daily print usage summaries."
+author: "JuliusShanMS"
+ms.localizationpriority: medium
+ms.prod: cloud-printing
+doc_type: apiPageType
+---
+
+# List printUsage
+Namespace: microsoft.graph
+
+Retrieve a list of daily print usage summaries.
+
+## Permissions
+One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).
+
+In addition to the following permissions, the user's tenant must have an active Universal Print subscription.
+
+|Permission type | Permissions (from least to most privileged) |
+|:---------------|:--------------------------------------------|
+|Delegated (work or school account)| Reports.Read.All |
+|Delegated (personal Microsoft account)|Not Supported.|
+|Application|Not Supported.|
+
+## HTTP request
+<!-- { "blockType": "ignored" } -->
+```http
+GET /reports/dailyPrintUsage
+```
+
+## Optional query parameters
+This method supports some of the OData query parameters to help customize the response. For general information, see [OData query parameters](/graph/query-parameters).
+
+## Request headers
+|Name|Description|
+|:---|:---|
+|Authorization|Bearer {token}. Required.|
+
+## Request body
+Do not supply a request body for this method.
+
+## Response
+
+If successful, this method returns a `200 OK` response code and a collection of [printUsage](../resources/printusage.md) objects in the response body.
+
+## Examples
+
+### Request
+The following is an example of a request.
+<!-- {
+  "blockType": "request",
+  "name": "list_printusage"
+}
+-->
+``` http
+GET https://graph.microsoft.com/beta/reports/dailyPrintUsage
+```
+
+
+### Response
+The following is an example of the response
+>**Note:** The response object shown here might be shortened for readability.
+<!-- {
+  "blockType": "response",
+  "truncated": true,
+  "@odata.type": "Collection(microsoft.graph.printUsage)"
+}
+-->
+``` http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "value": [
+    {
+      "id": "Oct-09-2022-dailyPrintUsageSummary",
+      "usageDate": "2022-10-10",
+      "completedBlackAndWhiteJobCount": 45,
+      "completedColorJobCount": 15,
+      "incompleteJobCount": 2,
+      "completedJobCount": 60,
+      "pageCount": 105,
+      "colorPageCount": 15,
+      "blackAndWhitePageCount": 90,
+      "mediaSheetCount": 105,
+      "doubleSidedSheetCount": 45,
+      "singleSidedSheetCount": 15
+    }
+  ]
+}
+```

--- a/api-reference/v1.0/resources/printusage.md
+++ b/api-reference/v1.0/resources/printusage.md
@@ -1,0 +1,63 @@
+---
+title: printUsage resource type
+description: Describes print activity during a specified time period (usageDate).
+author: JuliusShanMS
+ms.localizationpriority: medium
+ms.prod: cloud-printing
+doc_type: resourcePageType
+---
+
+# printUsage resource type
+
+Namespace: microsoft.graph
+
+Describes print activity during a specified time period (usageDate).
+
+## Methods
+
+| Method       | Return Type | Description |
+|:-------------|:------------|:------------|
+| [List (daily)](../api/reportroot-list-dailyprintusage.md) | [printUsage](printusage.md) | Get a list of daily print usage summaries. |
+
+## Properties
+| Property     | Type        | Description |
+|:-------------|:------------|:------------|
+|id|String|The ID of this usage summary.|
+|usageDate|Date|The date associated with these statistics.|
+|completedBlackAndWhiteJobCount|Int64|The number of black and white print jobs completed on the associated date.|
+|completedColorJobCount|Int64|The number of color print jobs completed on the associated date.|
+|completedJobCount|Int64|The number of print jobs that were completed on the associated date.|
+|incompleteJobCount|Int64|The number of print jobs that were queued, but not completed, on the associated date.|
+|pageCount|Int64|The number of pages printed on the associated date.|
+|blackAndWhitePageCount|Int64|The number of black and white pages printed on the associated date.|
+|colorPageCount|Int64|The number of color pages printed on the associated date.|
+|mediaSheetCount|Int64|The number of media sheets printed on the associated date.|
+|doubleSidedSheetCount|Int64|The number of double-sided media sheets printed on the associated date.|
+|singleSidedSheetCount|Int64|The number of single-sided media sheets printed on the associated date.|
+
+
+## JSON representation
+
+The following is a JSON representation of the resource.
+
+<!-- {
+  "blockType": "resource",
+  "@odata.type": "microsoft.graph.printUsage"
+}-->
+
+```json
+{
+    "id": "String (identifier)",
+    "usageDate": "String (timestamp)",
+    "completedBlackAndWhiteJobCount": 123456,
+    "completedColorJobCount": 123456,
+    "completedJobCount": 123456,
+    "incompleteJobCount": 123456,
+    "pageCount": 123456,
+    "blackAndWhitePageCount": 123456,
+    "colorPageCount": 123456
+    "mediaSheetCount": 123456,
+    "doubleSidedSheetCount": 123456,
+    "singleSidedSheetCount": 123456
+}
+```

--- a/api-reference/v1.0/toc.yml
+++ b/api-reference/v1.0/toc.yml
@@ -1721,6 +1721,8 @@ items:
             href: api/printtaskdefinition-update-task.md
         - name: Reports
           items:
+          - name: List daily reports
+            href: api/reportroot-list-dailyprintusage.md
           - name: Organized by printer
             items:
             - name: Get


### PR DESCRIPTION
Adds documentation for the printUsage resource type and for the dailyPrintUsage report for both beta and v1.0.

Note: had originally created a PR for updating beta docs, but merging it fell through. Hence creating a PR to add both beta and v1.0 now that beta has proven to be stable. 