### PR TITLE
Removed incorrect language about authentication challenges

### DIFF
--- a/concepts/webhooks-lifecycle.md
+++ b/concepts/webhooks-lifecycle.md
@@ -198,8 +198,7 @@ The following steps represent the flow of an authorization challenge for an acti
 ### Additional information
 
 - Authorization challenges don't replace the need to renew a subscription before it expires.
-
-    While you can choose to renew a subscription when you receive an authorization challenge, Microsoft Graph may not challenge all of your subscriptions. For example, a subscription that doesn't have any activity and has no change notifications pending delivery may not signal any reauthorization challenges to your app. Make sure to [renew subscriptions](/graph/api/subscription-update) before they expire.
+    The lifecycles of access tokens and subscription expiration are not the same.  Your access token may expire before your subscription.  It is important to be prepare to regularly reauthorize your endpoint to refresh your access token.  Reauthorizing your endpoint will not renew your subscription.  However, [renewing your subscription](/graph/api/subscription-update) will also reauthorize your endpoint.
 
 - The frequency of authorization challenges is subject to change.
 


### PR DESCRIPTION
Documentation contained an unfortunate error about situations where the service may fail to send lifecycle notifications about access token expiration.  No such situations exist short of major service outage/failure.