### PR TITLE
Update application-post-onlinemeetings.md

### DIFF
--- a/api-reference/v1.0/api/application-post-onlinemeetings.md
+++ b/api-reference/v1.0/api/application-post-onlinemeetings.md
@@ -49,6 +49,9 @@ POST /users/{userId}/onlineMeetings
 
 If the request contains an `Accept-Language` HTTP header, the `content` of `joinInformation` will be in the language and locale variant specified in the `Accept-Language` header. The default content will be in English.
 
+
+To get the `token` for the `Authorization`, follow [Get access on behalf of a user](/graph/auth-v2-user?tabs=http#3-request-an-access-token).
+
 ## Request body
 In the request body, supply a JSON representation of an [onlineMeeting](../resources/onlinemeeting.md) object.
 


### PR DESCRIPTION
Hello,

I would like to submit this PR to contribute to the application-post-onlinemeetings.md
which is the documentation for configuring creating teams meeting link using Microsoft Graph. I noticed that we could add the link for the documentation that shows how to get the token for the authorization. This will greatly help developers to achieve this faster.

In this PR, I have added a line that will provide the url to get the token for the authorization
I hope this addition is useful and informative for your users. Please let me know if there are any changes you would like me to make or if you have any feedback.

Thank you for your time and consideration.