### PR TITLE
Delete disclosure for AI-generated content

### DIFF
--- a/includes/ai-generated-attribution.md
+++ b/includes/ai-generated-attribution.md
@@ -1,7 +1,0 @@
----
-ms.localizationpriority: high
-ms.topic: include
----
-
-> [!NOTE]
-> This article was partially created with the help of artificial intelligence. Before publishing, an author reviewed and revised the content as needed. See [Our principles for using AI-generated content in Microsoft Learn](https://aka.ms/ai-content-principles).


### PR DESCRIPTION
As per the updated Learn guidance, you add a specific metadata attribute and the disclosure banner will be automatically added to the content on the Learn site.