### PR TITLE
Use cross-repo reference (CRR) 

### DIFF
--- a/api-reference/beta/resources/identitygovernance-lifecycleworkflows-overview.md
+++ b/api-reference/beta/resources/identitygovernance-lifecycleworkflows-overview.md
@@ -53,7 +53,9 @@ Each workflow contains general descriptive information such as it's identifier, 
 
 Workflow tasks are specific actions that run automatically when a workflow is triggered. Lifecycle Workflows defines the following preconfigured and read-only tasks that are allowed for the specified workflow categories. These task definitions show the settings for the task type, guiding you as you create tasks for your workflow.
 
-[!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)]
+<!-- [!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)] -->
+
+[!INCLUDE [identitygovernance-lifecycleworkflows-tasks](~/../azure_docs/includes/lifecycle-workflows-tasks-table.md)]
 
 Use the [taskDefinition resource type](identitygovernance-taskdefinition.md) and its associated methods to discover all the predefined tasks that you can configure for your workflow and the settings for the properties The [task](identitygovernance-task.md) resource type and its associated GET methods allow you to view the tasks that are configured for your workflow.
 

--- a/api-reference/beta/resources/identitygovernance-task.md
+++ b/api-reference/beta/resources/identitygovernance-task.md
@@ -44,7 +44,9 @@ Inherits from [entity](../resources/entity.md).
 
 ### Supported tasks
 
-[!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)]
+<!-- [!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)] -->
+
+[!INCLUDE [identitygovernance-lifecycleworkflows-tasks](~/../azure_docs/includes/lifecycle-workflows-tasks-table.md)]
 
 ## Relationships
 

--- a/api-reference/v1.0/resources/identitygovernance-lifecycleworkflows-overview.md
+++ b/api-reference/v1.0/resources/identitygovernance-lifecycleworkflows-overview.md
@@ -51,7 +51,9 @@ Each workflow contains general descriptive information such as it's identifier, 
 
 Workflow tasks are specific actions that run automatically when a workflow is triggered. Lifecycle Workflows defines the following preconfigured and read-only tasks that are allowed for the specified workflow categories. These task definitions show the settings for the task type, guiding you as you create tasks for your workflow.
 
-[!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)]
+<!-- [!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)] -->
+
+[!INCLUDE [identitygovernance-lifecycleworkflows-tasks](~/../azure_docs/includes/lifecycle-workflows-tasks-table.md)]
 
 Use the [taskDefinition resource type](identitygovernance-taskdefinition.md) and its associated methods to discover all the predefined tasks that you can configure for your workflow and the settings for the properties The [task](identitygovernance-task.md) resource type and its associated GET methods allow you to view the tasks that are configured for your workflow.
 

--- a/api-reference/v1.0/resources/identitygovernance-task.md
+++ b/api-reference/v1.0/resources/identitygovernance-task.md
@@ -41,7 +41,9 @@ Inherits from [entity](../resources/entity.md).
 
 ### Supported tasks
 
-[!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)]
+<!-- [!INCLUDE [lifecycle-workflows-tasks-table](../includes/identitygovernance-lifecycleworkflows-tasks-table.md)] -->
+
+[!INCLUDE [identitygovernance-lifecycleworkflows-tasks](~/../azure_docs/includes/lifecycle-workflows-tasks-table.md)]
 
 ## Relationships
 


### PR DESCRIPTION
Use CRR to avoid duplication of information related to lifecycle workflow tasks.