### PR TITLE
Windows Updates catalog docs changes

### DIFF
--- a/api-reference/beta/resources/windowsupdates-cveinformation.md
+++ b/api-reference/beta/resources/windowsupdates-cveinformation.md
@@ -1,0 +1,44 @@
+---
+title: "qualityUpdateCatalogEntry resource type"
+description: "Represents metadata for a Windows 10 quality update that you can approve for deployment."
+author: "angiechen22"
+ms.localizationpriority: medium
+ms.prod: "w10"
+doc_type: resourcePageType
+---
+
+# cveInformation resource type
+
+Namespace: microsoft.graph.windowsUpdates
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents the number and URL for a Common Vulnerability and Exposure (CVE).
+
+Information about Common Vulnerabilities and Exposures (CVEs) are maintained by the [Microsoft Security Response Center](https://msrc.microsoft.com/update-guide/vulnerability) (MSRC). MSRC investigates all reports of security vulnerabilities affecting Microsoft products and services, and provides the information here as part of the ongoing effort to help you manage security risks and help keep your systems protected. Each security quality update may address several CVEs.
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|number|String| Identifying number of the CVE. Read-only.|
+|url|String|URL to the full CVE information. Read-only.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.windowsUpdates.cveInformation",
+  "openType": false
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.windowsUpdates.cveInformation",
+  "id": "String",
+  "url": "String"
+}
+```

--- a/api-reference/beta/resources/windowsupdates-featureupdatecatalogentry.md
+++ b/api-reference/beta/resources/windowsupdates-featureupdatecatalogentry.md
@@ -27,6 +27,7 @@ Inherits from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareu
 |id|String|The unique identifier for the catalog entry. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
 |releaseDateTime|DateTimeOffset|The release date for the content. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
 |version|String|The version of the feature update. Read-only.|
+|buildNumber|String|The build number of the feature update. Read-only.|
 
 ## Relationships
 None.
@@ -48,7 +49,8 @@ The following is a JSON representation of the resource.
   "displayName": "String",
   "id": "String (identifier)",
   "releaseDateTime": "String (timestamp)",
-  "version": "String"
+  "version": "String",
+  "buildNumber": "String"
 }
 ```
 

