### PR TITLE
Shabu isg ti 0705

### DIFF
--- a/api-reference/beta/resources/security-api-overview.md
+++ b/api-reference/beta/resources/security-api-overview.md
@@ -147,17 +147,8 @@ Threat indicators, also referred to as indicators of compromise (IoCs), represen
 
 The [tiIndicators](tiindicator.md) entity allows customers to feed threat indicators to Microsoft security solutions to enable block and alert actions on malicious activity or allow, which suppresses actions for indicators determined not to be relevant to an organization. When sending indicators, both the Microsoft solution that will utilize the indicator and the action to be taken on that indicator are specified.
 
-You can integrate the [tiIndicator](tiindicator.md) entity into your application or use one of the following integrated threat intelligence platforms (TIP):
-
-- [Palo Alto Networks MineMeld Threat Intelligence Sharing](https://www.paloaltonetworks.com/products/secure-the-network/subscriptions/minemeld)
-- [MISP Open Source Threat Intelligence Platform](http://www.misp-project.org/) available through the [TI sample](https://aka.ms/tipmispsample)
-
-Threat indicators sent via the Microsoft Graph security API are available today in the following products:
-
-- [Azure Sentinel](/azure/sentinel/overview) – Enables you to correlate threat indicators with log data to get alerts on malicious activity.
 - [Microsoft Defender for Endpoint](/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-advanced-threat-protection) – Enables you to alert and/or block on threat indicators associated with malicious activity. You can also allow an indicator for ignoring the indicator from automated investigations. For details about the types of indicators supported and limits on indicator counts per tenant, see [Manage indicators](/windows/security/threat-protection/microsoft-defender-atp/manage-indicators).
-
-Support in other Microsoft security services will be available soon.
+- [Azure Sentinel](/azure/sentinel/overview) – Please review this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip).
 
 ## Threat submission
 

--- a/api-reference/beta/resources/security-api-overview.md
+++ b/api-reference/beta/resources/security-api-overview.md
@@ -148,7 +148,7 @@ Threat indicators, also referred to as indicators of compromise (IoCs), represen
 The [tiIndicators](tiindicator.md) entity allows customers to feed threat indicators to Microsoft security solutions to enable block and alert actions on malicious activity or allow, which suppresses actions for indicators determined not to be relevant to an organization. When sending indicators, both the Microsoft solution that will utilize the indicator and the action to be taken on that indicator are specified.
 
 - [Microsoft Defender for Endpoint](/windows/security/threat-protection/microsoft-defender-atp/microsoft-defender-advanced-threat-protection) – Enables you to alert and/or block on threat indicators associated with malicious activity. You can also allow an indicator for ignoring the indicator from automated investigations. For details about the types of indicators supported and limits on indicator counts per tenant, see [Manage indicators](/windows/security/threat-protection/microsoft-defender-atp/manage-indicators).
-- [Azure Sentinel](/azure/sentinel/overview) – Please review this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip).
+- [Azure Sentinel](/azure/sentinel/overview) – Please review this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip). Please note that the Security API exclusively accepts TiIndicator requests from existing customers.
 
 ## Threat submission
 

--- a/api-reference/beta/resources/tiindicator.md
+++ b/api-reference/beta/resources/tiindicator.md
@@ -19,15 +19,13 @@ Threat indicators uploaded via **tiIndicators** will be used in conjunction with
 
 Current **targetProduct** support includes the following:
 
-- **Azure Sentinel** – Supports all documented **tiIndicators** methods listed in the following section.
 - **Microsoft Defender for Endpoint** – Supports the following **tiIndicators** methods:
      - [Get tiIndicator](../api/tiindicator-get.md)
      - [Create tiIndicator](../api/tiindicators-post.md)
      - [List tiIndicators](../api/tiindicators-list.md)
      - [Update](../api/tiindicator-update.md)
      - [Delete](../api/tiindicator-delete.md)
-
-     Support for the bulk methods is coming soon.
+- **Azure Sentinel** – Please refer this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip). Please note that the Security API exclusively accepts TiIndicator requests from tenants with existing accounts.
 
   > [!NOTE]
   >The following indicator types are supported by Microsoft Defender for Endpoint targetProduct:

--- a/api-reference/beta/resources/tiindicator.md
+++ b/api-reference/beta/resources/tiindicator.md
@@ -25,7 +25,7 @@ Current **targetProduct** support includes the following:
      - [List tiIndicators](../api/tiindicators-list.md)
      - [Update](../api/tiindicator-update.md)
      - [Delete](../api/tiindicator-delete.md)
-- **Azure Sentinel** – Please refer this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip). Please note that the Security API exclusively accepts TiIndicator requests from tenants with existing accounts.
+- **Azure Sentinel** – Please refer this document to [Connect your threat intelligence platform to Microsoft Sentinel](https://learn.microsoft.com/en-us/azure/sentinel/connect-threat-intelligence-tip). Please note that the Security API exclusively accepts TiIndicator requests from existing customers.
 
   > [!NOTE]
   >The following indicator types are supported by Microsoft Defender for Endpoint targetProduct:


### PR DESCRIPTION
Updated the Graph Security API docs for Beta version. Sentinel customers should use Sentinel to submit indicators directly.