### PR TITLE
align m365d classification value to right value across pages

### DIFF
--- a/api-reference/beta/api/security-alert-update.md
+++ b/api-reference/beta/api/security-alert-update.md
@@ -47,7 +47,7 @@ PATCH /security/alerts_v2/{alertId}
 |Property|Type|Description|
 |:---|:---|:---|
 |status|microsoft.graph.security.alertStatus|The status of the alert. Possible values are: `new`, `inProgress`, `resolved`, `unknownFutureValue`.|
-|classification|microsoft.graph.security.alertClassification|Specifies the classification of the alert. Possible values are: `unknown`, `falsePositive`, `truePositive`, `benignPositive`, `unknownFutureValue`.|
+|classification|microsoft.graph.security.alertClassification|Specifies the classification of the alert. Possible values are: `unknown`, `falsePositive`, `truePositive`, `informationalExpectedActivity`, `unknownFutureValue`.|
 |determination|microsoft.graph.security.alertDetermination|Specifies the determination of the alert. Possible values are: `unknown`, `apt`, `malware`, `securityPersonnel`, `securityTesting`, `unwantedSoftware`, `other`, `multiStagedAttack`, `compromisedUser`, `phishing`, `maliciousUserActivity`, `clean`, `insufficientData`, `confirmedUserActivity`, `lineOfBusinessApplication`, `unknownFutureValue`.|
 |assignedTo|String|Owner of the incident, or null if no owner is assigned.|
 

--- a/api-reference/beta/resources/security-alert.md
+++ b/api-reference/beta/resources/security-alert.md
@@ -35,7 +35,7 @@ When detecting a threat, a security provider creates an alert in the system. Mic
 |alertWebUrl|String|URL for the alert page in the Microsoft 365 Defender portal.|
 |assignedTo|String|Owner of the **alert**, or null if no owner is assigned.|
 |category|String|The attack kill-chain category that the alert belongs to. Aligned with the MITRE ATT&CK framework.|
-|classification|[microsoft.graph.security.alertClassification](#alertclassification-values)|Specifies whether the alert represents a true threat. Possible values are: `unknown`, `falsePositive`, `truePositive`, `benignPositive`, `unknownFutureValue`.|
+|classification|[microsoft.graph.security.alertClassification](#alertclassification-values)|Specifies whether the alert represents a true threat. Possible values are: `unknown`, `falsePositive`, `truePositive`, `informationalExpectedActivity`, `unknownFutureValue`.|
 |comments|[microsoft.graph.security.alertComment](security-alertComment.md) collection|Array of comments created by the Security Operations (SecOps) team during the alert management process.|
 |createdDateTime|DateTimeOffset|Time when Microsoft 365 Defender created the alert.|
 |description|String|String value describing each alert.|

--- a/api-reference/v1.0/api/security-alert-update.md
+++ b/api-reference/v1.0/api/security-alert-update.md
@@ -45,7 +45,7 @@ PATCH /security/alerts_v2/{alertId}
 |Property|Type|Description|
 |:---|:---|:---|
 |status|microsoft.graph.security.alertStatus|The status of the alert. Possible values are: `new`, `inProgress`, `resolved`, `unknownFutureValue`.|
-|classification|microsoft.graph.security.alertClassification|Specifies the classification of the alert. Possible values are: `unknown`, `falsePositive`, `truePositive`, `benignPositive`, `unknownFutureValue`.|
+|classification|microsoft.graph.security.alertClassification|Specifies the classification of the alert. Possible values are: `unknown`, `falsePositive`, `truePositive`, `informationalExpectedActivity`, `unknownFutureValue`.|
 |determination|microsoft.graph.security.alertDetermination|Specifies the determination of the alert. Possible values are: `unknown`, `apt`, `malware`, `securityPersonnel`, `securityTesting`, `unwantedSoftware`, `other`, `multiStagedAttack`, `compromisedUser`, `phishing`, `maliciousUserActivity`, `clean`, `insufficientData`, `confirmedUserActivity`, `lineOfBusinessApplication`, `unknownFutureValue`.|
 |assignedTo|String|Owner of the incident, or null if no owner is assigned.|
 

--- a/api-reference/v1.0/resources/security-alert.md
+++ b/api-reference/v1.0/resources/security-alert.md
@@ -33,7 +33,7 @@ When detecting a threat, a security provider creates an alert in the system. Mic
 |alertWebUrl|String|URL for the alert page in the Microsoft 365 Defender portal.|
 |assignedTo|String|Owner of the **alert**, or null if no owner is assigned.|
 |category|String|The attack kill-chain category that the alert belongs to. Aligned with the MITRE ATT&CK framework.|
-|classification|[microsoft.graph.security.alertClassification](#alertclassification-values)|Specifies whether the alert represents a true threat. Possible values are: `unknown`, `falsePositive`, `truePositive`, `benignPositive`, `unknownFutureValue`.|
+|classification|[microsoft.graph.security.alertClassification](#alertclassification-values)|Specifies whether the alert represents a true threat. Possible values are: `unknown`, `falsePositive`, `truePositive`, `informationalExpectedActivity`, `unknownFutureValue`.|
 |comments|[microsoft.graph.security.alertComment](security-alertComment.md) collection|Array of comments created by the Security Operations (SecOps) team during the alert management process.|
 |createdDateTime|DateTimeOffset|Time when Microsoft 365 Defender created the alert.|
 |description|String|String value describing each alert.|


### PR DESCRIPTION
correct enum value is `informationalExpectedActivity` as appear in some places, but for some reason in other places `benignPositive` was used