### PR TITLE
Fixed some typos in the MS Graph URL, and update to v1.0

### DIFF
--- a/api-reference/v1.0/api/directory-deleteditems-list.md
+++ b/api-reference/v1.0/api/directory-deleteditems-list.md
@@ -48,7 +48,7 @@ This method supports the query parameters that are supported by the resource tha
 Some queries are supported only when you use the **ConsistencyLevel** header set to `eventual` and `$count`. For example:
 
 ```http
-GET https://graph.microsoft.com/beta/directory/deletedItems/microsoft.graph.group?&$count=true&$orderBy=deletedDateTime desc&$select=id,displayName,deletedDateTime
+GET https://graph.microsoft.com/v1.0/directory/deletedItems/microsoft.graph.group?$count=true&$orderBy=deletedDateTime%20desc&$select=id,displayName,deletedDateTime
 ConsistencyLevel: eventual
 ```
 


### PR DESCRIPTION
Correction to two invalid characters in the query. Technically speaking, RFC 2396 does not allow for spaces (even though most browsers allow it to be entered by the user, it cannot be legally transmitted as part of the HTTP protocol), and the query should not start with an ampersand.

Additionally, this query is now supported in v1.0 and the beta endpoint should not be listed here.