### PR TITLE
Fixed intelProfileIndicators documentation error in v1.0 Microsoft Graph documentation

### DIFF
--- a/api-reference/v1.0/api/security-intelligenceprofileindicator-get.md
+++ b/api-reference/v1.0/api/security-intelligenceprofileindicator-get.md
@@ -33,7 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 -->
 
 ```http
-GET /security/threatIntelligence/intelProfileIndicators/{intelligenceProfileIndicatorId}
+GET /security/threatIntelligence/intelligenceProfileIndicators/{intelligenceProfileIndicatorId}
 ```
 
 ## Optional query parameters
@@ -68,7 +68,7 @@ The following is an example of a request.
 -->
 
 ```http
-GET https://graph.microsoft.com/v1.0/security/threatIntelligence/intelProfileIndicators/ff3eecd2-a2be-27c2-8dc0-40d1c0eada55
+GET https://graph.microsoft.com/v1.0/security/threatIntelligence/intelligenceProfileIndicators/ff3eecd2-a2be-27c2-8dc0-40d1c0eada55
 ```
 
 ### Response


### PR DESCRIPTION
Fixed typo in intelligenceprofileindicator-get v1.0 Graph API documentation page where we were saying "intelProfileIndicator" as opposed to "intelligenceProfileIndicator" in certain places. The last PR I merged just made the fix for beta, this one is for v1.0. Sorry, forgot to include the v1.0 change in the last PR.