### PR TITLE
Adding back masked identity documentation

### DIFF
--- a/api-reference/beta/resources/onlinemeeting.md
+++ b/api-reference/beta/resources/onlinemeeting.md
@@ -41,6 +41,7 @@ This resource supports subscribing to [change notifications](/graph/webhooks). F
 | allowRecording | Boolean | Indicates whether recording is enabled for the meeting. |
 | allowedPresenters     | [onlineMeetingPresenters](#onlinemeetingpresenters-values)| Specifies who can be a presenter in a meeting. |
 | alternativeRecording  | Stream | The content stream of the alternative recording of a [Microsoft Teams live event](/microsoftteams/teams-live-events/what-are-teams-live-events). Read-only. |
+| anonymizeIdentityForRoles    | onlineMeetingRole collection | Specifies whose identity will be anonymized in the meeting. Possible values are: `attendee`. The `attendee` value cannot be removed through a PATCH operation once added.|
 | attendeeReport        | Stream | The content stream of the attendee report of a [Teams live event](/microsoftteams/teams-live-events/what-are-teams-live-events). Read-only.   |
 | audioConferencing     | [audioConferencing](audioconferencing.md)     | The phone access (dial-in) information for an online meeting. Read-only. |
 | broadcastSettings     | [broadcastMeetingSettings](broadcastMeetingSettings.md)     | Settings related to a live event.      |
@@ -134,6 +135,7 @@ This resource supports subscribing to [change notifications](/graph/webhooks). F
   "allowTeamworkReactions": "Boolean",
   "allowedPresenters": "String",
   "alternativeRecording": "Stream",
+  "anonymizeIdentityForRoles": ["String"],
   "attendeeReport": "Stream",
   "audioConferencing": {"@odata.type": "microsoft.graph.audioConferencing"},
   "broadcastSettings": {"@odata.type": "microsoft.graph.broadcastSettings"},

--- a/changelog/Microsoft.Skype.Calling.json
+++ b/changelog/Microsoft.Skype.Calling.json
@@ -3,6 +3,24 @@
     {
       "ChangeList": [
         {
+          "Id": "5bd55826-eb41-4116-820d-8629374e4ceb",
+          "ApiChange": "Property",
+          "ChangedApiName": "anonymizeIdentityForRoles",
+          "ChangeType": "Addition",
+          "Description": "Added the **anonymizeIdentityForRoles** property to the [onlineMeeting](https://docs.microsoft.com/en-us/graph/api/resources/onlineMeeting?view=graph-rest-beta) resource.",
+          "Target": "onlineMeeting"
+        }
+      ],
+      "Id": "5bd55826-eb41-4116-820d-8629374e4ceb",
+      "Cloud": "Prod",
+      "Version": "beta",
+      "CreatedDateTime": "2023-06-27T02:06:59.705919Z",
+      "WorkloadArea": "Teamwork and communications",
+      "SubArea": "Calls and online meetings"
+    },
+    {
+      "ChangeList": [
+        {
           "Id": "af2b778c-bcb4-4003-8412-f8b511443dc5",
           "ApiChange": "Property",
           "ChangedApiName": "allowRecording",


### PR DESCRIPTION
It was reverted in this commit #17834. Adding it back now that it's ready. Please consider approving and merging in a fast track since the previous commit has already been reviewed and approved before it got reverted.