### PR TITLE
Update addActivities urls with external segment

### DIFF
--- a/api-reference/beta/api/externalconnectors-externalitem-addactivities.md
+++ b/api-reference/beta/api/externalconnectors-externalitem-addactivities.md
@@ -32,7 +32,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 ``` http
-POST /connections/{connectionsId}/items/{externalItemId}/addActivities
+POST external/connections/{connectionsId}/items/{externalItemId}/addActivities
 ```
 
 ## Request headers

--- a/api-reference/beta/api/externalconnectors-externalitem-addactivities.md
+++ b/api-reference/beta/api/externalconnectors-externalitem-addactivities.md
@@ -75,7 +75,7 @@ The following is an example of a request.
 }
 -->
 ``` http
-POST https://graph.microsoft.com/beta/connections/contosohr/items/TSP228082938/addActivities
+POST https://graph.microsoft.com/beta/external/connections/contosohr/items/TSP228082938/addActivities
 Content-Type: application/json
 Content-length: 190
 

--- a/api-reference/v1.0/api/externalconnectors-externalitem-addactivities.md
+++ b/api-reference/v1.0/api/externalconnectors-externalitem-addactivities.md
@@ -70,7 +70,7 @@ The following is an example of a request.
 }
 -->
 ``` http
-POST https://graph.microsoft.com/v1.0/connections/contosohr/items/TSP228082938/addActivities
+POST https://graph.microsoft.com/v1.0/external/connections/contosohr/items/TSP228082938/addActivities
 Content-Type: application/json
 Content-length: 190
 

--- a/api-reference/v1.0/api/externalconnectors-externalitem-addactivities.md
+++ b/api-reference/v1.0/api/externalconnectors-externalitem-addactivities.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 }
 -->
 ``` http
-POST /connections/{connectionsId}/items/{externalItemId}/addActivities
+POST external/connections/{connectionsId}/items/{externalItemId}/addActivities
 ```
 
 ## Request headers


### PR DESCRIPTION
The "external" url segment is missing on these pages. Updating to avoid future churn and confusion.