### PR TITLE
Correct error that DirectoryRole supports $count/$search

### DIFF
--- a/api-reference/beta/api/directoryrole-list.md
+++ b/api-reference/beta/api/directoryrole-list.md
@@ -36,7 +36,7 @@ One of the following permissions is required to call this API. To learn more, in
 GET /directoryRoles
 ```
 ## Optional query parameters
-This method supports the `$count`, `$select`, `$search`, `$filter` (`eq`), and `$expand` [OData query parameters](/graph/query-parameters) to help customize the response.
+This method supports the `$select`, `$filter` (`eq` only), and `$expand` [OData query parameters](/graph/query-parameters) to help customize the response.
 
 ## Request headers
 | Name       | Description|


### PR DESCRIPTION
Removed the documentation that $count/$search is supported on directoryRole. Also clarified that $filter is only supported with `eq` and no other filter is accepted for this entity.