### PR TITLE
Docs update for enabling Private/shared channel change notifications in v1.0

### DIFF
--- a/concepts/teams-changenotifications-team-and-channel.md
+++ b/concepts/teams-changenotifications-team-and-channel.md
@@ -116,15 +116,16 @@ Content-Type: application/json
 
 
 To get change notifications for all changes related to any channel in a particular team, subscribe to `/teams/{team-id}/channels`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
-Following are some sample events which generates notifications for this resource
-- The display name of a channel is updated in the given team.
-- A private channel is created in the given team.
-- A shared channel owned by this team is shared/unshared with another team.
-- A shared channel owned by some other team is shared with this team.
-- A channel's properties like isFavoriteByDefault or description are updated.
+
+The following are examples of events that generate notifications for this resource:
+- The display name of a channel is updated in the team.
+- A private channel is created in the team.
+- A shared channel owned by this team is shared or unshared with another team.
+- A shared channel owned by another team is shared with this team.
+- The properties of a channel, such as **isFavoriteByDefault** or **description**, are updated.
 - A channel is deleted.
 
->**Note:** For Delegated context, only the authorized users will receive notifications for private/shared channels. Example: Anyone who belongs to the team (except guests) can subscribe to this resource in delegated context, but only the users who have access to private & shared channels will receive notifications for events happening in the private & shared channels.
+>**Note:** For delegated context, only the authorized users will receive notifications for private/shared channels. For example, anyone who belongs to the team (except guests) can subscribe to this resource in delegated context, but only the users who have access to private and shared channels will receive notifications for events happening in those channels.
 
 
 ### Permissions

--- a/concepts/teams-changenotifications-team-and-channel.md
+++ b/concepts/teams-changenotifications-team-and-channel.md
@@ -116,8 +116,15 @@ Content-Type: application/json
 
 
 To get change notifications for all changes related to any channel in a particular team, subscribe to `/teams/{team-id}/channels`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
+Following are some sample events which generates notifications for this resource
+- The display name of a channel is updated in the given team.
+- A private channel is created in the given team.
+- A shared channel owned by this team is shared/unshared with another team.
+- A shared channel owned by some other team is shared with this team.
+- A channel's properties like isFavoriteByDefault or description are updated.
+- A channel is deleted.
 
->**Note:** Change notifications for private and shared channels in delegated context are only supported in beta. This is not currently available in v1.0. When you call the v1.0 endpoint, a subscriber to this resource in delegated context will receive notifications only for standard channels under a particular team, not for private and shared channels.
+>**Note:** For Delegated context, only the authorized users will receive notifications for private/shared channels. Example: Anyone who belongs to the team (except guests) can subscribe to this resource in delegated context, but only the users who have access to private & shared channels will receive notifications for events happening in the private & shared channels.
 
 
 ### Permissions

--- a/concepts/teams-changenotifications-teammembership.md
+++ b/concepts/teams-changenotifications-teammembership.md
@@ -110,8 +110,6 @@ Content-Type: application/json
 
 To get change notifications for membership changes in all the private and shared channels in a particular team, subscribe to `/teams/{team-id}/channels/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.
 
->**Note:** This resource doesn't support delegated context in v1.0.
-
 [!INCLUDE [teams-model-A-and-B-disclaimer](../includes/teams-model-A-and-B-disclaimer.md)]
 
 ### Permissions


### PR DESCRIPTION
Docs update for enabling Private/shared channel change notifications in v1.0

Added sample scenarios and a note.