### PR TITLE
Fix what appears to be a broken link

### DIFF
--- a/concepts/auth/auth-concepts.md
+++ b/concepts/auth/auth-concepts.md
@@ -104,7 +104,7 @@ For the Microsoft identity platform endpoint:
 - Server middleware from Microsoft is available for .NET core and ASP.NET (OWIN OpenID Connect and OAuth) and for Node.js (Microsoft identity platform Passport.js).
 - The Microsoft identity platform is also compatible with many third-party authentication libraries.
 
-For a complete list of Microsoft client libraries, Microsoft server middleware, and compatible third-party libraries, see [Microsoft identity platform documentation](#see-also).
+For a complete list of Microsoft client libraries, Microsoft server middleware, and compatible third-party libraries, see [Microsoft identity platform documentation](/azure/active-directory/develop/).
 
 You don't need to use an authentication library to get an access token. To learn about directly using the Microsoft identity platform endpoints without the help of an authentication library, see the following articles:
 


### PR DESCRIPTION
I know it's actually an internal anchor to the "See also" section right below it, but that's not very obvious when you click the link.