### PR TITLE
Update user-findmeetingtimes.md

### DIFF
--- a/api-reference/v1.0/api/user-findmeetingtimes.md
+++ b/api-reference/v1.0/api/user-findmeetingtimes.md
@@ -174,7 +174,7 @@ Content-Type: application/json
   "isOrganizerOptional": "false",
   "meetingDuration": "PT1H",
   "returnSuggestionReasons": "true",
-  "minimumAttendeePercentage": "100"
+  "minimumAttendeePercentage": 100
 }
 ```
 


### PR DESCRIPTION
Fixes http example snippet where `minimumAttendeePercentage` is a number type Edm.Double and not a string. 