### PR TITLE
Added note about lifecycleNotificationUrl requirements for Team subscriptions.

### DIFF
--- a/concepts/teams-changenotifications-callrecording-and-calltranscript.md
+++ b/concepts/teams-changenotifications-callrecording-and-calltranscript.md
@@ -13,6 +13,9 @@ Change notifications enable you to subscribe to changes to transcripts. You can 
 
 This article describes scenarios for the **transcript** resource. For more details, see [Change notifications for Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
+
 ## Subscribe to transcripts available at the tenant-level
 
 To get change notifications for any transcript available for any online meeting in a tenant, subscribe to `communications/onlineMeetings/getAllTranscripts`. The notification for a transcript is sent only if the subscription happens before the transcription starts. This subscription is supported only for meeting scheduled on the calendar.

--- a/concepts/teams-changenotifications-chat.md
+++ b/concepts/teams-changenotifications-chat.md
@@ -13,6 +13,9 @@ Change notifications enable you to subscribe to changes (create and update) to c
 
 Continue with this article about scenarios for the **chat** resource. Or, find out about [change notifications for other Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).  
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
+
 ## Subscribe to changes in any chat at tenant level
 
 To get change notifications for all changes (create and update) related to any chat in a tenant, subscribe to `/chats`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.

--- a/concepts/teams-changenotifications-chatmembership.md
+++ b/concepts/teams-changenotifications-chatmembership.md
@@ -13,6 +13,9 @@ Change notifications enable you to subscribe to changes (create and delete) in c
 
 Continue with this article about scenarios for the **conversationMember** resource in the [chat](/graph/api/resources/chat) context. Or, find out about [change notifications for other Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
+
 ## Subscribe to changes in membership of any chat at tenant level
 
 To get change notifications for membership changes in any chat across the tenant, subscribe to `/chats/getAllMembers`. This resource supports [including resource data](webhooks-with-resource-data.md) in the notification.

--- a/concepts/teams-changenotifications-chatmessage.md
+++ b/concepts/teams-changenotifications-chatmessage.md
@@ -13,6 +13,9 @@ Change notifications enable you to subscribe to changes (create, update, and del
 
 Continue with this article about scenarios for the [chatMessage](/graph/api/resources/chatmessage) resource in the [channel](/graph/api/resources/channel) or [chat](/graph/api/resources/chat) context. Or, find out about [change notifications for other Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
+
 ## Subscribe to changes at the tenant level
 
 To track all changes related to messages in a tenant, you can use subscriptions at a tenant level for channel and chat messages. This requires you to create two subscriptions: one to track all messages across [channels](/graph/api/resources/channel?preserve-view=true), and one to track all messages across [chats](/graph/api/resources/chat?preserve-view=true).

--- a/concepts/teams-changenotifications-team-and-channel.md
+++ b/concepts/teams-changenotifications-team-and-channel.md
@@ -13,6 +13,8 @@ Change notifications enable you to subscribe to changes (create, update, and del
 
 Continue with this article about scenarios for the **team** or **channel** resource. Or, find out about [change notifications for other Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
 
 ## Subscribe to changes in any team at tenant level
 

--- a/concepts/teams-changenotifications-teammembership.md
+++ b/concepts/teams-changenotifications-teammembership.md
@@ -13,6 +13,8 @@ Change notifications enable you to subscribe to membership changes (create, upda
 
 Continue with this article about scenarios for the [conversationMember](/graph/api/resources/conversationmember) resource in the **team** or **channel** context. Or, find out about [change notifications for other Microsoft Teams resources](teams-change-notification-in-microsoft-teams-overview.md).
 
+> [!NOTE]
+> If you request a subscription date/time that is more than 1 hour in the future, you must include a **lifecycleNotificationUrl** property in your subscription request.
 
 ## Subscribe to changes in membership of a particular team
 


### PR DESCRIPTION
Updated documentation to include a note about new lifecycleNotificationUrl requirements.