--- a/api-reference/beta/resources/windowsupdates-knowledgebasearticle.md
+++ b/api-reference/beta/resources/windowsupdates-knowledgebasearticle.md
@@ -1,0 +1,44 @@
+---
+title: "qualityUpdateCatalogEntry resource type"
+description: "Represents a knowledge base article."
+author: "angiechen22"
+ms.localizationpriority: medium
+ms.prod: "w10"
+doc_type: resourcePageType
+---
+
+# knowledgeBaseArticle resource type
+
+Namespace: microsoft.graph.windowsUpdates
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents a knowledge base (KB) article.
+
+Each quality update contains 1 or more [product revisions](../resources/windowsupdates-productrevision.md). Each product revision is associated with exactly one knowledge base article.
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|id|String|The unique identifier for the knowledge base article. Read-only.|
+|url|String|The URL of the knowledge base article. Read-only.|
+
+## Relationships
+None.
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.windowsUpdates.knowledgeBaseArticle",
+  "openType": false
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.windowsUpdates.knowledgeBaseArticle",
+  "id": "String",
+  "url": "String"
+}
+```

--- a/api-reference/beta/resources/windowsupdates-productrevision.md
+++ b/api-reference/beta/resources/windowsupdates-productrevision.md
@@ -1,0 +1,57 @@
+---
+title: "qualityUpdateCatalogEntry resource type"
+description: "Represents a product revision that is associated with a quality update"
+author: "angiechen22"
+ms.localizationpriority: medium
+ms.prod: "w10"
+doc_type: resourcePageType
+---
+
+# productRevision resource type
+
+Namespace: microsoft.graph.windowsUpdates
+
+[!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
+
+Represents a product revision that is associated with a quality update.
+
+When a quality update is released, it includes one or more product revisions to operating system builds. The taxonomy of a product revision is `majorVersion`.`minorVersion`.`buildNumber`.`updateBuildRevision`.
+
+## Properties
+|Property|Type|Description|
+|:---|:---|:---|
+|displayName|String|The display name of the content. Read-only.|
+|id|String|The unique identifier for the product revision. Read-only.|
+|releaseDateTime|DateTimeOffset|The release date for the content. Read-only.|
+|version|String|The version of the feature update. Read-only.|
+|osBuild|microsoft.graph.windowsUpdates.buildVersionDetails|The version details of the product revision. Read-only.|
+
+## Relationships
+|Property|Type|Description|
+|:---|:---|:---|
+|knowledgeBaseArticle|[microsoft.graph.windowsUpdates.knowledgeBaseArticle](../resources/windowsupdates-knowledgebasearticle.md)|Knowledge base article associated with the product revision.|
+
+## JSON representation
+The following is a JSON representation of the resource.
+<!-- {
+  "blockType": "resource",
+  "keyProperty": "id",
+  "@odata.type": "microsoft.graph.windowsUpdates.productRevision",
+  "openType": false
+}
+-->
+``` json
+{
+  "@odata.type": "#microsoft.graph.windowsUpdates.productRevision",
+  "id": "String",
+  "displayName": "String",
+  "releaseDateTime": "String(timestamp)",
+  "version": "String",
+  "osBuild": {
+    "majorVersion": "Integer",
+    "minorVersion": "Integer",
+    "buildNumber": "Integer",
+    "updateBuildRevision": "Integer"
+  }
+}
+```

--- a/api-reference/beta/resources/windowsupdates-qualityupdatecatalogentry.md
+++ b/api-reference/beta/resources/windowsupdates-qualityupdatecatalogentry.md
@@ -15,7 +15,7 @@ Namespace: microsoft.graph.windowsUpdates
 
 Represents metadata for a Windows 10 quality update that you can approve for deployment.
 
-Windows 10 quality updates are released one or more times per month. These updates contain both security and quality fixes and are typically released on the second Tuesday of every month, though they might be released at any time. These updates are cumulative, so later versions always contain all previous fixes. We strongly recommend keeping devices current by installing the most recent quality updates as soon as they are available. 
+Windows 10 quality updates are released one or more times per month. These updates contain both security and quality fixes and are typically released on the second Tuesday of every month, though they might be released at any time. These updates are cumulative, so later versions always contain all previous fixes. We strongly recommend keeping devices current by installing the most recent quality updates as soon as they are available.
 
 Inherits from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).
 
@@ -24,13 +24,19 @@ Inherits from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareu
 |:---|:---|:---|
 |deployableUntilDateTime|DateTimeOffset|The date on which the content is no longer available for deployment using the service. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
 |displayName|String|The display name of the content. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
+|catalogName|String|The catalog name of the content. Read-only.|
+|shortName|String|The short name of the content. Read-only.|
 |id|String|The unique identifier for the catalog entry. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
 |isExpeditable|Boolean|Indicates whether the content can be deployed as an expedited quality update. Read-only.|
 |qualityUpdateClassification|microsoft.graph.windowsUpdates.qualityUpdateClassification|The classification on the quality update. Possible values are: `all`, `security`, `nonSecurity`, `unknownFutureValue`. Read-only.|
+|qualityUpdateCadence|microsoft.graph.windowsUpdates.qualityUpdateCadence|The publishing cadence of the quality update.Possible values are: `monthly`, `outOfBand`, `unknownFutureValue`. Read-only.|
 |releaseDateTime|DateTimeOffset|The release date of the content. Read-only. Inherited from [softwareUpdateCatalogEntry](../resources/windowsupdates-softwareupdatecatalogentry.md).|
+|cveSeverityInformation|microsoft.graph.windowsUpdates.qualityUpdateCveSeverityInformation|Severity information of the CVEs associated with the content.|
 
 ## Relationships
-None.
+|Property|Type|Description|
+|:---|:---|:---|
+|productRevisions|[microsoft.graph.windowsUpdates.productRevision](../resources/windowsupdates-productrevision.md) collection|The operating system product revisions that are released as part of this quality update.|
 
 ## JSON representation
 The following is a JSON representation of the resource.
@@ -47,10 +53,17 @@ The following is a JSON representation of the resource.
   "@odata.type": "#microsoft.graph.windowsUpdates.qualityUpdateCatalogEntry",
   "deployableUntilDateTime": "String (timestamp)",
   "displayName": "String",
+  "catalogName": "String",
+  "shortName": "String",
   "id": "String (identifier)",
   "isExpeditable": "Boolean",
   "qualityUpdateClassification": "String",
-  "releaseDateTime": "String (timestamp)"
+  "qualityUpdateCadence": "String",
+  "releaseDateTime": "String (timestamp)",
+  "cveSeverityInformation": {
+    "maxSeverityLevel": "String",
+    "maxBaseScore": "Double",
+    "exploitedCves": "Collection(microsoft.graph.windowsUpdates.qualityUpdateCveSeverityInformation)"
+  }
 }
 ```
-

