### PR TITLE
Update security-security-runhuntingquery.md

### DIFF
--- a/api-reference/beta/api/security-security-runhuntingquery.md
+++ b/api-reference/beta/api/security-security-runhuntingquery.md
@@ -46,6 +46,9 @@ POST /security/runHuntingQuery
 |Authorization|Bearer {token}. Required.|
 |Content-Type|application/json. Required.|
 
+> [!NOTE]
+> If you're using non-ANSI characters in your query, for example to query email subjects with malformed or lookalike characters, use `application/json; charset=utf-8` for the Content-Type header. 
+
 ## Request body
 
 In the request body, provide a JSON object for the parameter, `query`. 

--- a/api-reference/v1.0/api/security-security-runhuntingquery.md
+++ b/api-reference/v1.0/api/security-security-runhuntingquery.md
@@ -46,7 +46,7 @@ POST /security/runHuntingQuery
 |Content-Type|application/json. Required.|
 
 > [!NOTE]
-> Ensure to use ContentType 'application/json; charset=utf-8' in case your are using non ANSI characters in your query e.g. to query Emails Subjects with malformed or lookalike characters. 
+> If you're using non-ANSI characters in your query, for example to query email subjects with malformed or lookalike characters, use `application/json; charset=utf-8` for the Content-Type header. 
 
 ## Request body
 

--- a/api-reference/v1.0/api/security-security-runhuntingquery.md
+++ b/api-reference/v1.0/api/security-security-runhuntingquery.md
@@ -45,6 +45,9 @@ POST /security/runHuntingQuery
 |Authorization|Bearer {token}. Required.|
 |Content-Type|application/json. Required.|
 
+> [!NOTE]
+> Ensure to use ContentType 'application/json; charset=utf-8' in case your are using non ANSI characters in your query e.g. to query Emails Subjects with malformed or lookalike characters. 
+
 ## Request body
 
 In the request body, provide a JSON object for the parameter, `Query`. 


### PR DESCRIPTION
came across this due to customer escalation in which Advanced Hunting UI queries are returning different results compared to the same query using the API. We have been able solve the issue by explicitly using UTF8 in the content type header