### PR TITLE
Update reportroot-getm365appuserdetail.md

### DIFF
--- a/api-reference/v1.0/api/reportroot-getm365appuserdetail.md
+++ b/api-reference/v1.0/api/reportroot-getm365appuserdetail.md
@@ -33,7 +33,7 @@ One of the following permissions is required to call this API. To learn more, in
 
 ```http
 GET /reports/getM365AppUserDetail(period='{period_value}')
-GET /reports/getM365AppUserDetail(date='{date_value}')
+GET /reports/getM365AppUserDetail(date={date_value})
 ```
 
 ## Function parameters


### PR DESCRIPTION
When filtering by date using, if you include single quotation marks as shown in the example, the following error is returned:

Request:

GET https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(date='2023-07-09')

{
	"error": {

		"code": "BadRequest",
		"message": "Expression of type 'Edm.String' cannot be converted to type 'Edm.Date'.",
		"innerError": {
			"date": "2023-07-11T19:36:24",
			"request-id": "143692d7-e066-4bd3-b36b-9c072f9f7f9b",
			"client-request-id": "d50d8fcf-ffb5-ab64-fbf0-ff784aa391b4"
		}
	}
}
If you remove the quotation marks as follows, the filter will work.

https://graph.microsoft.com/v1.0/reports/getM365AppUserDetail(date=2023-07-09)