### PR TITLE
Fixed typo in intelligenceprofileindicator-get Graph API documentation page

### DIFF
--- a/api-reference/beta/api/security-intelligenceprofileindicator-get.md
+++ b/api-reference/beta/api/security-intelligenceprofileindicator-get.md
@@ -35,7 +35,7 @@ One of the following permissions is required to call this API. To learn more, in
 -->
 
 ```http
-GET /security/threatIntelligence/intelProfileIndicators/{intelligenceProfileIndicatorId}
+GET /security/threatIntelligence/intelligenceProfileIndicators/{intelligenceProfileIndicatorId}
 ```
 
 ## Optional query parameters
@@ -70,7 +70,7 @@ The following is an example of a request.
 -->
 
 ```http
-GET https://graph.microsoft.com/beta/security/threatIntelligence/intelProfileIndicators/ff3eecd2-a2be-27c2-8dc0-40d1c0eada55
+GET https://graph.microsoft.com/beta/security/threatIntelligence/intelligenceProfileIndicators/ff3eecd2-a2be-27c2-8dc0-40d1c0eada55
 ```
 
 ### Response


### PR DESCRIPTION
Fixed typo in intelligenceprofileindicator-get Graph API documentation page where we were saying "intelProfileIndicator" as opposed to "intelligenceProfileIndicator" in certain places.