### PR TITLE
Update application-post-tokenlifetimepolicies.md

### DIFF
--- a/api-reference/beta/api/application-list-tokenlifetimepolicies.md
+++ b/api-reference/beta/api/application-list-tokenlifetimepolicies.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-List the [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) objects that are assigned to an [application](../resources/application.md) or [servicePrincipal](../resources/servicePrincipal.md)..
+List the [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) objects that are assigned to an [application](../resources/application.md) or [servicePrincipal](../resources/servicePrincipal.md). Only one object is returned in the collection because only one tokenLifetimePolicy can be assigned to an application.
 
 ## Permissions
 

--- a/api-reference/beta/api/application-post-tokenlifetimepolicies.md
+++ b/api-reference/beta/api/application-post-tokenlifetimepolicies.md
@@ -13,7 +13,7 @@ Namespace: microsoft.graph
 
 [!INCLUDE [beta-disclaimer](../../includes/beta-disclaimer.md)]
 
-Assign a [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) to an [application](../resources/application.md) or [servicePrincipal](../resources/servicePrincipal.md).
+Assign a [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) to an [application](../resources/application.md) or [servicePrincipal](../resources/servicePrincipal.md). You can have multiple tokenLifetimePolicy policies in a tenant but can assign only one tokenLifetimePolicy per application.
 
 ## Permissions
 

--- a/api-reference/v1.0/api/application-list-tokenlifetimepolicies.md
+++ b/api-reference/v1.0/api/application-list-tokenlifetimepolicies.md
@@ -11,7 +11,7 @@ doc_type: "apiPageType"
 
 Namespace: microsoft.graph
 
-List the [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) objects that are assigned to an [application](../resources/application.md).
+List the [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) objects that are assigned to an [application](../resources/application.md). Only one object is returned in the collection because only one tokenLifetimePolicy can be assigned to an application.
 
 ## Permissions
 

--- a/api-reference/v1.0/api/application-post-tokenlifetimepolicies.md
+++ b/api-reference/v1.0/api/application-post-tokenlifetimepolicies.md
@@ -15,6 +15,8 @@ Namespace: microsoft.graph
 
 Assign a [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) to an [application](../resources/application.md).
 
+>**Note:** We can have multiple tokenLifetimePolicy policies in a tenant but only one tokenLifetimePolicy per application can be assigned.
+
 ## Permissions
 
 One of the following permissions is required to call this API. To learn more, including how to choose permissions, see [Permissions](/graph/permissions-reference).

--- a/api-reference/v1.0/api/application-post-tokenlifetimepolicies.md
+++ b/api-reference/v1.0/api/application-post-tokenlifetimepolicies.md
@@ -11,11 +11,7 @@ doc_type: "apiPageType"
 
 Namespace: microsoft.graph
 
-
-
-Assign a [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) to an [application](../resources/application.md).
-
->**Note:** We can have multiple tokenLifetimePolicy policies in a tenant but only one tokenLifetimePolicy per application can be assigned.
+Assign a [tokenLifetimePolicy](../resources/tokenlifetimepolicy.md) to an [application](../resources/application.md). You can have multiple tokenLifetimePolicy policies in a tenant but can assign only one tokenLifetimePolicy per application.
 
 ## Permissions
 

--- a/api-reference/v1.0/api/tokenlifetimepolicy-list.md
+++ b/api-reference/v1.0/api/tokenlifetimepolicy-list.md
@@ -30,7 +30,7 @@ One of the following permissions is required to call this API. To learn more, in
 <!-- { "blockType": "ignored" } -->
 
 ```http
-GET policies/tokenLifetimePolicies
+GET /policies/tokenLifetimePolicies
 ```
 
 ## Optional query parameters


### PR DESCRIPTION
**Purpose**: The purpose of this change is to make the documentation more clear while Assigning a tokenLifetimePolicy to an application using Graph-API.

**API Endpoint**:
`POST https://graph.microsoft.com/v1.0/applications/{AppObjectD}/tokenLifetimePolicies/$ref
Content-Type: application/json
{
  "@odata.id":"https://graph.microsoft.com/v1.0/policies/tokenLifetimePolicies/{policyId}"
}`
**Response**:
`
HTTP/1.1 204 No Content
`
The above write operation can be performed only to assign one tokenLifetimePolicies per application.

**Impact**: This change will bring more clarity into the documentation and make it up-to-date. This will make it easier for developers to use the API, which will lead to increased adoption of the API.

**Implementation**: The change will be implemented by updating the existing documentation and adding one new line as needed.

**In-house Repro:** This is reproducible at my end and also many other M365 tenants. Here find the reference, [stackoverflow](https://stackoverflow.com/questions/76650024/assigning-fails-with-the-second-token-lifetime-policy-with-graph-api-endpoint-po/76653847#76653847)