### PR TITLE
Adjusting for customer flow if they land on API page first

### DIFF
--- a/api-reference/v1.0/resources/webhooks.md
+++ b/api-reference/v1.0/resources/webhooks.md
@@ -1,5 +1,5 @@
 ---
-title: "Use the Microsoft Graph API to get change notifications"
+title: "Overview:  Microsoft Graph API change notifications"
 description: "Deliver change notifications to clients."
 ms.localizationpriority: high
 author: "keylimesoda"
@@ -8,11 +8,13 @@ doc_type: conceptualPageType
 ms.date: 09/10/2022
 ---
 
-# Use the Microsoft Graph API to get change notifications
+# Microsoft Graph API change notifications
 
 Namespace: microsoft.graph
 
-The Microsoft Graph REST API uses a webhook mechanism to deliver change notifications to clients. A client is a web service that configures its own URL to receive notifications. Client apps use notifications to update their state upon changes. For more details, including how to subscribe to and handle incoming notifications, see [Set up notifications for changes in user data](/graph/webhooks).
+This document provides technical details for  the change notifications APIs in Microsoft Graph.  For details on getting started using these APIs, including how to subscribe to and handle incoming notifications, please start here: [Set up notifications for changes in user data](/graph/webhooks).
+
+The Microsoft Graph REST API uses a webhook mechanism to deliver change notifications to clients. A client is a web service that configures its own URL to receive notifications. Client apps use notifications to update their state upon changes.
 
 [!INCLUDE [change-notifications-supported-resources-expanded](../../../concepts/includes/change-notifications-supported-resources-expanded.md)]
 


### PR DESCRIPTION
The docs are organized such that we expect folks to start with the "learning" sections of our docs if they want to learn how to use our APIs.  However, google search will bring people first to the API page.  So this is tweaked to help folks find the right resources.