### PR TITLE
Update cloudpcprovisioningpolicy-assign.md

### DIFF
--- a/api-reference/beta/api/cloudpcprovisioningpolicy-assign.md
+++ b/api-reference/beta/api/cloudpcprovisioningpolicy-assign.md
@@ -74,7 +74,6 @@ POST https://graph.microsoft.com/beta/deviceManagement/virtualEndpoint/provision
 Content-Type: application/json
 
 {
-  "@odata.type": "#microsoft.graph.cloudPcProvisioningPolicyAssignment",
   "assignments": [
     {
       "id": "b0c2d35f-3385-46c8-a6f5-6c3dfad7708b_64ff06de-9c00-4a5a-98b5-7f5abe26ffff",


### PR DESCRIPTION
Odata function should not have the `@odata.type` property at the root of the body. Causes generation of incorrect snippets as the type is incorrect