--- a/concepts/windowsupdates-deploy-expedited-update.md
+++ b/concepts/windowsupdates-deploy-expedited-update.md
@@ -51,29 +51,56 @@ Content-Type: application/json
         {
             "@odata.type": "#microsoft.graph.windowsUpdates.qualityUpdateCatalogEntry",
             "id": "bd9554dc-2737-4e3c-b794-fa2b8b3f4a30",
-            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10",
+            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10 and later",
+            "catalogName": "YYYY-MM Cumulative Update for Windows 10 and later",
+            "shortName": "YYYY.MM B",
             "releaseDateTime": "String (timestamp)",
             "deployableUntilDateTime": null,
             "isExpeditable": true,
-            "qualityUpdateClassification": "security"
+            "qualityUpdateClassification": "security",
+            "qualityUpdateCadence": "monthly",
+            "cveSeverityInformation": {
+                "maxSeverityLevel": "String",
+                "maxBaseScore": "Double",
+                "exploitedCves": Collection(microsoft.graph.cveInformation")
+            }
         },
         {
             "@odata.type": "#microsoft.graph.windowsUpdates.qualityUpdateCatalogEntry",
             "id": "68860630-c2d0-4dd2-8c4b-9b9737ee5081",
-            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10",
+            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10 and later",
+            "catalogName": "YYYY-MM Cumulative Update for Windows 10 and later",
+            "shortName": "YYYY.MM B",
             "releaseDateTime": "String (timestamp)",
             "deployableUntilDateTime": null,
             "isExpeditable": true,
-            "qualityUpdateClassification": "security"
+            "qualityUpdateClassification": "security",
+            "qualityUpdateClassification": "security",
+            "qualityUpdateCadence": "monthly",
+            "cveSeverityInformation": {
+                "maxSeverityLevel": "String",
+                "maxBaseScore": "Double",
+                "exploitedCves": null
+            }
+        },
         },
         {
             "@odata.type": "#microsoft.graph.windowsUpdates.qualityUpdateCatalogEntry",
             "id": "aa336b13-db33-4d94-89ea-90e43e4ad30b",
-            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10",
+            "displayName": "MM/DD/YYYY - YYYY.MM B Security Updates for Windows 10 and later",
+            "catalogName": "YYYY-MM Cumulative Update for Windows 10 and later",
+            "shortName": "YYYY.MM B",
             "releaseDateTime": "String (timestamp)",
             "deployableUntilDateTime": null,
             "isExpeditable": true,
-            "qualityUpdateClassification": "security"
+            "qualityUpdateClassification": "security",
+            "qualityUpdateClassification": "security",
+            "qualityUpdateCadence": "monthly",
+            "cveSeverityInformation": {
+                "maxSeverityLevel": "String",
+                "maxBaseScore": "Double",
+                "exploitedCves": Collection(microsoft.graph.cveInformation")
+            }
         }
     ]
 }

--- a/concepts/windowsupdates-deploy-update.md
+++ b/concepts/windowsupdates-deploy-update.md
@@ -45,19 +45,39 @@ Content-Type: application/json
     "value": [
         {
             "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateCatalogEntry",
-            "id": "560a186a-1434-4364-8330-deb944b494ff",
-            "displayName": "Windows 10, version 20H2",
-            "releaseDate": "String (timestamp)",
-            "deployableUntilDateTime": "String (timestamp)",
-            "version": "20H2"
+            "id": "d9049ddb-0ca8-4bc1-bd3c-41a456ef300f",
+            "displayName": "Windows 11, version 22H2",
+            "deployableUntilDateTime": "2025-10-14T00:00:00Z",
+            "releaseDateTime": "2022-09-20T00:00:00Z",
+            "version": "Windows 11, version 22H2"
+            "buildNumber": "22621"
         },
         {
             "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateCatalogEntry",
-            "id": "5e436dae-56bd-4925-bf8b-acf550e07227",
-            "displayName": "Windows 10, version 2004",
-            "releaseDate": "String (timestamp)",
-            "deployableUntilDateTime": "String (timestamp)",
-            "version": "2004"
+            "id": "7f4cee4c-9aa5-4e61-a4ca-c23a1bdba6f7",
+            "displayName": "Windows 11",
+            "deployableUntilDateTime": "2024-10-08T00:00:00Z",
+            "releaseDateTime": "2021-10-04T00:00:00Z",
+            "version": "Windows 11, version 21H2",
+            "buildNumber": "22000"
+        },
+        {
+            "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateCatalogEntry",
+            "id": "f341705b-0b15-4ce3-aaf2-6a1681d78606",
+            "displayName": "Windows 10, version 22H2",
+            "deployableUntilDateTime": "2025-10-14T00:00:00Z",
+            "releaseDateTime": "2022-10-18T00:00:00Z",
+            "version": "Windows 10, version 22H2"
+            "buildNumber": "19045"
+        },
+        {
+            "@odata.type": "#microsoft.graph.windowsUpdates.featureUpdateCatalogEntry",
+            "id": "53707a30-7816-448e-ab54-8cfedc48bfbc",
+            "displayName": "Windows 10, version 21H2",
+            "deployableUntilDateTime": "2024-06-11T00:00:00Z",
+            "releaseDateTime": "2021-11-16T00:00:00Z",
+            "version": "Windows 10, version 21H2",
+            "buildNumber": "19044"
         }
     ]
 }


### PR DESCRIPTION
I am a product owner of the Windows Update namespace in Microsoft Graph. The team has recently made several additions to the catalog endpoint that have been [approved by the Graph board](https://microsoftgraph.visualstudio.com/onboarding/_git/onboarding/pullrequest/14164?path=/reviews/17447-windows-updates-quality-update-catalog-entry-metadata-additions/api.md).

Changed /resources/ files

- windowsupdatesfeatureupdatecatalogentry
- windowsupdatesqualityupdatecatalogentry
- *new* windowsupdatesknowledgebasearticle
- *new* windowsupdatescveinformation
- *new* windowsupdatesproductrevision

Changed /concepts/ docs:

- windowsupdates-deploy-update
- windowsupdates-deploy-expedited-update
