### PR TITLE
Add `staffMemberIds` to bookingbusiness-post-appointments.md

### DIFF
--- a/api-reference/v1.0/api/bookingbusiness-post-appointments.md
+++ b/api-reference/v1.0/api/bookingbusiness-post-appointments.md
@@ -136,6 +136,9 @@ Content-type: application/json
     },
     "serviceName": "Catered bento",
     "serviceNotes": "Customer requires punctual service.",
+    "staffMemberIds": [
+      "8ee1c803-a1fa-406d-8259-7ab53233f148"
+    ],
     "startDateTime": {
         "@odata.type": "#microsoft.graph.dateTimeTimeZone",
         "dateTime": "2018-05-01T12:00:00.0000000+00:00",
@@ -256,7 +259,9 @@ Content-type: application/json
     "serviceNotes": "Customer requires punctual service.",
     "optOutOfCustomerEmail": false,
     "anonymousJoinWebUrl": null,
-    "staffMemberIds": [],
+    "staffMemberIds": [
+      "8ee1c803-a1fa-406d-8259-7ab53233f148"
+    ],
     "startDateTime": {
         "dateTime": "2018-05-01T12:00:00.0000000Z",
         "timeZone": "UTC"


### PR DESCRIPTION
`staffMemberIds` is a required field when user creates a booking  appointment using Application permissions.  If not provided, the service returns 400 Bad Request with message: "Invalid Staff".

This field is not required with Delegated Permissions.