### PR TITLE
Adding new properties to getPstnCalls

### DIFF
--- a/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
+++ b/api-reference/beta/api/callrecords-callrecord-getpstncalls.md
@@ -150,7 +150,11 @@ HTTP/1.1 200 OK
             "inventoryType": "Subscriber",
             "operator": "Microsoft",
             "callDurationSource": "microsoft",
-            "otherPartyCountryCode": "US"
+            "otherPartyCountryCode": "US",
+            "clientPublicIpV4Address": "99.76.33.16",
+            "clientPublicIpV6Address": "1234:fd2:5621:1:89::4500",
+            "clientLocalIpV4Address": "192.168.1.165",
+            "clientLocalIpV6Address": "2600:1700:1dca:8110::40"
         }
     ]
 }

--- a/api-reference/beta/resources/callrecords-pstncalllogrow.md
+++ b/api-reference/beta/resources/callrecords-pstncalllogrow.md
@@ -26,10 +26,10 @@ Represents a row of data in the public switched telephone network (PSTN) call lo
 |Property|Type|Description|
 |:---|:---|:---|
 |callDurationSource|microsoft.graph.callRecords.pstnCallDurationSource|The source of the call duration data. If the call uses a third-party telecommunications operator via the Operator Connect Program, the operator may provide their own call duration data. In this case, the property value is `operator`. Otherwise, the value is `microsoft`.|
-|callId|String|Call identifier. Not guaranteed to be unique.|
-|callType|String|Indicates whether the call was a PSTN outbound or inbound call and the type of call such as a call placed by a user or an audio conference.|
 |calleeNumber|String|Number of the user or bot who received the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
 |callerNumber|String|Number of the user or bot who made the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
+|callId|String|Call identifier. Not guaranteed to be unique.|
+|callType|String|Indicates whether the call was a PSTN outbound or inbound call and the type of call such as a call placed by a user or an audio conference.|
 |charge|Decimal|Amount of money or cost of the call that is charged to your account.|
 |clientLocalIpV4Address|String|Local IPv4 of the client that is retrieved from the operating system of the client.|
 |clientLocalIpV6Address|String|Local IPv6 of the client that is retrieved from the operating system of the client.|
@@ -73,10 +73,10 @@ The following is a JSON representation of the resource.
 {
   "@odata.type": "#microsoft.graph.callRecords.pstnCallLogRow",
   "callDurationSource": "String",
-  "callId": "String",
-  "callType": "String",
   "calleeNumber": "String",
   "callerNumber": "String",
+  "callId": "String",
+  "callType": "String",
   "charge": "Decimal",
   "clientLocalIpV4Address": "String",
   "clientLocalIpV6Address": "String",

--- a/api-reference/beta/resources/callrecords-pstncalllogrow.md
+++ b/api-reference/beta/resources/callrecords-pstncalllogrow.md
@@ -31,6 +31,10 @@ Represents a row of data in the public switched telephone network (PSTN) call lo
 |callId|String|Call identifier. Not guaranteed to be unique.|
 |callType|String|Indicates whether the call was a PSTN outbound or inbound call and the type of call such as a call placed by a user or an audio conference.|
 |charge|Decimal|Amount of money or cost of the call that is charged to your account.|
+|clientPublicIpV4Address|String|Public IPv4 of the client, can be used for determining the client's location.|
+|clientPublicIpV6Address|String|Public IPv6 of the client, can be used for determining the client's location.|
+|clientLocalIpV4Address|String|Local IPv4 of the client, retrieved from the client's operating system.|
+|clientLocalIpV6Address|String|Local IPv6 of the client, retrieved from the client's operating system.|
 |conferenceId|String|ID of the audio conference.|
 |connectionCharge|Decimal|Connection fee price.|
 |currency|String|Type of currency used to calculate the cost of the call ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).|
@@ -74,6 +78,10 @@ The following is a JSON representation of the resource.
   "callId": "String",
   "callType": "String",
   "charge": "Decimal",
+  "clientPublicIpV4Address": "String",
+  "clientPublicIpV6Address": "String",
+  "clientLocalIpV4Address": "String",
+  "clientLocalIpV6Address": "String",
   "conferenceId": "String",
   "connectionCharge": "Decimal",
   "currency": "String",

--- a/api-reference/beta/resources/callrecords-pstncalllogrow.md
+++ b/api-reference/beta/resources/callrecords-pstncalllogrow.md
@@ -26,15 +26,15 @@ Represents a row of data in the public switched telephone network (PSTN) call lo
 |Property|Type|Description|
 |:---|:---|:---|
 |callDurationSource|microsoft.graph.callRecords.pstnCallDurationSource|The source of the call duration data. If the call uses a third-party telecommunications operator via the Operator Connect Program, the operator may provide their own call duration data. In this case, the property value is `operator`. Otherwise, the value is `microsoft`.|
-|calleeNumber|String|Number of the user or bot who received the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
-|callerNumber|String|Number of the user or bot who made the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
 |callId|String|Call identifier. Not guaranteed to be unique.|
 |callType|String|Indicates whether the call was a PSTN outbound or inbound call and the type of call such as a call placed by a user or an audio conference.|
+|calleeNumber|String|Number of the user or bot who received the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
+|callerNumber|String|Number of the user or bot who made the call ([E.164](https://en.wikipedia.org/wiki/E.164)).|
 |charge|Decimal|Amount of money or cost of the call that is charged to your account.|
-|clientPublicIpV4Address|String|Public IPv4 of the client, can be used for determining the client's location.|
-|clientPublicIpV6Address|String|Public IPv6 of the client, can be used for determining the client's location.|
-|clientLocalIpV4Address|String|Local IPv4 of the client, retrieved from the client's operating system.|
-|clientLocalIpV6Address|String|Local IPv6 of the client, retrieved from the client's operating system.|
+|clientLocalIpV4Address|String|Local IPv4 of the client that is retrieved from the operating system of the client.|
+|clientLocalIpV6Address|String|Local IPv6 of the client that is retrieved from the operating system of the client.|
+|clientPublicIpV4Address|String|Public IPv4 of the client that can be used to determine the location of the client.|
+|clientPublicIpV6Address|String|Public IPv6 of the client that can be used to determine the location of the client.|
 |conferenceId|String|ID of the audio conference.|
 |connectionCharge|Decimal|Connection fee price.|
 |currency|String|Type of currency used to calculate the cost of the call ([ISO 4217](https://en.wikipedia.org/wiki/ISO_4217)).|
@@ -73,15 +73,15 @@ The following is a JSON representation of the resource.
 {
   "@odata.type": "#microsoft.graph.callRecords.pstnCallLogRow",
   "callDurationSource": "String",
-  "calleeNumber": "String",
-  "callerNumber": "String",
   "callId": "String",
   "callType": "String",
+  "calleeNumber": "String",
+  "callerNumber": "String",
   "charge": "Decimal",
-  "clientPublicIpV4Address": "String",
-  "clientPublicIpV6Address": "String",
   "clientLocalIpV4Address": "String",
   "clientLocalIpV6Address": "String",
+  "clientPublicIpV4Address": "String",
+  "clientPublicIpV6Address": "String",
   "conferenceId": "String",
   "connectionCharge": "Decimal",
   "currency": "String",

--- a/changelog/Microsoft.IC3.DataPlatform.json
+++ b/changelog/Microsoft.IC3.DataPlatform.json
@@ -38,7 +38,7 @@
             "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
             "Cloud": "Prod",
             "Version": "beta",
-            "CreatedDateTime": "2023-06-19T07:38:13.9482874Z",
+            "CreatedDateTime": "2023-06-27T07:38:13.9482874Z",
             "WorkloadArea": "Teamwork and communications",
             "SubArea": "Calls and online meetings"
         },

--- a/changelog/Microsoft.IC3.DataPlatform.json
+++ b/changelog/Microsoft.IC3.DataPlatform.json
@@ -2,6 +2,48 @@
     "changelog": [
         {
             "ChangeList": [
+              {
+                "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
+                "ApiChange": "Property",
+                "ChangedApiName": "clientLocalIpV4Address",
+                "ChangeType": "Addition",
+                "Description": "Added the `clientLocalIpV4Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Target": "pstnCallLogRow"
+              },
+              {
+                "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
+                "ApiChange": "Property",
+                "ChangedApiName": "clientLocalIpV6Address",
+                "ChangeType": "Addition",
+                "Description": "Added the `clientLocalIpV6Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Target": "pstnCallLogRow"
+              },
+              {
+                "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
+                "ApiChange": "Property",
+                "ChangedApiName": "clientPublicIpV4Address",
+                "ChangeType": "Addition",
+                "Description": "Added the `clientPublicIpV4Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Target": "pstnCallLogRow"
+              },
+              {
+                "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
+                "ApiChange": "Property",
+                "ChangedApiName": "clientPublicIpV6Address",
+                "ChangeType": "Addition",
+                "Description": "Added the `clientPublicIpV6Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Target": "pstnCallLogRow"
+              }
+            ],
+            "Id": "6e9d3a43-2765-461f-9bc7-92375bff3acb",
+            "Cloud": "Prod",
+            "Version": "beta",
+            "CreatedDateTime": "2023-06-19T07:38:13.9482874Z",
+            "WorkloadArea": "Cloud communications",
+            "SubArea": "Online meeting"
+        },
+        {
+            "ChangeList": [
                 {
                     "Id": "7032bc3a-d753-4589-9834-4c07d3c89f19",
                     "ApiChange": "Method",

--- a/changelog/Microsoft.IC3.DataPlatform.json
+++ b/changelog/Microsoft.IC3.DataPlatform.json
@@ -7,7 +7,7 @@
                 "ApiChange": "Property",
                 "ChangedApiName": "clientLocalIpV4Address",
                 "ChangeType": "Addition",
-                "Description": "Added the `clientLocalIpV4Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Description": "Added the **clientLocalIpV4Address** property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
                 "Target": "pstnCallLogRow"
               },
               {
@@ -15,7 +15,7 @@
                 "ApiChange": "Property",
                 "ChangedApiName": "clientLocalIpV6Address",
                 "ChangeType": "Addition",
-                "Description": "Added the `clientLocalIpV6Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Description": "Added the **clientLocalIpV6Address** property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
                 "Target": "pstnCallLogRow"
               },
               {
@@ -23,7 +23,7 @@
                 "ApiChange": "Property",
                 "ChangedApiName": "clientPublicIpV4Address",
                 "ChangeType": "Addition",
-                "Description": "Added the `clientPublicIpV4Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Description": "Added the **clientPublicIpV4Address** property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
                 "Target": "pstnCallLogRow"
               },
               {
@@ -31,7 +31,7 @@
                 "ApiChange": "Property",
                 "ChangedApiName": "clientPublicIpV6Address",
                 "ChangeType": "Addition",
-                "Description": "Added the `clientPublicIpV6Address` property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
+                "Description": "Added the **clientPublicIpV6Address** property to the [pstnCallLogRow](https://learn.microsoft.com/en-us/graph/api/resources/callRecords-pstnCallLogRow?view=graph-rest-beta) resource.",
                 "Target": "pstnCallLogRow"
               }
             ],
@@ -39,8 +39,8 @@
             "Cloud": "Prod",
             "Version": "beta",
             "CreatedDateTime": "2023-06-19T07:38:13.9482874Z",
-            "WorkloadArea": "Cloud communications",
-            "SubArea": "Online meeting"
+            "WorkloadArea": "Teamwork and communications",
+            "SubArea": "Calls and online meetings"
         },
         {
             "ChangeList": [


### PR DESCRIPTION
Adding new fields to callRecord: getPstnCalls:
clientPublicIpV4Address
clientPublicIpV6Address
clientLocalIpV4Address
clientLocalIpV6Address

API review PR approved and merged:
https://microsoftgraph.visualstudio.com/onboarding/_git/onboarding/pullrequest/14053

Workloads schema PR:
https://dev.azure.com/msazure/One/_git/AD-AggregatorService-Workloads/pullrequest/8296942